### PR TITLE
BMID interface work. Various bug fixes & tweaks.

### DIFF
--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -13,6 +13,7 @@ const SINGULAR_MODELS = [
   'access-document',
   'asset-person',
   'asset-attachment',
+  'bmid',
   'person',
   'position',
   'position-credit',
@@ -38,5 +39,4 @@ export default class ApplicationAdapter extends DS.RESTAdapter.extend(DataAdapte
   pathForType(modelName) {
     return SINGULAR_MODELS.includes(modelName) ?  modelName : Inflector.inflector.pluralize(modelName);
   }
-
 }

--- a/app/components/bmid-edit.js
+++ b/app/components/bmid-edit.js
@@ -1,0 +1,17 @@
+import Component from '@ember/component';
+import { argument } from '@ember-decorators/argument';
+import { optional } from '@ember-decorators/argument/types';
+import { MealOptions, BmidStatusOptions, ShowerOptions } from 'clubhouse/constants/bmid';
+
+export default class BmidEditComponent extends Component {
+  @argument('object') entry;
+  @argument('number') year;
+  @argument('object') onSave;
+  @argument(optional('object')) onCancel;
+  @argument(optional('boolean')) modalBox = true;
+  @argument('object') admissionDateOptions;
+
+  bmidStatusOptions = BmidStatusOptions;
+  mealOptions = MealOptions;
+  showerOptions = ShowerOptions;
+}

--- a/app/components/ch-form.js
+++ b/app/components/ch-form.js
@@ -35,6 +35,8 @@ export default class ChFormComponent extends Component {
 
   @argument(optional('string')) formClass;
 
+  @argument(optional('boolean')) formless = false;
+
   // Was the original backing model updated?
   watchingModel = false;
 
@@ -149,13 +151,13 @@ export default class ChFormComponent extends Component {
      }
 
      const field = Object.keys(error)[0];
-     const label = `#${this.formId} label[for="${field}"]`;
+     const label = `label[for="${this.formId}-${field}"]`;
 
      // Scroll the label into view if it exists, otherwise the element
      if (document.querySelector(label)) {
        this.house.scrollToElement(label);
      } else {
-       this.house.scrollToElement(`#${this.formId} [name="${field}"]`);
+       this.house.scrollToElement(`[name="${this.formId}-${field}"]`);
      }
   }
 

--- a/app/components/loading-message.js
+++ b/app/components/loading-message.js
@@ -1,6 +1,8 @@
 import Component from '@ember/component';
 import { argument } from '@ember-decorators/argument';
+import { tagName } from '@ember-decorators/component';
 
+@tagName('')
 export default class LoadingMessageComponent extends Component {
   static positionalParams = [ 'message' ];
 

--- a/app/constants/bmid.js
+++ b/app/constants/bmid.js
@@ -1,0 +1,46 @@
+
+export const BmidStatusLabels = {
+  in_prep: 'Prep',
+  do_not_print: 'Do Not Print',
+  ready_to_print: 'Ready To Print',
+  ready_to_reprint_lost: 'Ready To Reprint (Lost)',
+  ready_to_reprint_changed: 'Ready To Reprint (Changed)',
+  issues: 'Issues',
+  submitted: 'Submitted',
+};
+
+export const BmidStatusOptions = [
+  ['Prep', 'in_prep'],
+  ['Do Not Print', 'do_not_print'],
+  ['Ready To Print', 'ready_to_print'],
+  ['Ready To Reprint (Lost)', 'ready_to_reprint_lost'],
+  ['Ready To Reprint (Changed)', 'ready_to_reprint_changed'],
+  ['Issues', 'issues'],
+  ['Submitted', 'submitted']
+];
+
+export const MealLabels = {
+  pre: 'Pre',
+  post: 'Post',
+  event: 'Event',
+  all: 'All',
+  'pre+post': 'Pre+Post',
+  'pre+event': 'Pre+Event',
+  'event+post': 'Event+Post',
+};
+
+export const MealOptions = [
+  ['None', ''],
+  ['Pre', 'pre'],
+  ['Post', 'post'],
+  ['Event', 'event'],
+  ['All', 'all'],
+  ['Pre+Post', 'pre+post'],
+  ['Pre+Event', 'pre+event'],
+  ['Event+Post', 'event+post']
+];
+
+export const ShowerOptions = [
+  [ 'No', false ],
+  [ 'Yes', true ],
+];

--- a/app/controllers/admin/action-log.js
+++ b/app/controllers/admin/action-log.js
@@ -14,6 +14,7 @@ const EventOptions = [
     [ 'Schedule Updates', 'person-slot-%' ],
     [ 'Role Changes', 'person-role-%' ],
     [ 'Position Changes', 'person-position-%' ],
+    [ 'Status Changes', 'person-status-change' ]
 ];
 
 const SortOptions = [
@@ -86,6 +87,7 @@ export default class AdminActionLogController extends Controller {
         params[param] = null;
       }
     });
+    params.page = null;
     this.setProperties(params);
     this.toast.clear();
   }

--- a/app/controllers/person/access-documents.js
+++ b/app/controllers/person/access-documents.js
@@ -1,6 +1,6 @@
 import Controller from '@ember/controller';
 import { action, computed } from '@ember-decorators/object';
