### PR TITLE
Hack - remove autofocus from timesheet entry correction textarea.

### DIFF
--- a/app/components/admin/slot-form.js
+++ b/app/components/admin/slot-form.js
@@ -59,6 +59,6 @@ export default class SlotFormComponent extends Component {
 
   @action
   cancel(model) {
-        this.onCancel(model);
+    this.onCancel(model);
   }
 }

--- a/app/components/ch-form.js
+++ b/app/components/ch-form.js
@@ -105,7 +105,7 @@ export default class ChFormComponent extends Component {
         null;
     });
 
-    $('[autofocus]').focus();
+    $(`#${this.formId} [autofocus]`).focus();
   }
 
   willDestroyElement() {

--- a/app/controllers/me/timesheet-corrections/review.js
+++ b/app/controllers/me/timesheet-corrections/review.js
@@ -5,7 +5,7 @@ import { validatePresence } from 'ember-changeset-validations/validators';
 export default class MeTimesheetCorrectionsReviewController extends Controller {
   entry = null; // Incorrect entry
 
-  corectionValidations = {
+  correctionValidations = {
     notes: validatePresence({ presence: true})
   };
 

--- a/app/templates/components/admin/slot-form.hbs
+++ b/app/templates/components/admin/slot-form.hbs
@@ -1,4 +1,4 @@
-{{#ch-form "slot" slot modalBox=true modalTitle=formTitle validator=slotValidations onSubmit=(action "save") as |f|}}
+{{#ch-form "slot" slot modalBox=true modalTitle=formTitle validator=slotValidations onSubmit=(action "save") onCancel=(action "cancel") as |f|}}
   <div class="form-row">
     {{f.input "position_id" label="Position" type="select" options=positionOptions grid="col-md-auto"}}
     {{f.input "trainer_slot_id"
@@ -30,7 +30,7 @@
 
   <div class="form-group mt-2">
     {{f.submit}}
-    <button type="submit" class="btn btn-secondary" {{action "cancel" f.model}}>Cancel</button>
+    {{f.cancel}}
   </div>
 
 {{/ch-form}}

--- a/app/templates/components/ch-form.hbs
+++ b/app/templates/components/ch-form.hbs
@@ -39,7 +39,7 @@
           )
           cancel=(component "ch-form/cancel"
             label=label
-            class=cancelClass
+            cancelClass=cancelClass
             cancelAction=(action "cancelForm")
             disabled=disabled
           )
@@ -84,7 +84,7 @@
 
   cancel=(component "ch-form/cancel"
     label=label
-    class=cancelClass
+    cancelClass=cancelClass
     cancelAction=(action "cancelForm")
     disabled=disabled
   )

--- a/app/templates/components/ch-form/cancel.hbs
+++ b/app/templates/components/ch-form/cancel.hbs
@@ -1,1 +1,1 @@
-<button class="btn btn-secondary {{cancelClass}}" type="submit" {{action cancelAction}} disabled={{disabled}}>{{label}}</button>
+<button class="btn btn-secondary {{cancelClass}}" type="button" {{action cancelAction}} disabled={{disabled}}>{{label}}</button>

--- a/app/templates/components/person/position-form.hbs
+++ b/app/templates/components/person/position-form.hbs
@@ -1,9 +1,9 @@
-{{#ch-form "positions" positionForm modalBox=true modalTitle="Edit Positions" onSubmit=(action "save") as |f|}}
+{{#ch-form "positions" positionForm modalBox=true modalTitle="Edit Positions" onSubmit=(action "save") onCancel=(action "cancel") as |f|}}
   <div class="form-row">
     {{f.input "positionIds" type="checkboxGroup" wrapClass="form-row" options=positionOptions}}
   </div>
   <div class="form-group mt-4">
     {{f.submit}}
-    <button type="submit" class="btn btn-secondary" {{action "cancel" f.model}}>Cancel</button>
+    {{f.cancel}}
   </div>
 {{/ch-form}}

--- a/app/templates/components/person/role-form.hbs
+++ b/app/templates/components/person/role-form.hbs
@@ -1,9 +1,9 @@
-{{#ch-form "roles" roleForm modalBox=true modalTitle="Edit Roles" onSubmit=(action "save") as |f|}}
+{{#ch-form "roles" roleForm modalBox=true modalTitle="Edit Roles" onSubmit=(action "save") onCancel=(action "cancel") as |f|}}
   <div class="form-row">
     {{f.input "roleIds" type="checkboxGroup" wrapClass="form-row" options=roleOptions}}
   </div>
   <div class="form-group mt-4">
     {{f.submit}}
-    <button type="submit" class="btn btn-secondary" {{action "cancel" f.model}}>Cancel</button>
+    {{f.cancel}}
   </div>
 {{/ch-form}}

--- a/app/templates/components/position-form.hbs
+++ b/app/templates/components/position-form.hbs
@@ -1,4 +1,4 @@
-{{#ch-form "position" position modalBox=true modalTitle=formTitle validator=positionValidations onSubmit=(action "save") as |f|}}
+{{#ch-form "position" position modalBox=true modalTitle=formTitle validator=positionValidations onSubmit=(action "save") onCancel=(action "cancel") as |f|}}
   <fieldset>
     <legend>Description</legend>
     <div class="form-row">
@@ -30,7 +30,7 @@
 
   <div class="mt-4">
     {{f.submit}}
-    <button type="submit" class="btn btn-secondary" {{action "cancel" f.model}}>Cancel</button>
+    {{f.cancel}}
   </div>
 
 {{/ch-form}}

--- a/app/templates/me/timesheet-corrections/review.hbs
+++ b/app/templates/me/timesheet-corrections/review.hbs
@@ -134,7 +134,7 @@
 
 {{! Timesheet entry correction form dialog }}
 {{#if entry}}
-  {{#ch-form "correction" entry modalBox=true modalTitle="Timesheet Correction" validator=corectionValidations onSubmit=(action "saveCorrectionAction") onCancel=(action "cancelCorrectionAction") as |f|}}
+  {{#ch-form "correction" entry modalBox=true modalTitle="Timesheet Correction" validator=correctionValidations onSubmit=(action saveCorrectionAction) onCancel=(action cancelCorrectionAction) as |f|}}
     <dl class="form-row">
       <dt class="col-sm-2">Position:</dt>
       <dd class="col-sm-10">{{entry.position.title}}</dd>
@@ -166,7 +166,7 @@
         <li>Provide an explanation on why you think the entry is wrong.</li>
       </ul>
     </div>
-    {{f.input "notes" label="Your correction note:" type="textarea" cols=80 rows=3 autofocus=true}}
+    {{f.input "notes" label="Your correction note:" type="textarea" cols=80 rows=3}}
     {{f.submit label="Submit Correction" disabled=isSubmitting}}
     {{f.cancel}}
   {{/ch-form}}


### PR DESCRIPTION
- Need to investigate this further but the timesheet correction form with
autofocus is having issue and being able to cancel the form. Something
is hijacking the click events completely. No other form with autofocus has this bug.

- Fixup a few existing forms to use the cancel field instead of using a button with
an action.