### PR TITLE
Fixed url routing. Anything under /client should be served as index.html

### DIFF
--- a/docker/nginx-default.conf
+++ b/docker/nginx-default.conf
@@ -3,7 +3,7 @@ server {
     listen 80 default_server;
     listen [::]:80 default_server;
 
-    root   /var/www/html;
+    root   /var/www/application/client;
     index index.html;
 
     error_log /var/log/nginx/error.log debug;
@@ -29,11 +29,15 @@ server {
     }
 
     #
-    # Application
+    # Application - any url under /client serve as index.html
+    # The ember app, once booted, will inspect the url and route correctly within the app.
     #
 
     location /client {
-        root /var/www/application;
+        alias /var/www/application/client;
+        index index.html;
+        add_header Cache-Control 'no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0';
+        try_files $uri $uri/ /index.html;
     }
 
 }


### PR DESCRIPTION
Ember, once booted in the browser,  will handle the rest.