### PR TITLE
Slot editing with too long description fix. More word smithing.

### DIFF
--- a/app/templates/components/admin/slot-form.hbs
+++ b/app/templates/components/admin/slot-form.hbs
@@ -23,9 +23,10 @@
   </div>
 
   <div class="form-row">
-    {{f.input "url" label="Information" type="textarea" rows=3 cols=80 maxlength=255 wrapClass="col-12"
-        hint="Additional information may be given about the shift in the above area.
-    e.g., Women of Khaki will meet at Tokyo before shift. More info at http://women.khaki/meetup or email women@khaki.rangers"}}
+    {{f.input "url" label="Information" type="textarea" rows=3 cols=80 maxlength=512 wrapClass="col-12"
+        hint=(concat (if f.model.url f.model.url.length "0") " of 512 characters.
+Additional information may be given about the shift in the above area.
+e.g., Women of Khaki will meet at Tokyo before shift. More info at http://women.khaki/meetup or email women@khaki.rangers")}}
   </div>
 
   <div class="form-group mt-2">

--- a/app/templates/components/ch-form/field.hbs
+++ b/app/templates/components/ch-form/field.hbs
@@ -90,7 +90,7 @@
     autofocus   = autofocus
     rows        = rows
     cols        = cols
-    maxLength   = maxlength
+    maxlength   = maxlength
   }}
 {{else if (or (eq type "datetime") (eq type "date"))}}
   {{datetime-picker
@@ -123,7 +123,7 @@
 {{/if}}
 
 {{#if hint}}
-  <small id="{{_domId}}Help" class="{{hintClass}}">{{hint}}</small>
+  <small id="{{_domId}}Help" class="{{hintClass}}">{{nl2br hint}}</small>
 {{/if}}
 
 {{#unless isValid}}

--- a/app/templates/components/schedule-manage.hbs
+++ b/app/templates/components/schedule-manage.hbs
@@ -155,7 +155,7 @@
                     {{#if isCurrentYear}}
                       {{#if slot.slot_active}}
                         {{#if (or (not slot.isFull) (not slot.has_started) (has-role "admin"))}}
-                          <button {{action "joinSlot" slot}} class="btn btn-primary btn-sm" title="Show people who are signed up">{{fa-icon "user-plus" type="fas"}}</button>
+                          <button {{action "joinSlot" slot}} class="btn btn-primary btn-sm" title="Sign up for the shift">{{fa-icon "user-plus" type="fas"}}</button>
                         {{/if}}
                       {{else}}
                         <small class="text-danger">Inactive</small>

--- a/app/templates/me/overview.hbs
+++ b/app/templates/me/overview.hbs
@@ -70,7 +70,7 @@ then let them know what's up.
       {{#if (lte person.years.length 1)}}
         Hello Shiny Penny! Congratulations on becoming a Ranger.
       {{else}}
-        Hello {{#if person.vintage}}Vintage{{/if}} Ranger! You have been active for {{person.years.length}} years.
+        Hello {{#if person.vintage}}Vintage{{/if}} Ranger! You have Rangered at {{pluralize person.years.length "burn"}}.
       {{/if}}
     </div>
   {{/if}}


### PR DESCRIPTION
- ch-form was not setting maxlength correctly on a textarea element which mucked up things when someone tried to enter too long of a slot description.
- upped the slot description to 512 characters.
- show slot description character count below textarea.
- changed home page text "You have been an active Ranger for X years" to "You have Rangered at X burns" because Ranger active is not the same as the dictionary definition of active.