### PR TITLE
Add less-noisy "Experimental" eye rhymes rule

### DIFF
--- a/app/controllers/handle-checker.js
+++ b/app/controllers/handle-checker.js
@@ -7,6 +7,7 @@ import {
   AmericanSoundexRule,
   DoubleMetaphoneRule,
   EditDistanceRule,
+  ExperimentalEyeRhymeRule,
   EyeRhymeRule,
   FccRule,
   MinLengthRule,
@@ -52,11 +53,11 @@ export default class HandlerCheckerController extends Controller {
   get handleRules() {
     const handles = this.model.toArray();
     const rules = [];
-    const addRule = (rule, name) => rules.pushObject(EmberObject.create({
+    const addRule = (rule, name, enabled=true) => rules.pushObject(EmberObject.create({
       id: rule.id,
       name: name,
       rule: rule,
-      enabled: true,
+      enabled: enabled,
     }));
     // Rule ordering: Substring is first per 2019 request from Threepio.
     // No input yet on ideal ordering for all checks.
@@ -68,6 +69,7 @@ export default class HandlerCheckerController extends Controller {
     addRule(new AmericanSoundexRule(handles), 'American Soundex');
     addRule(new DoubleMetaphoneRule(handles), 'Double Metaphone');
     addRule(new EyeRhymeRule(handles), 'Eye rhymes');
+    addRule(new ExperimentalEyeRhymeRule(handles), 'Experimental eye rhymes', false);
     return rules;
   }
 

--- a/tests/unit/utils/handle-rules-test.js
+++ b/tests/unit/utils/handle-rules-test.js
@@ -3,6 +3,7 @@ import {
   AmericanSoundexRule,
   DoubleMetaphoneRule,
   EditDistanceRule,
+  // TODO test ExperimentalEyeRhymeRule
   EyeRhymeRule,
   FccRule,
   MinLengthRule,
@@ -71,6 +72,7 @@ module('Unit | Utility | handle-rules', function(hooks) {
       'american-soundex',
       'double-metaphone',
       'edit-distance',
+      'experimental-eye-rhyme',
       'eye-rhyme',
       'fcc',
       'min-length',


### PR DESCRIPTION
The current Eye rhymes rule emits a conflict if a single syllable looks
like a rhyme.  This means that "Fool Me Once" matches "Tool" even though
the length makes it unlikely they'd be confused.  The experimental
version requires that at least half of the syllables in the subject name
match an existing handle, e.g. 1/2, 2/3, 2/4, 3/5 syllables.

This change also collapses double consonants in a syllable so that
"This Bean" has two rhymes with "Miss Klean", not one.