-import moment from 'moment';
+import admissionDateOptions from 'clubhouse/utils/admission-date-options';
 
 export default class PersonAccessDocumentsController extends Controller {
   entry = null;
@@ -37,24 +37,7 @@ export default class PersonAccessDocumentsController extends Controller {
 
   @computed
   get admissionDateOptions() {
-    const year = (new Date()).getFullYear();
-    const options = [
-      ['Unspecificed', '']
-    ];
-
-    let low = 5, high = 26;
-    const range = this.ticketingInfo.wap_date_range;
-    if (range != null) {
-      [low, high] = range.split('-');
-    }
-
-    for (let day = high; day >= low; day--) {
-      const date = `${year}-08-${day < 10 ? '0'+day : day}`;
-      options.push([moment(date).format('ddd, MM/DD/YY'), date]);
-    }
-
-    options.push(['Any', 'any']);
-    return options;
+    return admissionDateOptions(this.house.currentYear(), this.ticketingInfo.wap_date_range);
   }
 
   @action

--- a/app/controllers/person/bmid.js
+++ b/app/controllers/person/bmid.js
@@ -1,0 +1,21 @@
+import Controller from '@ember/controller';
+import { action, computed } from '@ember-decorators/object';
+import admissionDateOptions from 'clubhouse/utils/admission-date-options';
+
+export default class PersonBmidController extends Controller {
+  @computed('year')
+  get admissionDateOptions() {
+    return admissionDateOptions(this.year, this.ticketingInfo.wap_date_range);
+  }
+
+  @action
+  save(model, isValid) {
+    if (!isValid)
+      return;
+
+    model.save().then(() => {
+      this.toast.success('BMID successfully updated.');
+    })
+    .catch((response) => this.house.handleErrorResponse(response));
+  }
+}

--- a/app/controllers/person/index.js
+++ b/app/controllers/person/index.js
@@ -116,7 +116,7 @@ export default class PersonIndexController extends Controller {
       this.toast.success('The information was successfully updated.');
 
       // Reload the current user.
-      if (model.get('id') == this.session.user_id) {
+      if (model.get('id') == this.session.user.id) {
         this.session.loadUser();
       }
 

--- a/app/controllers/vc/bmid-print.js
+++ b/app/controllers/vc/bmid-print.js
@@ -1,0 +1,51 @@
+import Controller from '@ember/controller';
+import { action, computed } from '@ember-decorators/object';
+import { set } from '@ember/object';
+
+export default class VcBmidPrintController extends Controller {
+  queryParams = [ 'year', 'filter' ];
+
+  batchForm = {};
+
+  filterOptions = [
+    [ 'Specials (titles, meals, showers, or early arrival)', 'special' ],
+    [ 'Alphas', 'alpha' ],
+    [ 'Vets w/shift after 8/15 OR PASSED training; excludes PNVs', 'signedup' ],
+  ];
+
+  @computed('bmids.@each.selected')
+  get bmidsSelectedCount() {
+    return this.bmids.reduce((total, bmid) => (bmid.selected ? 1 : 0)+total, 0);
+  }
+
+  @action
+  sendToLambase(model) {
+    const batch_info = model.get('batchInfo');
+
+    this.modal.confirm('Confirm Submitting To Lambase',
+      `${this.bmidsSelectedCount} BMID(s) have been selected to print. Are you sure you want to do this?`,
+      () => {
+        const person_ids = this.bmids.reduce((ids, bmid) => {
+          if (bmid.selected) {
+            ids.push(bmid.person_id);
+          }
+          return ids;
+        }, []);
+
+        this.set('isSubmitting', true);
+        this.ajax.request(`bmid/lambase`, { method: 'POST', data: { year: this.year, person_ids, batch_info }}).then((result) => {
+          result.bmids.forEach((bmid) => {
+            const found = this.bmids.find((needle) => needle.person_id == bmid.person_id);
+
+            if (found) {
+              set(found, 'status', bmid.status);
+            }
+          });
+
+          this.toast.success('BMID(s) send to Lambase.');
+        }).catch((response) => this.house.handleErrorResponse(response))
+        .finally(() => this.set('isSubmitting', false));
+      }
+    );
+  }
+}

--- a/app/controllers/vc/bmid.js
+++ b/app/controllers/vc/bmid.js
@@ -1,0 +1,415 @@
+import Controller from '@ember/controller';
+import { action, computed, observes } from '@ember-decorators/object';
+import { isEmpty } from '@ember/utils';
+import { schedule, later } from '@ember/runloop';
+import { MealOptions, BmidStatusOptions, ShowerOptions } from 'clubhouse/constants/bmid';
+import admissionDateOptions from 'clubhouse/utils/admission-date-options';
+import Changeset from 'ember-changeset';
+
+/*
+ * BMID management controller
+ */
+
+// How many elements to render at a time
+const BMID_RENDER_SLICE = 100;
+
+const CSV_COLUMNS = [
+  'callsign',
+  'title1',
+  'title2',
+  'title3',
+  'meals',
+  'showers',
+  'mvr',
+  'team',
+  'notes',
+  'wap_status',
+  'access_date',
+];
+
+export default class VcBmidController extends Controller {
+  queryParams = [ 'year', 'filter' ];
+
+  bmidStatusOptions = BmidStatusOptions;
+  mealOptions = MealOptions;
+  showerOptions = ShowerOptions;
+
+  filterOptions = [
+    [ 'Specials (titles, meals, showers, or early arrival)', 'special' ],
+    [ 'Alphas', 'alpha' ],
+    [ 'Vets w/shift after 8/15 OR PASSED training; excludes PNVs', 'signedup' ],
+    [ 'BMIDs marked as "Issues" or "Do Not Print"', 'nonprint' ],
+    [ 'Submitted BMIDs', 'submitted' ],
+    [ 'Printed BMIDs', 'printed' ]
+  ];
+
+  sortColumn = 'callsign';
+  titleFilter = 'All';
+  teamFilter = 'All';
+
+  sortOptions = [
+    'callsign',
+    'status',
+    'title1',
+    'title2',
+    'title3',
+    'mvr',
+    'showers',
+    'meals',
+    'wap',
+    'team',
+    'notes'
+  ];
+
+
+  textFilterFields = [
+    'person.callsign',
+    'title1',
+    'title2',
+    'title3',
+    'teams',
+    'notes'
+  ];
+
+  /*
+   * Return the BMIDs to view which is filtered, and sorted
+   */
+
+  @computed('sortColumn', 'titleFilter', 'teamFilter', 'textFilter', 'bmids.[]')
+  get viewBmids() {
+    let bmids = this.bmids;
+    const titleFilter = this.titleFilter;
+    let key;
+
+    if (this.titleFilter != 'All') {
+      bmids = bmids.filter((bmid) => (bmid.title1 == titleFilter || bmid.title2 == titleFilter || bmid.title3 == titleFilter ));
+    }
+
+    if (this.teamFilter != 'All') {
+      bmids = bmids.filter((bmid) => (!isEmpty(bmid.team) && bmid.team.indexOf(this.teamFilter) !== -1));
+    }
+
+    if (!isEmpty(this.textFilter)) {
+      const regexp = new RegExp(this.textFilter, 'i');
+
+      bmids = bmids.filter((bmid) => {
+        let haveMatch = false;
+        this.textFilterFields.forEach((field) => {
+          const value = bmid.get(field);
+
+          if (!isEmpty(value) && regexp.test(value)) {
+            haveMatch = true;
+          }
+        });
+
+        return haveMatch;
+      });
+    }
+
+    switch (this.sortColumn) {
+      case 'callsign':
+        // Sort by callsign
+        bmids.sort((a,b) => {
+          const personA = (a.person ? a.person.callsign.toLowerCase() : `Deleted #${a.person_id}`);
+          const personB = (b.person ? b.person.callsign.toLowerCase() : `Deleted #${b.person_id}`);
+          return personA.localeCompare(personB);
+        });
+        break;
+
+      case 'status':
+      case 'title1':
+      case 'title2':
+      case 'title3':
+      case 'meals':
+      case 'team':
+      case 'notes':
+        key = this.sortColumn;
+        bmids.sort((a,b) => {
+          const aCol = a[key], bCol = b[key];
+
+          // Have empty values appear at the end
+          if (!aCol) { return 1; }
+          if (!bCol) { return -1; }
+
+          return aCol.toLowerCase().localeCompare(bCol.toLowerCase());
+        });
+        break;
+
+      case 'mvr':
+        // With Insurance first
+        bmids.sort((a,b) => b.org_vehicle_insurance - a.org_vehicle_insurance);
+        break;
+
+      case 'showers':
+        // With showers first
+        bmids.sort((a,b) => b.showers - a.showers);
+        break;
+
+      case 'wap':
+        bmids.sort((a,b) => a.access_date_sortable - b.access_date_sortable);
+        break;
+    }
+
+    return bmids;
+  }
+
+  /*
+   * Take a chunk out of viewBmids and add it to renderBmids.
+   *
+   * Ember may lock up the browser trying to render a large table.
+   * Gradually build up the to-be-rendered BMIDs for a better UI experience.
+   */
+
+
+  _setRenderBmidsSlice(startSlice) {
+    const viewBmids = this.viewBmids;
+    let slice =  viewBmids.slice(startSlice, startSlice + BMID_RENDER_SLICE);
+    this.set('renderBmids', this.renderBmids.concat(slice));
+    slice = slice.map((row) => new Changeset(row));
+    this.set('editableBmids', this.editableBmids.concat(slice));
+
+    if (this.renderBmids.length < viewBmids.length) {
+      schedule('afterRender', this, () => {
+        later(() => { this._setRenderBmidsSlice(startSlice + BMID_RENDER_SLICE) }, 1)
+      });
+    } else {
+      this.set('isRendering', false);
+    }
+  }
+
+  /*
+   * Kick off building up over time the BMIDs to be shown
+   */
+
+  @observes('viewBmids', 'bmids', 'editMode')
+  startRenderBmids() {
+    if (this.isRendering) {
+      return;
+    }
+
+    this.set('isRendering', true);
+    this.set('renderBmids', []);
+    this.set('editableBmids', []);
+    later(() => { this._setRenderBmidsSlice(0) }, 1);
+  }
+
+  /*
+   * How many BMIDs have not been saved.
+   */
+
+  @computed('editableBmids.@each.isDirty')
+  get unsaveRows() {
+    return this.editableBmids.reduce((total, row) => (row.isDirty ? 1 : 0)+total, 0);
+  }
+
+  /*
+   * Build the title filter options
+   */
+
+  @computed('bmids.[]', 'bmids.@each.{title1,title2,title3}')
+  get titleFilterOptions() {
+    const titles = {};
+
+    this.bmids.forEach((bmid) => {
+      if (!isEmpty(bmid.title1)) {
+        titles[bmid.title1] = true;
+      }
+      if (!isEmpty(bmid.title2)) {
+        titles[bmid.title2] = true;
+      }
+      if (!isEmpty(bmid.title3)) {
+        titles[bmid.title3] = true;
+      }
+    });
+
+    const options = Object.keys(titles).sort();
+    options.unshift('All');
+
+    return options;
+  }
+
+  /*
+   * Build the team filter options. Split out combined teams if a
+   * '+' or '/' is in the field. (e.g., Pre/Post becomes two teams [Pre, Post],)
+   */
+
+  @computed('bmids.{[],@each.team}')
+  get teamFilterOptions() {
+    const teams = {};
+
+    this.bmids.forEach((bmid) => {
+      if (!isEmpty(bmid.team)) {
+        bmid.team.split(/(\+|\/)/).forEach((word) => {
+          if (word != '+' && word != '/')
+            teams[word] = true;
+         });
+      }
+    });
+
+    const options = Object.keys(teams).sort();
+    options.unshift('All');
+
+    return options;
+  }
+
+  /*
+   * Build the access dates allowed for the current year
+   */
+
+  @computed('year')
+  get admissionDateOptions() {
+    return admissionDateOptions(this.year, this.ticketingInfo.wap_date_range);
+  }
+
+  @action
+  toggleEditMode() {
+    this.toggleProperty('editMode');
+  }
+
+  @action
+  editBmid(bmid) {
+    this.set('entry', bmid);
+
+  }
+
+  @action
+  cancelBmid() {
+    this.set('entry', null);
+  }
+
+  /*
+   * Save a BMID being edited in a the modal box. Need to close the modal down after
+   * a successful save.
+   */
+
+  @action
+  saveBmid(model, isValid) {
+    if (!isValid) {
+      return;
+    }
+
+    model.save().then(() => {
+      this.toast.success('BMID successfully updated.');
+      this.set('entry', null);
+    })
+    .catch((response) => this.house.handleErrorResponse(response));
+  }
+
+  /*
+   * Save a BMID being edited in the table.
+   */
+
+  @action
+  saveInlineBmid(model) {
+    model.save().then(() => {
+      this.toast.success('BMID successfully updated.');
+    })
+    .catch((response) => this.house.handleErrorResponse(response));
+  }
+
+  /*
+   * Provide a string filter. Verify any regular expressions entered are valid.
+   */
+
+  @action
+  textFilterAction() {
+    this.set('textFilterError', '');
+    const filter = this.textFilterInput;
+
+    if (isEmpty(filter)) {
+      return;
+    }
+
+    try {
+      RegExp(filter);
+      this.set('textFilter', filter);
+    } catch(e) {
+      this.set('textFilterError', e.toString());
+    }
+  }
+
+  @action
+  clearTextFilterAction() {
+    this.set('textFilter', '');
+    this.set('textFilterInput', '');
+    this.set('textFilterError', '');
+  }
+
+  /*
+   * Increase the note textarea rows when editing inline and the note receives
+   * focus.
+   */
+
+  @action
+  focusNote(event) {
+    event.target.rows = 10;
+  }
+
+  /*
+   * When losing focus on the note field - reduce the textarea rows back to 1
+   * and store what was entered.
+   */
+
+  @action
+  blurNote(bmid, event) {
+    bmid.set('notes', event.target.value);
+    event.target.rows = 1;
+  }
+
+  /*
+   * Update a field on blur/lost of focus.
+   */
+
+  @action
+  updateColumn(bmid, column, event) {
+    const value = event.target.value;
+
+    /*
+     * When a blank field is entered and then exited without entering
+     * any characters. the target.value will be "". The record column  might be
+     * null, so check to see if both are empty, and do nothing.
+     * Otherwise setting the column to "" will cause isDirty to be set and
+     * we don't want that.
+     */
+
+    if (isEmpty(value) && isEmpty(bmid.get(column))) {
+      return;
+    }
+
+    bmid.set(column, isEmpty(value) ? null : value);
+  }
+
+  /*
+   * Export current selection to a CSV file
+   */
+
+  @action
+  exportCSV() {
+    const bmids = this.viewBmids.map((bmid) => {
+      return {
+        callsign: bmid.person.callsign,
+        title1: bmid.title1,
+        title2: bmid.title2,
+        title3: bmid.title3,
+        meals: bmid.meals,
+        showers: bmid.showers ? 'Y' : 'N',
+        mvr: bmid.org_vehicle_insurance ? 'Y' : 'N',
+        team: bmid.team,
+        notes: bmid.notes,
+        wap_status: bmid.wap_id ? bmid.wap_status : 'missing',
+        access_date: bmid.admission_date || 'unspecified',
+      }
+    });
+
+    this.house.downloadCsv(`bmids-${this.year}-${this.filter}.csv`, CSV_COLUMNS, bmids);
+  }
+
+  /*
+   * Sort the table
+   */
+
+  @action
+  sortBmidsAction(column) {
+    this.set('sortColumn', column);
+  }
+}

--- a/app/helpers/fa-icon.js
+++ b/app/helpers/fa-icon.js
@@ -6,7 +6,8 @@ export function faIcon([ name ], namedParams) {
   const type = namedParams.type || 'fas';
   const color = namedParams.color ? ` text-${namedParams.color}` : '';
   const title = namedParams.title ? ` title="${namedParams.title}"` : '';
-  return htmlSafe(`<i class="${type} fa-${name}${size}${color}"${title}></i>`)
+  const spinner = namedParams.spin ? ` fa-spin` : '';
+  return htmlSafe(`<i class="${type} fa-${name}${size}${color}${spinner}"${title}></i>`)
 }
 
 export default helper(faIcon);

--- a/app/mixins/models/person.js
+++ b/app/mixins/models/person.js
@@ -52,7 +52,6 @@ export default Mixin.create({
   isNotRanger: computed('status', function () {
     const status = this.status;
 
-    // TODO shouldn't resigned/retired/uberbonked/etc. be in this list?
     return (status == PersonStatus.AUDITOR ||
       status == PersonStatus.ALPHA ||
       status == PersonStatus.BONKED ||

--- a/app/models/bmid.js
+++ b/app/models/bmid.js
@@ -1,0 +1,105 @@
+import DS from 'ember-data';
+import { computed } from '@ember-decorators/object';
+import { attr } from '@ember-decorators/data';
+import { isEmpty } from '@ember/utils';
+import { ticketTypeLabel } from 'clubhouse/constants/ticket-types';
+import { BmidStatusLabels, MealLabels } from 'clubhouse/constants/bmid';
+
+import moment from 'moment';
+
+const { Model } = DS;
+
+export default class BmidModel extends Model {
+  @attr('number') person_id;
+  @attr('string') status;
+  @attr('number') year;
+  @attr('string') title1;
+  @attr('string') title2;
+  @attr('string') title3;
+  @attr('boolean') showers;
+  @attr('boolean') org_vehicle_insurance;
+  @attr('string') meals;
+  @attr('string') batch;
+  @attr('string') team;
+  @attr('string') notes;
+  @attr('string') create_datetime;
+  @attr('string') modified_datetime;
+
+  @attr('string') access_date;
+  @attr('boolean') access_any_time;
+
+  @attr('', { readOnly: true }) person;
+  @attr('number', { readOnly: true }) wap_id;
+  @attr('string', { readOnly: true }) wap_status;
+  @attr('string', { readOnly: true }) wap_type;
+
+  @computed('access_date', 'access_any_time')
+  get admission_date() {
+    if (this.access_any_time) {
+      return 'any';
+    } else {
+      if (this.access_date) {
+        return moment(this.access_date).format('YYYY-MM-DD');
+      } else {
+        return null;
+      }
+    }
+  }
+
+  set admission_date(value) {
+    if (value == 'any') {
+      this.set('access_any_time', true);
+      this.set('access_date', null);
+    } else {
+      this.set('access_any_time', false);
+      this.set('access_date', value);
+    }
+  }
+
+  @computed('access_date', 'access_any_time')
+  get access_date_sortable() {
+    if (this.wapMissing) {
+      return 0;
+    }
+
+    if (this.access_any_time) {
+      return 1;
+    }
+
+    if (isEmpty(this.access_date)) {
+      return -1;
+    }
+
+    return moment(this.access_date).valueOf();
+  }
+
+  @computed('wap_status', 'wap_id')
+  get wapDisabled() {
+    return !this.wap_id || this.wap_status == 'submitted';
+  }
+
+  @computed('wap_status', 'wap_id')
+  get wapMissing() {
+    return !this.wap_id;
+  }
+
+  @computed('wap_status')
+  get wapSubmitted() {
+    return this.wap_status == 'submitted';
+  }
+
+  @computed('wap_type')
+  get wapTypeHuman() {
+    return ticketTypeLabel[this.wap_type] || this.wap_type;
+  }
+
+  @computed('meals')
+  get mealsHuman() {
+    return (isEmpty(this.meals) ? 'None' : (MealLabels[this.meals] || this.meals));
+  }
+
+  @computed('status')
+  get statusHuman() {
+    return (BmidStatusLabels[this.status] || `Unknown status ${this.status}`);
+  }
+}

--- a/app/router.js
+++ b/app/router.js
@@ -101,6 +101,7 @@ Router.map(function() {
     this.route('broadcast-log');
     this.route('access-documents');
     this.route('tickets');
+    this.route('bmid');
   });
 
   this.route('logout');
@@ -134,6 +135,9 @@ Router.map(function() {
       this.route('expiring');
       this.route('trs');
     });
+    this.route('bmid');
+    this.route('bmid-sanity-check');
+    this.route('bmid-print');
   });
   this.route('register');
 

--- a/app/routes/admin.js
+++ b/app/routes/admin.js
@@ -4,6 +4,7 @@ import { Role } from 'clubhouse/constants/roles';
 
 export default class AdminRoute extends Route.extend(AuthenticatedRouteMixin) {
   beforeModel() {
+    super.beforeModel(...arguments);
     this.house.roleCheck([Role.EDIT_SLOTS, Role.ADMIN]);
   }
 }

--- a/app/routes/error.js
+++ b/app/routes/error.js
@@ -25,16 +25,6 @@ export default class ErrorRoute extends Route {
         stack: error.stack
       };
 
-      if (error.isAdapterError) {
-        // Looks like an ember-data exception
-        route_error.description = error.description;
-        route_error.filename = error.fileName;
-        route_error.line_number = error.lineNumber;
-        route_error.name = error.name;
-        route_error.number = error.number;
-        route_error.code = error.code;
-      }
-
       data.append('data', JSON.stringify({
         build_timestamp: ENV.APP.buildTimestamp,
         version: ENV.APP.version,

--- a/app/routes/hq.js
+++ b/app/routes/hq.js
@@ -8,6 +8,7 @@ import DS from 'ember-data';
 
 export default class HqRoute extends Route.extend(AuthenticatedRouteMixin) {
   beforeModel() {
+    super.beforeModel(...arguments);
     this.house.roleCheck([ Role.ADMIN, Role.MANAGE ]);
   }
 

--- a/app/routes/mentor.js
+++ b/app/routes/mentor.js
@@ -4,6 +4,7 @@ import { Role } from 'clubhouse/constants/roles';
 
 export default class MentorRoute extends Route.extend(AuthenticatedRouteMixin) {
   beforeModel() {
+    super.beforeModel(...arguments);
     this.house.roleCheck([ Role.ADMIN, Role.MENTOR ]);
   }
 }

--- a/app/routes/person/bmid.js
+++ b/app/routes/person/bmid.js
@@ -1,0 +1,28 @@
+import Route from '@ember/routing/route';
+import RSVP from 'rsvp';
+
+export default class PersonBmidRoute extends Route {
+  model() {
+    const person_id = this.modelFor('person').id;
+    return RSVP.hash({
+      bmid: this.ajax.request(`bmid/manage-person`, { data: { person_id, year: this.house.currentYear() }}).then((result) => result.bmid),
+      ticketingInfo: this.ajax.request('ticketing/info').then((result) => result.ticketing_info)
+    });
+  }
+
+  setupController(controller, model) {
+    let bmid;
+    this.store.unloadAll('bmid');
+
+    if (model.bmid.id) {
+      bmid = this.house.pushPayload('bmid', model.bmid);
+    } else {
+      bmid = this.store.createRecord('bmid', model.bmid);
+    }
+
+    controller.set('bmid', bmid);
+    controller.set('person', this.modelFor('person'));
+    controller.set('year', this.house.currentYear());
+    controller.set('ticketingInfo', model.ticketingInfo);
+  }
+}

--- a/app/routes/reports.js
+++ b/app/routes/reports.js
@@ -7,6 +7,7 @@ import { Role } from 'clubhouse/constants/roles';
 
 export default class ReportsRoute extends Route.extend(AuthenticatedRouteMixin) {
   beforeModel() {
+    super.beforeModel(...arguments);
     this.house.roleCheck([ Role.ADMIN, Role.MANAGE ]);
   }
 

--- a/app/routes/vc.js
+++ b/app/routes/vc.js
@@ -5,6 +5,7 @@ import { Role } from 'clubhouse/constants/roles';
 
 export default class VcRoute extends Route.extend(AuthenticatedRouteMixin) {
   beforeModel() {
-    this.house.roleCheck([ Role.ADMIN, Role.VC ]);
+    super.beforeModel(...arguments);
+    this.house.roleCheck([ Role.ADMIN, Role.VC, Role.EDIT_BMIDS ]);
   }
 }

--- a/app/routes/vc/bmid-print.js
+++ b/app/routes/vc/bmid-print.js
@@ -1,0 +1,84 @@
+import Route from '@ember/routing/route';
+import { set } from '@ember/object';
+import { Role } from 'clubhouse/constants/roles';
+import requestYear from 'clubhouse/utils/request-year';
+
+import RSVP from 'rsvp';
+
+const ALLOWED_STATUSES = [
+  'active', 'inactive', 'inactive extension', 'retired', 'alpha', 'prospective'
+];
+
+export default class VcBmidPrintRoute extends Route {
+  queryParams = {
+    year: { refreshModel: true },
+    filter: { refreshModel: true },
+  };
+
+  beforeModel() {
+    this.house.roleCheck([ Role.ADMIN, Role.EDIT_BMIDS ]);
+  }
+
+  model(params) {
+    const year = requestYear(params);
+    const filter = params.filter || 'special';
+
+    return RSVP.hash({
+      year,
+      filter,
+      bmids: this.ajax.request(`bmid/manage`, { data: { year, filter }}).then((result) => result.bmids),
+    });
+  }
+
+  setupController(controller, model) {
+    const bmids = [], doNotPrint = [], issues = [],
+        printed = [], submitted = [], unusualStatus = [];
+
+    controller.set('year', model.year);
+    controller.set('filter', model.filter);
+    controller.set('batchForm', {});
+
+    this.store.unloadAll('bmid');
+
+    model.bmids.forEach((bmid) =>{
+      switch (bmid.status) {
+        case 'do_not_print':
+          doNotPrint.push(bmid);
+          return;
+
+        case 'issues':
+          issues.push(bmid);
+          return;
+
+        case 'printed':
+          printed.push(bmid);
+          return;
+
+        case 'submitted':
+          submitted.push(bmid);
+          return;
+      }
+
+      if (!ALLOWED_STATUSES.includes(bmid.person.status)) {
+        unusualStatus.push(bmid);
+        return;
+      }
+
+      set(bmid, 'selected', 1)
+      bmids.push(this.store.createRecord('bmid', bmid));
+    });
+
+    controller.setProperties({
+      bmids, doNotPrint, issues, printed, submitted, unusualStatus
+    });
+
+    controller.set('totalBmids', model.bmids.length);
+  }
+
+  resetController(controller) {
+    controller.setProperties({
+      bmids: null, doNotPrint: null, issues: null, printed: null, submitted: null, unusualStatus: null
+    });
+    this.store.unloadAll('bmid');
+  }
+}

--- a/app/routes/vc/bmid-sanity-check.js
+++ b/app/routes/vc/bmid-sanity-check.js
@@ -1,0 +1,28 @@
+import Route from '@ember/routing/route';
+import { Role } from 'clubhouse/constants/roles';
+import requestYear from 'clubhouse/utils/request-year';
+import RSVP from 'rsvp';
+
+export default class VcBmidSanityCheckRoute extends Route {
+  queryParams = {
+    year: { refreshModel: true },
+  };
+
+  beforeModel() {
+    this.house.roleCheck([ Role.ADMIN, Role.EDIT_BMIDS ]);
+  }
+
+  model(params) {
+    const year = requestYear(params);
+
+    return RSVP.hash({
+      year,
+      bmidMadHouse: this.ajax.request(`bmid/sanity-check`, { data: { year }}),
+      ticketingInfo: this.ajax.request('ticketing/info').then((result) => result.ticketing_info)
+    });
+  }
+
+  setupController(controller, model) {
+    controller.setProperties(model);
+  }
+}

--- a/app/routes/vc/bmid.js
+++ b/app/routes/vc/bmid.js
@@ -1,0 +1,70 @@
+import Route from '@ember/routing/route';
+import { Role } from 'clubhouse/constants/roles';
+import requestYear from 'clubhouse/utils/request-year';
+import RSVP from 'rsvp';
+
+export default class VcBmidRoute extends Route {
+  queryParams = {
+    year: { refreshModel: true },
+    filter: { refreshModel: true },
+  };
+
+  beforeModel() {
+    this.house.roleCheck([ Role.ADMIN, Role.EDIT_BMIDS ]);
+  }
+
+  model(params) {
+    const year = requestYear(params);
+    const filter = params.filter || 'special';
+
+    return RSVP.hash({
+      year,
+      filter,
+      bmids: this.ajax.request(`bmid/manage`, { data: { year, filter }}).then((result) => result.bmids),
+      ticketingInfo: this.ajax.request('ticketing/info').then((result) => result.ticketing_info)
+    });
+  }
+
+  setupController(controller, model) {
+    const bmids = [];
+
+    this.store.unloadAll('bmid');
+
+    // Loop through the list
+    model.bmids.forEach((bmid) => {
+      let rec;
+      if (bmid.id) {
+        rec = this.house.pushPayload('bmid', bmid);
+      } else {
+        // Potential new BMID
+        rec = this.store.createRecord('bmid', bmid);
+      }
+
+      bmids.push(rec);
+    });
+
+    controller.set('bmids', bmids);
+    controller.set('year', model.year);
+    controller.set('filter', model.filter);
+    controller.set('ticketingInfo', model.ticketingInfo);
+    controller.set('sortColumn', 'callsign');
+    controller.set('titleFilter', 'All');
+    controller.set('teamFilter', 'All');
+    controller.set('textFilterInput', '');
+    controller.set('textFilter', '');
+    controller.set('textFilterError', '');
+
+    controller.set('editMode', false);
+  }
+
+  resetController(controller) {
+    // Clear up the controller - otherwise a race condition might happen
+    // when refreshing the route where the same record(s) is shown between
+    // two different views.
+    controller.set('bmids', []);
+    controller.set('renderedBmids', []);
+    controller.set('entry', null);
+
+    this.store.unloadAll('bmid');
+  }
+}

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -11,6 +11,7 @@ $theme-colors: (
   "khaki": $kakhi,
   "gray": #dcdcdc,
   "light-red": #ff6666,
+  "highlight": #ffff99,
 );
 
 // bootstrap set the link-color to the primary color
@@ -262,6 +263,14 @@ legend {
   height: 64px;
   width: 64px;
   margin: 0 auto;
+  background-image: url("images/spinner.gif");
+  background-size: cover;
+}
+
+.loading-spinner-inline {
+  display: inline-block;
+  height: 14px;
+  width: 14px;
   background-image: url("images/spinner.gif");
   background-size: cover;
 }

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -4,7 +4,11 @@
       <span class="navbar-toggler-icon"></span>
     </button>
     {{#link-to "me.overview" class="navbar-brand"}}
-      Clubhouse
+      {{#if (eq (config "DeploymentEnvironment") "Staging")}}
+        <span class="text-danger">Staging Server</span>
+      {{else}}
+        Clubhouse
+      {{/if}}
     {{/link-to}}
 
     <div class="collapse navbar-collapse" id="navbarNavDropdown">
@@ -129,7 +133,7 @@
                   {{#link-to "vc.access-documents" class="dropdown-item"}}Manage Access Docs{{/link-to}}
                 {{/if}}
                 {{#if (has-role "edit-bmids")}}
-                  <a href="{{cgo "bmidc" "manageBMIDs"}}" class="dropdown-item">Manage BMIDs</a>
+                  {{#link-to "vc.bmid" class="dropdown-item"}}Manage BMIDs{{/link-to}}
                 {{/if}}
                 <a href="{{cgo "timesheet" "noobTracker"}}" class="dropdown-item">N00b Tracker!</a>
               </div>
@@ -343,7 +347,6 @@
       {{/ch-form}}
     </div>
   {{/if}}
-
 </header>
 
 {{#if session.isAuthenticated}}

--- a/app/templates/components/bmid-edit.hbs
+++ b/app/templates/components/bmid-edit.hbs
@@ -1,0 +1,51 @@
+{{#ch-form "bmid" @entry modalBox=modalBox modalTitle=(if @entry.id (concat "Edit BMID #" @entry.id) "New BMID") onSubmit=(action @onSave) as |f|}}
+  {{#if modalBox}}
+    <h3>{{@year}} {{@entry.person.callsign}} &lt;{{@entry.person.status}},{{@entry.person.first_name}} {{@entry.person.last_name}}&gt;</h3>
+  {{/if}}
+  <p>
+    {{#if @entry.wap_id}}
+      WAP ID #{{@entry.wap_id}} - {{@entry.wapTypeHuman}} - {{@entry.wap_status}}
+      {{#if @entry.wapSubmitted}}
+        <br>
+        <strong class="text-danger">WAP has been submitted for processing - WAP Date cannot be changed.</strong>
+      {{/if}}
+    {{else}}
+      <strong class="text-danger">WAP could not be located - WAP Date cannot be changed.</strong>
+    {{/if}}
+  </p>
+  <div class="form-row">
+    {{f.input "status" label="BMID Status" type="select" options=bmidStatusOptions}}
+    {{f.input "meals" label="Meals" type="select" options=mealOptions grid="col-auto"}}
+    {{f.input "showers" label="Showers" type="select" options=showerOptions grid="col-auto"}}
+    {{f.input "admission_date" label="WAP Date" type="select" disabled=@entry.wapDisabled options=admissionDateOptions}}
+  </div>
+
+  <div class="form-row">
+    {{f.input "title1" label="Title 1" type="text" size=64 grid="col-auto"}}
+    {{f.input "title2" label="Title 2" type="text" size=64 grid="col-auto"}}
+    {{f.input "title3" label="Title 3" type="text" size=64 grid="col-auto"}}
+  </div>
+
+  <div class="form-row">
+    {{f.input "team" label="Team" type="text" size=80 grid="col-auto"}}
+    {{f.input "notes" label="Notes" type="textarea" rows=4 cols=80}}
+  </div>
+  <div class="form-group row">
+    <div class="col-auto">
+      {{#if @entry.isNew}}
+        BMID record will be created on save.
+      {{else}}
+        Created {{@entry.create_datetime}} Last modified {{@entry.modified_datetime}}
+      {{/if}}
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-auto">
+      {{f.submit}}
+      {{#if @onCancel}}
+        {{f.cancel cancelAction=(action @onCancel)}}
+      {{/if}}
+    </div>
+  </div>
+{{/ch-form}}

--- a/app/templates/components/ch-form.hbs
+++ b/app/templates/components/ch-form.hbs
@@ -1,58 +1,4 @@
-{{#if modalBox}}
-<div id="form-dialog" class="modal" tabindex="-1" role="dialog" data-backdrop="static">
-  <div class="modal-dialog  modal-lg" role="document">
-    <div class="modal-content">
-      <div class="modal-header">
-        <h5 class="modal-title">{{modalTitle}}</h5>
-      </div>
-      <div class="modal-body">
-        <form id="{{formId}}" class="{{formClass}}" method="post" autocomplete={{autocomplete}} {{action "submitForm" on="submit"}}>
-        {{yield (hash
-          model=model
-          input=(component "ch-form/field"
-            model=model
-            formId=formId
-            placeholder=placeholder
-            size=size
-            maxlength=maxlength
-            disabled=disabled
-            onChange=onChange
-            fieldChangeAction=(action "fieldChangeAction")
-            autofocus=autofocus
-            autocomplete=autocomplete
-            includeBlank=includeBlank
-            startDate=startDate
-            onFocus=onFocus
-            noSpaces=noSpaces
-          )
-          submit=(component "ch-form/submit"
-            label=label
-            submitClass=submitClass
-            formSubmitAction=(action "submitForm")
-            onSubmit=onSubmit
-            disabled=disabled
-          )
-          reset=(component "ch-form/reset-button"
-            label=label
-            class=resetClass
-            resetAction=(action "resetForm")
-            disabled=disabled
-          )
-          cancel=(component "ch-form/cancel"
-            label=label
-            cancelClass=cancelClass
-            cancelAction=(action "cancelForm")
-            disabled=disabled
-          )
-        ) }}
-        </form>
-      </div>
-    </div>
-  </div>
-</div>
-{{else}}
-<form id="{{formId}}" method="post" autocomplete={{autocomplete}} {{action "submitForm" on="submit"}} class={{formClass}}>
-{{yield (hash
+{{#let (hash
   model=model
   input=(component "ch-form/field"
     model=model
@@ -68,6 +14,7 @@
     includeBlank=includeBlank
     startDate=startDate
     onFocus=onFocus
+    noSpaces=noSpaces
   )
   submit=(component "ch-form/submit"
     label=label
@@ -82,13 +29,33 @@
     resetAction=(action "resetForm")
     disabled=disabled
   )
-
   cancel=(component "ch-form/cancel"
     label=label
     cancelClass=cancelClass
     cancelAction=(action "cancelForm")
     disabled=disabled
   )
-) }}
-</form>
-{{/if}}
+) as |controls|}}
+  {{#if formless}}
+    {{yield controls}}
+  {{else if modalBox}}
+    <div id="form-dialog" class="modal" tabindex="-1" role="dialog" data-backdrop="static">
+      <div class="modal-dialog  modal-lg" role="document">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title">{{modalTitle}}</h5>
+          </div>
+          <div class="modal-body">
+            <form id="{{formId}}" class="{{formClass}}" method="post" autocomplete={{autocomplete}} {{action "submitForm" on="submit"}}>
+              {{yield controls}}
+            </form>
+          </div>
+        </div>
+      </div>
+    </div>
+  {{else}}
+    <form id="{{formId}}" class="{{formClass}}" method="post" autocomplete={{autocomplete}} {{action "submitForm" on="submit"}}>
+      {{yield controls}}
+    </form>
+  {{/if}}
+{{/let}}

--- a/app/templates/components/ch-form/field.hbs
+++ b/app/templates/components/ch-form/field.hbs
@@ -1,6 +1,6 @@
 {{#if emitTopLabel}}
   {{#if label}}
-      <label class="{{labelClass}}" for="{{name}}">
+      <label class="{{labelClass}}" for="{{_domId}}">
         {{label}}{{#if required}} {{requiredLabel}}{{/if}}
       </label>
   {{/if}}

--- a/app/templates/error.hbs
+++ b/app/templates/error.hbs
@@ -19,6 +19,21 @@
         {{/each}}
       </dd>
     {{/if}}
+
+    {{#if error.isAdapterError}}
+      <dt>Description:</dt>
+      <dd>{{error.description}}</dd>
+
+      <dt>Filename / Line:</dt>
+      <dd>{{error.fileName}}:{{error.lineNumber}}</dd>
+
+      <dt>Name:</dt>
+      <dd>{{error.name}}</dd>
+
+      <dt>Number / Code:</dt>
+      <dd>{{error.number}} / {{error.code}}</dd>
+    {{/if}}
+
     <dt>Stack:</dt>
     <dd>
       <pre>{{error.stack}}</pre>

--- a/app/templates/person/bmid.hbs
+++ b/app/templates/person/bmid.hbs
@@ -1,0 +1,6 @@
+<div class="float-right">
+  {{#link-to "person.access-documents" person.id class="btn btn-secondary"}}Access Documents{{/link-to}}
+  {{#link-to "vc.bmid" class="btn btn-secondary"}}Manage BMIDs{{/link-to}}
+</div>
+<h3>{{year}} BMID</h3>
+{{bmid-edit entry=bmid modalBox=false year=year admissionDateOptions=admissionDateOptions onSave=(action save) }}

--- a/app/templates/person/index.hbs
+++ b/app/templates/person/index.hbs
@@ -223,7 +223,7 @@
     <div class="col-sm-12 col-md-9">
       {{#if (or canEditBMIT canEditAccessDocs)}}
         {{#if canEditBMIT}}
-          <a href="{{cgo "bmidc" "edit" personId=person.id}}" class="btn btn-secondary btn-sm mr-2">Edit BMID</a>
+          {{#link-to "person.bmid" class="btn btn-secondary btn-sm"}}Edit BMID{{/link-to}}
         {{/if}}
         {{#if canEditAccessDocs}}
           {{#link-to "person.tickets" class="btn btn-secondary btn-sm"}}Edit Tickets &amp; Stuff{{/link-to}}
@@ -270,7 +270,7 @@
     </div>
     {{#if (has-role "admin")}}
       <div class="col-sm-12 col-md-2 ml-auto">
-        <button type="button" class="btn btn-danger btn-sm" {{action "removePerson"}}>Remove</button>
+        <button type="button" class="btn btn-secondary btn-sm" {{action "removePerson"}}>Remove</button>
       </div>
     {{/if}}
   </div>

--- a/app/templates/training/session/index.hbs
+++ b/app/templates/training/session/index.hbs
@@ -86,7 +86,7 @@ Signups: {{students.length}} of {{slot.max}}
 
   <tbody>
     {{#each students as |student|}}
-      <tr class="{{if (or student.is_retired student.is_inactive) "bg-warning"}}">
+      <tr class="{{if (or student.is_retired student.is_inactive) "bg-highlight"}}">
         <td class="w-20">
           {{#if (or student.is_retired student.is_inactive)}}
             {{fa-icon "exclamation-triangle"}}

--- a/app/templates/vc/bmid-print.hbs
+++ b/app/templates/vc/bmid-print.hbs
@@ -1,0 +1,122 @@
+<main class="col">
+  {{year-select "Submit BMIDs To Lambase" year=year onChange=(action (mut year))}}
+
+  <div class="form-group row">
+    <div class="col-auto">
+      <label>Filter:</label>
+      {{ch-form/select
+        name="filter"
+        value=this.filter
+        options=this.filterOptions
+        onChange=(action (mut this.filter))
+        controlClass="form-control-sm"
+        disabled=this.isRendering
+      }}
+    </div>
+    <div class="col-auto ml-4">
+      {{#link-to "vc.bmid" class="btn btn-secondary btn-sm"}}Manage BMIDs{{/link-to}}
+    </div>
+</div>
+
+  <p>
+    <span class="d-inline">
+      Total BMIDs: {{totalBmids}}
+    </span>
+    <span class="d-inline {{if doNotPrint "text-danger"}}">
+      Do Not Print: {{doNotPrint.length}}
+    </span>
+    <span class="d-inline {{if issues "text-danger"}}">
+      Issues: {{issues.length}}
+    </span>
+    <span class="d-inline {{if unusualStatus "text-danger"}}">
+      Unusual Person Status: {{unusualStatus.length}}
+    </span>
+    <span class="d-inline">
+      Printed: {{printed.length}}
+    </span>
+    <span class="d-inline">
+      Submitted: {{submitted.length}}
+    </span>
+  </p>
+
+  {{#if doNotPrint}}
+    <div class="border p-2">
+      Do Not Print:
+      {{#each doNotPrint as |bmid idx|~}}
+        {{~if idx ","}}{{person-link person=bmid.person~}}
+      {{/each}}
+    </div>
+  {{/if}}
+
+  {{#if issues}}
+  <div class="border p-2">
+      Issues:
+      {{#each issues as |bmid idx|~}}
+        {{~if idx ","}}{{person-link person=bmid.person~}}
+      {{/each}}
+</div>
+  {{/if}}
+
+  {{#if unusualStatus}}
+  <div class="border p-2">
+      Unusual Status:
+      {{#each unusualStatus as |bmid idx|~}}
+        {{~if idx ","}}<span class="d-inline-block">{{person-link person=bmid.person~}} ({{bmid.person.status}})</span>
+      {{/each}}
+    </div>
+  {{/if}}
+
+  Showing {{pluralize bmids.length "BMID"}} / {{bmidsSelectedCount}} selected.
+  <table class="table table-sm table-striped">
+    <thead>
+      <tr>
+        <th>{{fa-icon "check"}}</th>
+        <th>Status</th>
+        <th>Callsign</th>
+        <th>First Name</th>
+        <th>Last Name</th>
+        <th>Title 1</th>
+        <th>Title 2</th>
+        <th>Title 3</th>
+        <th>MVR</th>
+        <th>Showers</th>
+        <th>Meals</th>
+      </tr>
+    </thead>
+
+    <tbody>
+      {{#each bmids as |bmid|}}
+        <tr class="{{if (eq bmid.status "failed") "bg-danger"}}">
+          <td>{{input type="checkbox" checked=bmid.selected}}</td>
+          <td>{{bmid.statusHuman}}</td>
+          <td>{{bmid.person.callsign}}</td>
+          <td>{{bmid.person.first_name}}</td>
+          <td>{{bmid.person.last_name}}</td>
+          <td>{{present-or-not bmid.title1 "-"}}</td>
+          <td>{{present-or-not bmid.title2 "-"}}</td>
+          <td>{{present-or-not bmid.title3 "-"}}</td>
+          <td>{{yesno bmid.org_vehicle_insurance}}</td>
+          <td>{{yesno bmid.showers}}</td>
+          <td>{{bmid.mealsHuman}}</td>
+        </tr>
+      {{/each}}
+    </tbody>
+  </table>
+
+  <h3>Submit Selected BMIDs To Lambase</h3>
+
+  {{#ch-form "batch" batchForm onSubmit=(action sendToLambase) as |f|}}
+    <div class="form-row">
+      {{f.input "batchInfo" label="Batch Information" size=32 maxlength=32 grid="col-auto"
+        hint="Example batch info might be 'Batch #1, specials' or 'Batch #2, special stragglers', or 'Batch #3, alphas', etc. The Clubhouse will automatically add
+your name and the date and time you submitted to Lambase."
+      }}
+    </div>
+    <div class="form-group row">
+      <div class="col-auto">
+        You will be asked to confirm the operation after clicking below.
+      </div>
+    </div>
+    {{f.submit label="Send To Lambase" disabled=(or isSubmitting (not bmidsSelectedCount))}}
+  {{/ch-form}}
+</main>

--- a/app/templates/vc/bmid-sanity-check.hbs
+++ b/app/templates/vc/bmid-sanity-check.hbs
@@ -1,0 +1,64 @@
+<main class="col">
+  <div class="float-right">
+      {{#link-to "vc.bmid-print" class="btn btn-secondary"}}Print via Lambase{{/link-to}}
+      {{#link-to "vc.bmid" class="btn btn-secondary"}}Manage BMIDs{{/link-to}}
+  </div>
+  {{year-select "Sanity Check BMIDs" year=year onChange=(action (mut year))}}
+
+  {{#each bmidMadHouse as |asylum|}}
+    <h3>
+    </h3>
+
+    <table class="table table-striped table-sm">
+      <caption>
+        {{#if (eq asylum.type "shifts-before-access-date")}}
+          Signed Up For Shifts Earlier Than WAP Access Date
+        {{else if (eq asylum.type "shifts-no-wap")}}
+          Signed Up For Pre-Event Shifts But No WAP
+        {{else if (eq asylum.type "rpt-before-box-office")}}
+          Reduced Price Ticket Access Before Box Office Open {{mdy-format asylum.box_office}}
+        {{else}}
+          Unknown insanity type ({{asylum.type}})
+        {{/if}} ({{asylum.people.length}})
+      </caption>
+
+      <thead>
+        <tr>
+          <th class="w-15">Callsign</th>
+          <th class="w-10">Name</th>
+          <th class="w-10">Status</th>
+          <th class="w-20">Email</th>
+          <th class="w-20">Action</th>
+        </tr>
+      </thead>
+
+      <tbody>
+        {{#each asylum.people as |person|}}
+          <tr>
+            <td class="w-15">
+              {{person-link person=person}}
+            </td>
+            <td class="w-10">
+              {{person.first_name}} {{person.last_name}}
+            </td>
+            <td class="w-10">
+              {{person.status}}
+            </td>
+            <td class="w-20">
+              {{mail-to person.email}}
+            </td>
+            <td class="w-20">
+              {{#link-to "person.index" person.id class="btn btn-primary btn-sm"}}View{{/link-to}}
+              {{#link-to "person.schedule" person.id class="btn btn-primary btn-sm"}}Schedule{{/link-to}}
+              {{#link-to "person.access-documents" person.id class="btn btn-primary btn-sm"}}Access Docs{{/link-to}}
+            </td>
+          </tr>
+        {{else}}
+          <tr>
+            <td colspan="5" class="text-success">Congratulations! Nobody was found with this diagnosis.</td>
+          </tr>
+        {{/each}}
+      </tbody>
+    </table>
+  {{/each}}
+</main>

--- a/app/templates/vc/bmid.hbs
+++ b/app/templates/vc/bmid.hbs
@@ -1,0 +1,207 @@
+<main class="col">
+  {{year-select "Manage BMIDs" year=year onChange=(action (mut year))}}
+
+  <div class="form-group row">
+    <div class="col-auto">
+      <label>Filter:</label>
+      {{ch-form/select
+          name="filter"
+          value=this.filter
+          options=this.filterOptions
+          onChange=(action (mut this.filter))
+          controlClass="form-control-sm"
+          disabled=this.isRendering
+        }}
+    </div>
+    <div class="col-auto">
+      <label>Title Filter:</label>
+      {{ch-form/select
+          name="titleFilter"
+          value=this.titleFilter
+          options=this.titleFilterOptions
+          onChange=(action (mut this.titleFilter))
+          controlClass="form-control-sm"
+          disabled=this.isRendering
+          }}
+    </div>
+    <div class="col-auto">
+      <label>Team Filter:</label>
+      {{ch-form/select
+          name="teamFilter"
+          value=this.teamFilter
+          options=this.teamFilterOptions
+          onChange=(action (mut this.teamFilter))
+          controlClass="form-control-sm"
+          disabled=this.isRendering
+          }}
+
+    </div>
+  </div>
+  <div class="form-group row">
+    <div class="col-auto">
+      <div class="input-group">
+        <label>Callsign, title, team, notes filter:</label>
+        {{input type="text" value=this.textFilterInput class="form-control-sm ml-2" enter=(action textFilterAction) disabled=this.isRendering}}
+        <button class="btn btn-primary btn-sm ml-1" {{action textFilterAction}} disabled={{this.isRendering}}>Filter</button>
+        <button class="btn btn-secondary btn-sm ml-1" {{action clearTextFilterAction}} disabled={{this.isRendering}}>Clear</button>
+      </div>
+      {{#if textFilterError}}
+        <div class="text-danger">{{this.textFilterError}}</div>
+      {{/if}}
+      <div class="text-muted small">Regular Expression allowed</div>
+    </div>
+
+    <div class="col-auto">
+      <button class="btn btn-secondary btn-sm" disabled={{this.isRendering}} {{action toggleEditMode}}>{{#if editMode}}Table View{{else}}Edit Mode{{/if}}</button>
+      <button class="btn btn-secondary btn-sm" disabled={{this.isRendering}} {{action exportCSV}}>Export CSV</button>
+      {{#link-to "vc.bmid-sanity-check" class="btn btn-secondary btn-sm" disabled=this.isRendering}}Sanity Check{{/link-to}}
+      {{#link-to "vc.bmid-print" class="btn btn-secondary btn-sm" disabled=this.isRendering}}Print via Lambase{{/link-to}}
+    </div>
+  </div>
+
+  {{#if this.isRendering}}
+    <div class="text-danger h3 font-weight-bold">Hang Tight - Rendering {{this.renderBmids.length}} of {{this.viewBmids.length}} {{fa-icon "spinner" spin=true}}</div>
+  {{else}}
+    Showing {{this.viewBmids.length}} of {{this.bmids.length}}
+    {{#if textFilter}}
+      <span class="ml-2 font-weight-bold">Text filtering by "{{this.textFilter}}"</span>
+    {{/if}}
+  {{/if}}
+  {{#if unsaveRows}}<span class="ml-4 text-danger">UNSAVED {{pluralize unsaveRows "record"}}</span>{{/if}}
+  <table class="table table-sm table-striped table-hover">
+    <thead>
+      <tr>
+        <th>{{#if (eq sortColumn "callsign")}}[Callsign]{{else}}<a href {{action sortBmidsAction "callsign"}}>Callsign</a>{{/if}}</th>
+        {{#unless this.editMode}}
+          <th>Action</th>
+        {{/unless}}
+        <th>{{#if (eq sortColumn "status")}}[Status]{{else}}<a href {{action sortBmidsAction "status"}}>Status</a>{{/if}}</th>
+        <th class="w-10">{{#if (eq sortColumn "title1")}}[Title 1]{{else}}<a href {{action sortBmidsAction "title1"}}>Title 1</a>{{/if}}</th>
+        <th class="w-10">{{#if (eq sortColumn "title2")}}[Title 2]{{else}}<a href {{action sortBmidsAction "title2"}}>Title 2</a>{{/if}}</th>
+        <th class="w-10">{{#if (eq sortColumn "title3")}}[Title 3]{{else}}<a href {{action sortBmidsAction "title3"}}>Title 3</a>{{/if}}</th>
+        <th>{{#if (eq sortColumn "mvr")}}[MVR]{{else}}<a href {{action sortBmidsAction "mvr"}}>MVR</a>{{/if}}</th>
+        <th>{{#if (eq sortColumn "showers")}}[Showers]{{else}}<a href {{action sortBmidsAction "showers"}}>Showers</a>{{/if}}</th>
+        <th>{{#if (eq sortColumn "meals")}}[Meals]{{else}}<a href {{action sortBmidsAction "meals"}}>Meals</a>{{/if}}</th>
+        <th class="w-10">{{#if (eq sortColumn "wap")}}[WAP]{{else}}<a href {{action sortBmidsAction "wap"}}>WAP</a>{{/if}}</th>
+        <th>{{#if (eq sortColumn "team")}}[Team]{{else}}<a href {{action sortBmidsAction "team"}}>Team</a>{{/if}}</th>
+        <th class="w-30">{{#if (eq sortColumn "notes")}}[Notes]{{else}}<a href {{action sortBmidsAction "notes"}}>Notes</a>{{/if}}</th>
+        {{#if this.editMode}}
+          <th>Action</th>
+        {{/if}}
+      </tr>
+    </thead>
+
+    <tbody>
+      {{#if this.viewBmids}}
+        {{#if this.editMode}}
+          {{#each this.editableBmids as |bmid|}}
+            <tr class="{{if bmid.isDirty "bg-warning"}}">
+              <td>
+                {{#if bmid.person}}
+                  {{person-link person=bmid.person}}
+                {{else}}
+                  Deleted #{{bmid.person_id}}
+                {{/if}}
+              </td>
+              <td>
+                {{ch-form/select name=(concat "status" bmid.person.id) value=bmid.status options=bmidStatusOptions
+                      onChange=(action (mut bmid.status))
+                      controlClass="form-control-sm"
+                    }}
+              </td>
+              {{!
+                  Performance optimization here - using ch-form to manage over 1,000+ rows is too much for
+                  the browser.
+
+                  bmid.* is not updated until after the record is successfully saved. Using the object
+                  for the intial control values will help prevent rendering.
+
+                  editBmid is the changeset object which the data is manipulated in.
+                }}
+              <td><input value={{bmid.title1}} onblur={{action updateColumn bmid "title1"}} size="30"></td>
+              <td><input value={{bmid.title2}} onblur={{action updateColumn bmid "title2"}} size="30"></td>
+              <td><input value={{bmid.title3}} onblur={{action updateColumn bmid "title3"}} size="30"></td>
+              <td>{{yesno bmid.org_vehicle_insurance}}</td>
+              <td>
+                {{ch-form/select name=(concat "showers" bmid.person.id) value=bmid.showers options=showerOptions
+                      onChange=(action (mut bmid.showers))
+                      controlClass="form-control-sm"
+                      }}
+              </td>
+              <td>
+                {{ch-form/select name=(concat "meals" bmid.person.id) value=bmid.meals options=mealOptions
+                      onChange=(action (mut bmid.meals))
+                      controlClass="form-control-sm"
+                  }}
+              </td>
+              <td>
+                {{ch-form/select name=(concat "admission_date" bmid.person.id) value=bmid.admission_date options=admissionDateOptions
+                      onChange=(action (mut bmid.admission_date))
+                      controlClass="form-control-sm"
+                      disabled=bmid.wapDisabled
+                      }}
+                {{#if bmid.wapDisabled}}
+                  {{#if bmid.wapMissing}}
+                    <strong class="text-danger">WAP misssing</strong>
+                  {{else}}
+                    <strong class="text-danger">WAP submitted</strong>
+                  {{/if}}
+                {{/if}}
+              </td>
+              <td><input value={{bmid.team}} onblur={{action updateColumn bmid "team"}} size="10"></td>
+              <td><textarea cols="40" rows="1" onfocus={{action focusNote}} onblur={{action blurNote bmid}}>{{bmid.notes}}</textarea></td>
+              <td><button type="button" {{action saveInlineBmid bmid}}>Save</button></td>
+            </tr>
+          {{/each}}
+        {{else}}
+          {{#each this.renderBmids as |bmid|}}
+            <tr>
+              <td>
+                {{#if bmid.person}}
+                  {{person-link person=bmid.person}}
+                {{else}}
+                  Deleted #{{bmid.person_id}}
+                {{/if}}
+              </td>
+              <td><a href {{action editBmid bmid}}>Edit</a></td>
+              <td>{{bmid.statusHuman}}</td>
+              <td class="w-10">{{present-or-not bmid.title1 "-"}}</td>
+              <td class="w-10">{{present-or-not bmid.title2 "-"}}</td>
+              <td class="w-10">{{present-or-not bmid.title3 "-"}}</td>
+              <td>{{yesno bmid.org_vehicle_insurance}}</td>
+              <td>{{yesno bmid.showers}}</td>
+              <td>{{bmid.mealsHuman}}</td>
+              <td class="w-10">
+                {{#if bmid.wapMissing}}
+                  <strong class="text-danger">missing</strong>
+                {{else if bmid.admission_date}}
+                  {{bmid.admission_date}}
+                {{else}}
+                  (no date)
+                {{/if}}
+              </td>
+              <td>{{bmid.team}}</td>
+              <td class="w-30">{{nl2br bmid.notes}}</td>
+            </tr>
+          {{/each}}
+        {{/if}}
+      {{else}}
+        <tr>
+          <td colspan="12">
+            <strong class="text-danger">
+              {{#if this.bmids}}
+                No BMIDs match the filter criteria.
+              {{else}}
+                No BMIDs were found for {{year}}.
+              {{/if}}
+            </strong>
+          </td>
+        </tr>
+      {{/if}}
+    </tbody>
+  </table>
+</main>
+
+{{#if this.entry}}
+  {{bmid-edit entry=this.entry year=this.year admissionDateOptions=admissionDateOptions onSave=(action saveBmid) onCancel=(action cancelBmid)}}
+{{/if}}

--- a/app/utils/admission-date-options.js
+++ b/app/utils/admission-date-options.js
@@ -1,0 +1,20 @@
+import moment from 'moment';
+
+export default function admissionDateOptions(year, wapDateRange) {
+  const options = [
+    [ 'Unspecified', '']
+  ];
+
+  let low = 5, high = 26;
+  if (wapDateRange != null) {
+    [low, high] = wapDateRange.split('-');
+  }
+
+  for (let day = high; day >= low; day--) {
+    const date = `${year}-08-${day < 10 ? '0'+day : day}`;
+    options.push([moment(date).format('ddd, MM/DD/YY'), date]);
+  }
+
+  options.push(['Any', 'any']);
+  return options;
+}

--- a/tests/integration/components/bmid-edit-test.js
+++ b/tests/integration/components/bmid-edit-test.js
@@ -1,0 +1,26 @@
+import { module, skip } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | bmid-edit', function(hooks) {
+  setupRenderingTest(hooks);
+
+  skip('it renders', async function(assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.set('myAction', function(val) { ... });
+
+    await render(hbs`{{bmid-edit}}`);
+
+    assert.equal(this.element.textContent.trim(), '');
+
+    // Template block usage:
+    await render(hbs`
+      {{#bmid-edit}}
+        template block text
+      {{/bmid-edit}}
+    `);
+
+    assert.equal(this.element.textContent.trim(), 'template block text');
+  });
+});

--- a/tests/unit/controllers/person/bmid-test.js
+++ b/tests/unit/controllers/person/bmid-test.js
@@ -1,0 +1,12 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Controller | person/bmid', function(hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function(assert) {
+    let controller = this.owner.lookup('controller:person/bmid');
+    assert.ok(controller);
+  });
+});

--- a/tests/unit/controllers/vc/bmid-print-test.js
+++ b/tests/unit/controllers/vc/bmid-print-test.js
@@ -1,0 +1,12 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Controller | vc/bmid-print', function(hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function(assert) {
+    let controller = this.owner.lookup('controller:vc/bmid-print');
+    assert.ok(controller);
+  });
+});

--- a/tests/unit/controllers/vc/bmid-test.js
+++ b/tests/unit/controllers/vc/bmid-test.js
@@ -1,0 +1,12 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Controller | vc/bmid', function(hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function(assert) {
+    let controller = this.owner.lookup('controller:vc/bmid');
+    assert.ok(controller);
+  });
+});

--- a/tests/unit/models/bmid-test.js
+++ b/tests/unit/models/bmid-test.js
@@ -1,0 +1,13 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Model | bmid', function(hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function(assert) {
+    let store = this.owner.lookup('service:store');
+    let model = store.createRecord('bmid', {});
+    assert.ok(model);
+  });
+});

--- a/tests/unit/routes/person/bmid-test.js
+++ b/tests/unit/routes/person/bmid-test.js
@@ -1,0 +1,11 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Route | person/bmid', function(hooks) {
+  setupTest(hooks);
+
+  test('it exists', function(assert) {
+    let route = this.owner.lookup('route:person/bmid');
+    assert.ok(route);
+  });
+});

--- a/tests/unit/routes/vc/bmid-print-test.js
+++ b/tests/unit/routes/vc/bmid-print-test.js
@@ -1,0 +1,11 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Route | vc/bmid-print', function(hooks) {
+  setupTest(hooks);
+
+  test('it exists', function(assert) {
+    let route = this.owner.lookup('route:vc/bmid-print');
+    assert.ok(route);
+  });
+});

--- a/tests/unit/routes/vc/bmid-sanity-check-test.js
+++ b/tests/unit/routes/vc/bmid-sanity-check-test.js
@@ -1,0 +1,11 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Route | vc/bmid-sanity-check', function(hooks) {
+  setupTest(hooks);
+
+  test('it exists', function(assert) {
+    let route = this.owner.lookup('route:vc/bmid-sanity-check');
+    assert.ok(route);
+  });
+});

--- a/tests/unit/routes/vc/bmid-test.js
+++ b/tests/unit/routes/vc/bmid-test.js
@@ -1,0 +1,11 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Route | vc/bmid', function(hooks) {
+  setupTest(hooks);
+
+  test('it exists', function(assert) {
+    let route = this.owner.lookup('route:vc/bmid');
+    assert.ok(route);
+  });
+});

--- a/tests/unit/utils/admission-date-options-test.js
+++ b/tests/unit/utils/admission-date-options-test.js
@@ -1,0 +1,23 @@
+import admissionDateOptions from 'clubhouse/utils/admission-date-options';
+import { module, test } from 'qunit';
+
+module('Unit | Utility | admission-date-options', function() {
+
+  // Replace this with your real tests.
+  test('it works', function(assert) {
+    let result = admissionDateOptions(2019, "20-25");
+
+    const match = [
+      [ 'Unspecified', '' ],
+      [ 'Sun, 08/25/19', '2019-08-25' ],
+      [ 'Sat, 08/24/19', '2019-08-24' ],
+      [ 'Fri, 08/23/19', '2019-08-23' ],
+      [ 'Thu, 08/22/19', '2019-08-22' ],
+      [ 'Wed, 08/21/19', '2019-08-21' ],
+      [ 'Tue, 08/20/19', '2019-08-20' ],
+      [ 'Any', 'any' ],
+    ];
+
+    assert.deepEqual(match, result);
+  });
+});


### PR DESCRIPTION
- fa-icon has a 'spinner' boolean argument for rotation animation
- ch-form label was not using the form id to generate the "for=" property.
- Reload the user's login info when editing self under the person page.
- CSV export properly quotes things now
- "Staging Server" (in red) is shown instead of Clubhouse in the top left when running on the staging server.
- Change the person "remove" to be the secondary color instead of red BECAUSE IT FREAKED USERS OUT!
- New "highlight" theme CSS color (text-highlight, bg-highlight, etc.) used by the training pages.