### PR TITLE
Event Date CRUD. Pre-Event slot restrictions. T-Shirt fixes. Storage fix.

### DIFF
--- a/app/components/admin/slot-form.js
+++ b/app/components/admin/slot-form.js
@@ -20,6 +20,8 @@ export default class SlotFormComponent extends Component {
   // cancel action
   @argument('object') onCancel;
 
+  @argument('object') onClone;
+
   @computed('positions')
   get positionOptions() {
     return this.positions.map((p) => [ p.title, p.id ]);
@@ -56,6 +58,12 @@ export default class SlotFormComponent extends Component {
   save(model, isValid, originalModel) {
     this.onSave(model, isValid, originalModel);
   }
+
+  @action
+  cloneRecord(model, isValid, originalModel) {
+    this.onClone(model, isValid, originalModel);
+  }
+
 
   @action
   cancel(model) {

--- a/app/components/json-format.js
+++ b/app/components/json-format.js
@@ -7,6 +7,17 @@ export default class JsonFormatComponent extends Component {
 
   didInsertElement() {
     super.didInsertElement(...arguments);
+    let obj;
+
+    try {
+      if (typeof obj == "string") {
+        obj = JSON.parse(this.json);
+      } else {
+        obj = this.json;
+      }
+    } catch (e) {
+      obj = this.json;
+    }
 
     const formatter = new JSONFormatter(JSON.parse(this.json), 1, {
       animateOpen: false,

--- a/app/constants/shirts.js
+++ b/app/constants/shirts.js
@@ -1,4 +1,5 @@
 export const ShortSleeve = [
+  'Unknown',
   'Womens V-Neck XS',
   'Womens V-Neck S',
   'Womens V-Neck M',
@@ -16,6 +17,7 @@ export const ShortSleeve = [
 ];
 
 export const LongSleeve = [
+  'Unknown',
   'Womens XS',
   'Womens S',
   'Womens M',

--- a/app/controllers/admin/event-dates.js
+++ b/app/controllers/admin/event-dates.js
@@ -1,0 +1,68 @@
+import Controller from '@ember/controller';
+import { action } from '@ember-decorators/object';
+import { validatePresence } from 'ember-changeset-validations/validators';
+import validateDateTime from 'clubhouse/validators/datetime';
+import moment from 'moment';
+
+export default class AdminEventDatesController extends Controller {
+  eventDateValidations = {
+    event_start:  [ validateDateTime({ before: 'event_end' }), validatePresence(true) ],
+    event_end:  [ validateDateTime({ after: 'event_start' }), validatePresence(true) ],
+
+    pre_event_start:  [ validateDateTime({ before: 'post_event_end' }), validatePresence(true) ],
+    post_event_end:  [ validateDateTime({ after: 'pre_event_start' }), validatePresence(true) ],
+
+    pre_event_slot_start:  [ validateDateTime({ before: 'pre_event_slot_end' }), validatePresence(true) ],
+    pre_event_slot_end:  [ validateDateTime({ after: 'pre_event_slot_start' }), validatePresence(true) ],
+  };
+
+  @action
+  save(model, isValid) {
+    if (!isValid)
+      return;
+
+    const eventYear = moment(model.get('event_start')).year();
+    const mismatches = [];
+
+    // Verify all years match
+    [ 'event_end', 'post_event_end', 'pre_event_slot_end', 'pre_event_slot_start', 'pre_event_start' ].forEach((column) => {
+      const value = model.get(column);
+      if (value && moment(value).year() != eventYear) {
+        mismatches.push(column);
+      }
+    });
+
+    if (mismatches.length > 0) {
+      this.modal.info('Year Mistmatch',
+          `All fields must have the same year as the event start. The following fields have a different year: ${mismatches.join(', ')}`);
+      return;
+    }
+
+    const isNew = this.entry.isNew;
+
+    model.save().then(() => {
+        if (isNew) {
+          this.eventDates.push(this.entry);
+          this.eventDates.sortBy('event_start');
+        }
+
+        this.set('entry', null);
+        this.toast.succes(`Event Date succesfully ${isNew ? 'created' : 'updated'}.`);
+    });
+  }
+
+  @action
+  cancel() {
+    this.set('entry', null);
+  }
+
+  @action
+  edit(eventDate) {
+    this.set('entry', eventDate);
+  }
+
+  @action
+  newRecord() {
+    this.set('entry', this.store.createRecord('event-date'));
+  }
+}

--- a/app/controllers/admin/slots.js
+++ b/app/controllers/admin/slots.js
@@ -1,41 +1,44 @@
 import Controller from '@ember/controller';
+import { set } from '@ember/object';
 import { computed, action } from '@ember-decorators/object';
 import moment from 'moment';
 
-const allDays = { id: 'all', title: 'All Days'};
-const allPositions = {id: 'all', title: 'All Positions'};
+const allDays = { id: 'all', title: 'All' };
+
+const DATETIME_FORMAT = 'YYYY-MM-DD hh:mm:ss';
 
 export default class SlotsController extends Controller {
   queryParams = [ 'year' ];
 
-  dayFilter =  allDays;
-  positionFilter =  allPositions;
-  activeFilter = 0;
+  dayFilter = 'all';
+  positionFilter = 'all';
+  activeFilter = 'all';
 
-  @computed('slots[]','slots.@each.{position_id,begins}', 'dayFilter', 'positionFilter', 'activeFilter')
+  activeOptions = [
+    { id: 'all', title: 'All' },
+    { id: 'active', title: 'Active' },
+    { id: 'inactive', title: 'Inactive' },
+  ];
+
+  showingGroups = { };
+
+  @computed('slots[]','slots.@each.{position_id,begins}', 'dayFilter', 'activeFilter')
   get viewSlots() {
     let slots = this.slots;
     const dayFilter = this.dayFilter;
-    const positionFilter = this.positionFilter;
     const activeFilter = this.activeFilter;
 
-    if (activeFilter == 1) {
+    if (activeFilter == 'active') {
       slots = slots.filterBy('active', true);
-    } else if (activeFilter == 2) {
+    } else if (activeFilter == 'inactive') {
       slots = slots.filterBy('active', false);
     }
 
-    if (positionFilter && positionFilter.id && positionFilter.id != 'all') {
-        slots = slots.filterBy('position_id', positionFilter.id);
-    }
-
-    if (dayFilter && dayFilter.id) {
-      const day = dayFilter.id;
-
-      if (day == 'upcoming') {
+    if (dayFilter) {
+      if (dayFilter == 'upcoming') {
         slots = slots.filterBy('has_started', false);
-      } else if (day != 'all') {
-        slots = slots.filterBy('slotDay', day);
+      } else if (dayFilter != 'all') {
+        slots = slots.filterBy('slotDay', dayFilter);
       }
     }
 
@@ -58,7 +61,7 @@ export default class SlotsController extends Controller {
     return days;
   }
 
-  @computed('viewSlots', 'dayFilter', 'positionFilter', 'active')
+  @computed('viewSlots.@each.{active,position_id}', 'dayFilter', 'activeFilter')
   get slotGroups() {
     let slots = this.viewSlots;
     let groups = [];
@@ -70,26 +73,21 @@ export default class SlotsController extends Controller {
       if (group) {
         group.slots.push(slot);
       } else {
-        groups.push({title, position_id: slot.position_id, slots: [ slot ]});
+        group = {
+          title,
+          position_id: slot.position_id,
+          slots: [ slot ],
+          inactive: 0
+        }
+        groups.push(group);
+      }
+
+      if (!slot.active) {
+        group.inactive++;
       }
     });
 
     return groups.sortBy('title');
-  }
-
-  @computed('slots.{[],@each.position_id}')
-	get positionOptions() {
-    const unique = this.slots.uniqBy('position_title');
-
-    let options = [];
-
-    unique.forEach(function(slot) {
-      options.push({id: slot.position_id, title: slot.position_title});
-    });
-
-    options = options.sortBy('title');
-    options.unshift(allPositions);
-    return options;
   }
 
   @computed('slots.{[],@each.position_id}')
@@ -134,6 +132,44 @@ export default class SlotsController extends Controller {
     })
   }
 
+  _duplicateSlot(model) {
+    return this.store.createRecord('slot', {
+      begins: model.get('begins'),
+      ends: model.get('ends'),
+      description: model.get('description'),
+      active: model.get('active'),
+      position_id: model.get('position_id'),
+      //trainer_slot_id: model.get('trainer_slot_id'),
+      max: model.get('max'),
+      url: model.get('url')
+    });
+  }
+
+  @action
+  repeatSlot(slot) {
+    const duplicate = this._duplicateSlot(slot);
+
+    duplicate.save().then(() => {
+      this.slots.pushObject(duplicate);
+      duplicate.set('signed_up', 0);
+      this.toast.success('Slot was successfully repeated.');
+    });
+  }
+
+  @action
+  repeatSlotAdd24Hours(slot) {
+    const duplicate = this._duplicateSlot(slot);
+
+    duplicate.set('begins', moment(slot.begins).add(24, 'hours').format(DATETIME_FORMAT));
+    duplicate.set('ends',moment(slot.ends).add(24, 'hours').format(DATETIME_FORMAT));
+
+    duplicate.save().then(() => {
+      duplicate.set('signed_up', 0);
+      this.slots.pushObject(duplicate);
+      this.toast.success('Slot was successfully repeated with 24 hour addition.');
+    });
+  }
+
   @action
   deleteSlot(slot) {
     this.modal.confirm(
@@ -148,6 +184,20 @@ export default class SlotsController extends Controller {
             .catch((response) => this.house.handleErrorResponse(response) )
       }
     );
+  }
+
+  @action
+  cloneSlot(model, isValid) {
+    if (!isValid) {
+      return;
+    }
+
+    const duplicate = this._duplicateSlot(model);
+    duplicate.save().then(() => {
+      this.slots.pushObject(duplicate);
+      this.toast.success(`Slot successfully created from existing slot.`);
+      this.set('slot', duplicate);
+    });
   }
 
   @action
@@ -176,5 +226,10 @@ export default class SlotsController extends Controller {
   changeYear(year) {
     // Magic! set the year, and the query params fire off.
     this.set('year', year);
+  }
+
+  @action
+  toggleShowing(group) {
+    set(this.showingGroups, group.position_id, !this.showingGroups[group.position_id]);
   }
 }

--- a/app/models/event-date.js
+++ b/app/models/event-date.js
@@ -1,0 +1,13 @@
+import DS from 'ember-data';
+import { attr } from '@ember-decorators/data';
+
+const { Model } = DS;
+
+export default class EventDateModel extends Model {
+  @attr('shiftdate') event_end;
+  @attr('shiftdate') event_start;
+  @attr('shiftdate') post_event_end;
+  @attr('shiftdate') pre_event_slot_end;
+  @attr('shiftdate') pre_event_slot_start;
+  @attr('shiftdate') pre_event_start;
+}

--- a/app/router.js
+++ b/app/router.js
@@ -54,15 +54,16 @@ Router.map(function() {
     this.route('languages');
   });
   this.route('admin', function() {
-    this.route('positions');
-    this.route('slots');
-    this.route('credits');
-    this.route('roles');
-    this.route('error-log');
-    this.route('bulk-upload');
-    this.route('settings');
-    this.route('salesforce');
     this.route('action-log');
+    this.route('bulk-upload');
+    this.route('credits');
+    this.route('error-log');
+    this.route('event-dates');
+    this.route('positions');
+    this.route('roles');
+    this.route('salesforce');
+    this.route('settings');
+    this.route('slots');
   });
 
   this.route('hq', { path: '/hq/:person_id' }, function() {

--- a/app/routes/admin/event-dates.js
+++ b/app/routes/admin/event-dates.js
@@ -1,0 +1,16 @@
+import Route from '@ember/routing/route';
+import { Role } from 'clubhouse/constants/roles';
+
+export default class AdminEventDatesRoute extends Route {
+  beforeModel() {
+    this.house.roleCheck(Role.ADMIN);
+  }
+
+  model() {
+    return this.store.findAll('event-date').then((results) => results.toArray());
+  }
+
+  setupController(controller, model) {
+    controller.set('eventDates', model);
+  }
+}

--- a/app/routes/admin/slots.js
+++ b/app/routes/admin/slots.js
@@ -14,12 +14,16 @@ export default class AdminSlotsRoute extends Route {
       slots: this.store.query('slot', { year }).then((result) => { return result.toArray() }),
       positions: this.store.query('position', {}),
       year,
-      yearList: this.ajax.request('slot/years').then((result) => result.years)
+      yearList: this.ajax.request('slot/years').then((result) => result.years),
+      eventDate: this.ajax.request('event-dates/year', { data: { year }}).then((result) => result.event_date)
     });
   }
 
   setupController(controller, model) {
     controller.set('slot', null);
     controller.setProperties(model)
+    controller.set('showingGroups', {});
+    controller.set('dayFilter', 'all');
+    controller.set('activeFilter', 'all');
   }
 }

--- a/app/services/house.js
+++ b/app/services/house.js
@@ -245,11 +245,19 @@ export default class HouseService extends Service {
    }
 
    _getStorage() {
-     let storage = window.localStorage.getItem('clubhouse');
+     let storage;
 
-     if (storage) {
-       storage = JSON.parse(storage);
+     try {
+       storage = window.sessionStorage.getItem('clubhouse');
+
+       if (storage) {
+         storage = JSON.parse(storage);
+       }
+     } catch (e) {
+       // browser blocking sessionStorage or not available.
+       return {};
      }
+
 
      return storage || { };
    }
@@ -266,7 +274,11 @@ export default class HouseService extends Service {
        storage[key] = data;
      }
 
-     window.localStorage.setItem('clubhouse', JSON.stringify(storage));
+     try {
+       window.sessionStorage.setItem('clubhouse', JSON.stringify(storage));
+     } catch (e) {
+       // browser blocking sessionStorage or not available.
+     }
    }
 
    getKey(key) {
@@ -274,6 +286,10 @@ export default class HouseService extends Service {
    }
 
    clearStorage() {
-     window.localStorage.removeItem('clubhouse');
+     try {
+       window.sessionStorage.removeItem('clubhouse');
+     } catch (e) {
+       // browser blocking sessionStorage or not available.
+     }
    }
 }

--- a/app/templates/admin/event-dates.hbs
+++ b/app/templates/admin/event-dates.hbs
@@ -1,0 +1,69 @@
+<h1>Edit Event Dates</h1>
+
+<div class="float-right">
+  <button class="btn btn-primary btn-sm" {{action newRecord}}>New Event Date</button>
+</div>
+
+{{pluralize eventDates.length "event dates"}}
+<table class="table table-sm table-striped">
+  <thead>
+    <tr>
+      <th>Year</th>
+      <th>Event Start</th>
+      <th>Event End</th>
+      <th>Pre-Event Start</th>
+      <th>Post-Event End</th>
+      <th>Pre-Event Slot Start</th>
+      <th>Pre-Event Slot End</th>
+      <th>Action</th>
+    </tr>
+  </thead>
+
+  <tbody>
+    {{#each eventDates as |ed|}}
+      <tr>
+        <td>{{moment-format ed.event_start "YYYY"}}</td>
+        <td>{{shift-format ed.event_start}}</td>
+        <td>{{shift-format ed.event_end}}</td>
+        <td>{{shift-format ed.pre_event_start}}</td>
+        <td>{{shift-format ed.post_event_end}}</td>
+        <td>{{shift-format ed.pre_event_slot_start}}</td>
+        <td>{{shift-format ed.pre_event_slot_end}}</td>
+        <td><button class="btn btn-primary btn-sm" {{action edit ed}}>Edit</button></td>
+      </tr>
+    {{/each}}
+  </tbody>
+</table>
+
+{{#if entry}}
+  {{#ch-form "event_date" entry validator=eventDateValidations modalBox=true modalTitle="Edit Event Date Record" onSubmit=(action save) onCancel=(action cancel) as |f|}}
+    <div class="form-row">
+      {{f.input "event_start" label="Event Start / Gate Open" type="datetime" grid="col-auto" size=25}}
+      {{f.input "event_end" label="Event End" type="datetime" grid="col-auto" size=25}}
+    </div>
+    <div class="form-row mb-2">
+      <div class="col">
+        Pre-Event and Post Event are datetimes used by Hours &amp; Credits report to determine which credit hours should be included.
+      </div>
+    </div>
+    <div class="form-row">
+      {{f.input "pre_event_start" label="Pre-Event Start" type="datetime" grid="col-auto" size=25}}
+      {{f.input "post_event_end" label="Post Event End" type="datetime" grid="col-auto" size=25}}
+    </div>
+    <div class="form-row mb-2">
+      <div class="col">
+        Pre-event slot start and end are used to restrict slot creation for the pre event period. When
+        trying to create a slot during the pre-event period, the slot must be an approved pre-event position OR the user
+        must be an admin.
+      </div>
+    </div>
+    <div class="form-row">
+      {{f.input "pre_event_slot_start" label="Pre-Event Slot Start" type="datetime" grid="col-auto" size=25}}
+      {{f.input "pre_event_slot_end" label="Pre-Event Slot End" type="datetime" grid="col-auto" size=25}}
+    </div>
+    <div class="form-group">
+    {{f.submit label=(if f.model.isNew "Create" "Update")}}
+    {{f.cancel}}
+  </div>
+  {{/ch-form}}
+{{/if}}

--- a/app/templates/admin/slots.hbs
+++ b/app/templates/admin/slots.hbs
@@ -1,111 +1,111 @@
 {{year-select "Clubhouse Slots" year=year years=yearList onChange=(action "changeYear")}}
 
 {{#if slot}}
-  {{admin/slot-form slot=slot positions=positions trainerSlots=trainerSlots onSave=(action "saveSlot") onCancel=(action "cancel")}}
+  {{admin/slot-form slot=slot positions=positions trainerSlots=trainerSlots onSave=(action saveSlot) onCancel=(action cancel) onClone=(action cloneSlot)}}
 {{/if}}
 
+<div class="float-right">
+  <button {{action "newSlot"}} class="btn btn-primary">New Slot</button>
+</div>
 
-<div class="row mb-1">
-  <div class="col-md-4 mb-2">
-    {{#power-select
-          options=positionOptions
-          selected=positionFilter
-          searchEnabled=false
-          searchField="title"
-          onchange=(action (mut positionFilter))
-                    as |item| }}
-        {{item.title}}
-    {{/power-select}}
+<div class="form-row mb-1">
+  <div class="col-auto">
+    <label class="col-form-label">Day Filter</label>
   </div>
   <div class="col-md-3 mb-2">
-    {{#power-select
-          selected=dayFilter
-          options=dayOptions
-          searchEnabled=false
-          searchField="title"
-          onchange=(action (mut dayFilter))
-                    as |item| }}
-        {{item.title}}
-    {{/power-select}}
+    {{ch-form/select name="dayFilter" value=dayFilter options=dayOptions onChange=(action (mut dayFilter)) controlClass="form-control"}}
   </div>
 
+  <div class="col-auto">
+    <label class="col-form-label">Active Filter</label>
+  </div>
   <div class="col-md-3 mb-2">
-    <div class="btn-group btn-group-toggle">
-      {{#radio-button value=0 groupValue=activeFilter classNames="btn btn-info" checkedClass="active"}}
-        All
-      {{/radio-button}}
-      {{#radio-button value=1 groupValue=activeFilter classNames="btn btn-info" checkedClass="active"}}
-        Active
-      {{/radio-button}}
-      {{#radio-button value=2 groupValue=activeFilter classNames="btn btn-info" checkedClass="active"}}
-        Inactive
-      {{/radio-button}}
-    </div>
-  </div>
-
-  <div class="col-md-2 mb-2">
-    <a href {{action "newSlot"}} class="btn btn-primary">New Slot</a>
+    {{ch-form/select name="activeFilter" value=activeFilter options=activeOptions onChange=(action (mut activeFilter)) controlClass="form-control"}}
   </div>
 </div>
 
-{{#if slots.length}}
-<div class="text-muted">Showing {{viewSlots.length}} of {{slots.length}}</div>
-{{#unless viewSlots}}
-  <p class="text-danger">
-    No slots matched the filter criteria.
-  </p>
-{{/unless}}
+{{#if (and eventDate.pre_event_slot_start eventDate.pre_event_slot_end)}}
+  <p>{{year}} Pre-event is {{shift-format eventDate.pre_event_slot_start}} to {{shift-format eventDate.pre_event_slot_end}}.</p>
 {{else}}
-No slots were found for {{year}}?
+  {{#ch-alert "danger"}}
+    WARNING: {{year}} pre-event slot dates are not set. Pre-Event slots may not be properly vetted. Visit {{#link-to "admin.event-dates"}}Admin &gt; Edit Event Dates{{/link-to}} to set the dates.
+  {{/ch-alert}}
+{{/if}}
+
+{{#if slots.length}}
+  <div class="text-muted">Showing {{viewSlots.length}} of {{slots.length}}</div>
+  {{#unless viewSlots}}
+    <p class="text-danger">
+      No slots matched the filter criteria.
+    </p>
+  {{/unless}}
+{{else}}
+  No slots were found for {{year}}?
 {{/if}}
 
 
 {{#each slotGroups as |group|}}
-<table class="table table-sm schedule-table table-hover">
-  <caption>
-    {{group.title}}
-    <div class="float-right mr-4">
-      <a href class="btn btn-primary btn-sm" {{action "activate" group}}>Activate All</a>
-      <a href class="btn btn-primary btn-sm" {{action "deactivate" group}}>Deactivate All</a>
-    </div>
-  </caption>
-  <thead>
-    <tr>
-      <th>ID</th>
-      <th>From</th>
-      <th>To</th>
-      <th class="text-right">Max / Sign ups</th>
-      <th class="text-right">Credits</th>
-      <th>Description</th>
-      <th>Active</th>
-      <th>Actions</th>
-    </tr>
-  </thead>
-  <tbody>
-    {{#each group.slots as |slot|}}
-    <tr id="slot-{{slot.id}}" >
-      <td>{{slot.id}}</td>
-      <td>{{shift-format slot.begins}}</td>
-      <td>{{shift-format slot.ends}}</td>
-      <td class="text-right">{{slot.max}} / {{slot.signed_up}}</td>
-      <td class="text-right">{{credits-format slot.credits}}</td>
-      <td>
-        {{slot-info-link slot.description slot.url}}
-      </td>
-      <td>{{#if slot.active}}{{fa-icon "check"}} {{else}} {{fa-icon "times"}}{{/if}}</td>
-      <td>
-        <button {{action "editSlot" slot}} class="btn btn-primary btn-sm" title="Edit slot">{{fa-icon "edit"}}</button>
-        <button {{action "deleteSlot" slot}} class="btn btn-danger btn-sm" title="Delete slot">{{fa-icon "trash-alt" type="fas"}}</button>
-      </td>
-    </tr>
-    {{#if slot.trainer_slot}}
-    <tr class="{{if slot.trainer_slot "tr-no-border"}}">
-      <td colspan="7">
-        Trainer slot: <a href="#slot-{{slot.trainer_slot.id}}">#{{slot.trainer_slot.id}} {{slot.trainer_slot_title}} {{slot.trainer_slot.description}} {{shift-format slot.trainer_slot.begins}}</a>
-      </td>
-    </tr>
+{{! template-lint-disable table-groups}}
+  <table class="table table-sm table-box table-hover">
+    <caption>
+      <a href {{action toggleShowing group}}>
+        {{fa-icon (if (get showingGroups group.position_id) "caret-down" "caret-right")}} {{group.title}}
+        ({{group.slots.length}}{{#if group.inactive}} / <span class="text-danger">{{group.inactive}} inactive</span>{{/if}})
+      </a>
+      {{#if (get showingGroups group.position_id)}}
+        <div class="float-right mr-4">
+          <button class="btn btn-primary btn-sm" {{action activate group}}>Activate All</button>
+          <button class="btn btn-primary btn-sm" {{action deactivate group}}>Deactivate All</button>
+        </div>
+      {{/if}}
+    </caption>
+    {{#if (get showingGroups group.position_id)}}
+      <thead>
+        <tr>
+          <th>ID</th>
+          <th>From</th>
+          <th>To</th>
+          <th class="text-right">Max / Sign ups</th>
+          <th class="text-right">Credits</th>
+          <th>Description</th>
+          <th>Active</th>
+          <th>Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        {{#each group.slots as |slot|}}
+          <tr id="slot-{{slot.id}}">
+            <td>{{slot.id}}</td>
+            <td>{{shift-format slot.begins}}</td>
+            <td>{{shift-format slot.ends}}</td>
+            <td class="text-right">{{slot.max}} / {{slot.signed_up}}</td>
+            <td class="text-right">{{credits-format slot.credits}}</td>
+            <td>
+              {{slot-info-link slot.description slot.url}}
+            </td>
+            <td clas="text-center">
+              {{#if slot.active}}
+                {{fa-icon "check"}}
+              {{else}}
+                <span class="text-danger">{{fa-icon "times"}}</span>
+              {{/if}}
+            </td>
+            <td>
+              <button {{action repeatSlot slot}} class="btn btn-secondary btn-sm" title="Repeat Slot">Repeat</button>
+              <button {{action repeatSlotAdd24Hours slot}} class="btn btn-secondary btn-sm" title="Repeat Slot With 24 hours addition">Repeat+24</button>
+              <button {{action deleteSlot slot}} class="btn btn-danger btn-sm" title="Delete slot">{{fa-icon "trash-alt" type="fas"}}</button>
+              <button {{action editSlot slot}} class="btn btn-primary btn-sm" title="Edit slot">{{fa-icon "edit"}}</button>
+            </td>
+          </tr>
+          {{#if slot.trainer_slot}}
+            <tr class="{{if slot.trainer_slot "tr-no-border"}}">
+              <td colspan="8">
+                Trainer slot: <a href="#slot-{{slot.trainer_slot.id}}">#{{slot.trainer_slot.id}} {{slot.trainer_slot_title}} {{slot.trainer_slot.description}} {{shift-format slot.trainer_slot.begins}}</a>
+              </td>
+            </tr>
+          {{/if}}
+        {{/each}}
+      </tbody>
     {{/if}}
-  {{/each}}
-  </tbody>
-</table>
+  </table>
 {{/each}}

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -151,6 +151,7 @@
                         {{#link-to "admin.positions" class="dropdown-item"}}Edit Positions{{/link-to}}
                         {{#link-to "admin.roles" class="dropdown-item"}}Edit (System) Roles{{/link-to}}
                         {{#link-to "admin.settings" class="dropdown-item"}}Edit Settings{{/link-to}}
+                        {{#link-to "admin.event-dates" class="dropdown-item"}}Edit Event Dates{{/link-to}}
                         <a href="{{cgo "maintenance" "selectAll"}}" class="dropdown-item">Maintenance</a>
                         <a href="{{cgo "logview" "show"}}" class="dropdown-item">Log View (CH1)</a>
                         {{#link-to "admin.error-log" class="dropdown-item"}}Error Log{{/link-to}}

--- a/app/templates/components/admin/slot-form.hbs
+++ b/app/templates/components/admin/slot-form.hbs
@@ -30,6 +30,9 @@
 
   <div class="form-group mt-2">
     {{f.submit label=(if slot.isNew "Create" "Update")}}
+    {{#unless slot.isNew}}
+      {{f.submit label="Create New Slot" onSubmit=(action cloneRecord)}}
+    {{/unless}}
     {{f.cancel}}
   </div>
 

--- a/tests/integration/components/admin/slot-form-test.js
+++ b/tests/integration/components/admin/slot-form-test.js
@@ -24,8 +24,9 @@ module('Integration | Component | admin/slot-form', function(hooks) {
     this.set('trainerSlots', []);
     this.set('onCancel', () => { });
     this.set('onSave', () => { });
+    this.set('onClone', () => { });
 
-    await render(hbs`{{admin/slot-form slot=slot positions=positions trainerSlots=trainerSlots onCancel=onCancel onSave=onSave}}`);
+    await render(hbs`{{admin/slot-form slot=slot positions=positions trainerSlots=trainerSlots onCancel=onCancel onSave=onSave onClone=onClone}}`);
 
     //assert.dom(this.element).hasText('');
     assert.dom('input#slot-description').hasValue('Afternoon');

--- a/tests/integration/components/json-format-test.js
+++ b/tests/integration/components/json-format-test.js
@@ -7,20 +7,8 @@ module('Integration | Component | json-format', function(hooks) {
   setupRenderingTest(hooks);
 
   test('it renders', async function(assert) {
-    // Set any properties with this.set('myProperty', 'value');
-    // Handle any actions with this.set('myAction', function(val) { ... });
-
-    await render(hbs`{{json-format}}`);
-
-    assert.equal(this.element.textContent.trim(), '');
-
-    // Template block usage:
-    await render(hbs`
-      {{#json-format}}
-        template block text
-      {{/json-format}}
-    `);
-
-    assert.equal(this.element.textContent.trim(), 'template block text');
+    this.set('json', '{ "abc": "def" }');
+    await render(hbs`{{json-format json=json}}`);
+    assert.ok(this.element.querySelector('.json-formatter-row'));
   });
 });

--- a/tests/unit/controllers/admin/event-dates-test.js
+++ b/tests/unit/controllers/admin/event-dates-test.js
@@ -1,0 +1,12 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Controller | admin/event-dates', function(hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function(assert) {
+    let controller = this.owner.lookup('controller:admin/event-dates');
+    assert.ok(controller);
+  });
+});

--- a/tests/unit/models/event-date-test.js
+++ b/tests/unit/models/event-date-test.js
@@ -1,0 +1,13 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Model | event date', function(hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function(assert) {
+    let store = this.owner.lookup('service:store');
+    let model = store.createRecord('event-date', {});
+    assert.ok(model);
+  });
+});

--- a/tests/unit/routes/admin/event-dates-test.js
+++ b/tests/unit/routes/admin/event-dates-test.js
@@ -1,0 +1,11 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Route | admin/event-dates', function(hooks) {
+  setupTest(hooks);
+
+  test('it exists', function(assert) {
+    let route = this.owner.lookup('route:admin/event-dates');
+    assert.ok(route);
+  });
+});


### PR DESCRIPTION
- New Admin > Event Date work.
- Warn user in Edit Slots if Event Date pre-event slot dates are not set.
- Switch over from localStorage to sessionStorage for browser security workaround.
- Added back Unknown as a t-shirt size. (Like, omg, is an American Unknown bigger than
an EU Unknown? This Unknown makes me look fat.)
- Ported Repeat and Repeat+24 buttons to Edit Slot.
- Edit Slot UI reworking to show collapsed positions tables similar to the Schedule page.