### PR TITLE
Freaking years report tweaks. Schedule display adjustments.

### DIFF
--- a/app/components/modal-multiple-enrollment.js
+++ b/app/components/modal-multiple-enrollment.js
@@ -2,6 +2,7 @@ import Component from '@ember/component';
 import { argument } from '@ember-decorators/argument';
 import { optional } from '@ember-decorators/argument/types';
 import { alias } from '@ember-decorators/object/computed';
+import { computed } from '@ember-decorators/object';
 
 export default class ModalMultipleEnrollmentComponent extends Component {
   @argument(optional('object')) dialog;
@@ -9,4 +10,16 @@ export default class ModalMultipleEnrollmentComponent extends Component {
   @argument(optional('object')) onConfirm;
 
   @alias('dialog.data') data;
+
+  @alias('data.slots.firstObject.position.title') trainingType;
+
+  @computed('data.person')
+  get isMe() {
+    return this.session.user.id == this.data.person.id;
+  }
+
+  @computed('data.slots.firstObject')
+  get isAlpha() {
+    return this.data.slots.firstObject.position.title == 'Alpha';
+  }
 }

--- a/app/components/schedule-manage.js
+++ b/app/components/schedule-manage.js
@@ -221,8 +221,7 @@ export default class ScheduleManageComponent extends Component {
           {
             title: 'Multiple Enrollments Not Allowed',
             slots: result.slots,
-            isMe: (this.person.id == this.session.user.id ),
-            isAlpha: (result.slots[0].position.title == 'Alpha')
+            person: this.person,
           } );
         break;
 
@@ -233,13 +232,9 @@ export default class ScheduleManageComponent extends Component {
   }
 
   joinSlotRequest(slot) {
-    const personId = this.person.id;
-    const slotId = slot.id;
-    const isMe = (personId == this.session.user.id);
-
-    this.ajax.request(`person/${personId}/schedule`, {
+    this.ajax.request(`person/${this.person.id}/schedule`, {
       method: 'POST',
-      data: { slot_id: slotId }
+      data: { slot_id: slot.id }
     }).then((result) => {
         if (result.status == 'success') {
           slot.set('person_assigned', true);
@@ -253,7 +248,7 @@ export default class ScheduleManageComponent extends Component {
               {
                 title: 'Sign Up Forced - Other Enrollments Found',
                 slots: result.slots,
-                isMe,
+                person: this.person,
                 forced: true,
               });
           } else {
@@ -293,10 +288,7 @@ export default class ScheduleManageComponent extends Component {
     this.modal.confirm('Confirm Leaving Shift',
       `Are you sure you want to leave the shift "${slot.slot_description}"?`,
       () => {
-        const personId = this.person.id;
-        const slotId = slot.id;
-
-        this.ajax.request(`person/${personId}/schedule/${slotId}`, {
+        this.ajax.request(`person/${this.person.id}/schedule/${slot.id}`, {
           method: 'DELETE',
         }).then((result) => {
           slot.set('person_assigned', false);

--- a/app/components/schedule-table.js
+++ b/app/components/schedule-table.js
@@ -70,6 +70,11 @@ export default class ScheduleTableComponent extends Component {
     return this.slots.reduce(function(total, slot) { return (slot.is_overlapping ? 1 : 0)+total;}, 0);
   }
 
+  @computed('slots')
+  get trainingOverlap() {
+    return this.slots.reduce(function(total, slot) { return (slot.is_training_overlap ? 1 : 0)+total;}, 0);
+  }
+
   @action
   changeView(value) {
     this.set('viewSchedule', value);

--- a/app/components/ticket-threshold.js
+++ b/app/components/ticket-threshold.js
@@ -2,7 +2,9 @@ import Component from '@ember/component';
 import { computed } from '@ember-decorators/object';
 import { argument } from '@ember-decorators/argument';
 import { config } from 'clubhouse/utils/config';
+import { tagName } from '@ember-decorators/component';
 
+@tagName('')
 export default class TicketThresholdComponent extends Component {
   @argument('number') credits;
   @argument('number') creditsEarned;

--- a/app/controllers/reports/freaking-years.js
+++ b/app/controllers/reports/freaking-years.js
@@ -7,27 +7,43 @@ export default class ReportsFreakingYearsController extends Controller {
   showAll = 0;
 
   @action
-  exportToCsv(group) {
+  exportToCsv() {
     const CSV_COLUMNS = [
       { title: 'Callsign', key: 'callsign' },
-      { title: 'Name', key: 'name' },
-      { title: 'Years Rangered', key: 'years' },
+      { title: 'Last Name', key: 'last_name' },
+      { title: 'First Name', key: 'first_name' },
+      { title: 'Years', key: 'years' },
       { title: 'First Year', key: 'first_year' },
       { title: 'Last Year', key: 'last_year' },
       { title: `Signed Up In ${this.signed_up_year}`, key: 'signed_up' }
     ];
 
-    const data = group.people.map((row) => {
-      return {
-          callsign: row.callsign,
-          name: `${row.first_name} ${row.last_name}`,
-          years: row.years,
-          first_year: row.first_year,
-          last_year: row.last_year,
-          signed_up: row.signed_up ? 'Y' : 'N'
+    const people = [];
+
+    this.freaking.forEach((freaks) => {
+      freaks.people.forEach((row) => {
+        people.push({
+            callsign: row.callsign,
+            first_name: row.first_name,
+            last_name: row.last_name,
+            years: row.years,
+            first_year: row.first_year,
+            last_year: row.last_year,
+            signed_up: row.signed_up ? 'Y' : 'N'
+        });
+      })
+    })
+
+    people.sort((a,b) => {
+      const lastCmp = a.last_name.localeCompare(b.last_name);
+
+      if (lastCmp == 0) {
+        return a.first_name.localeCompare(b.first_name);
+      } else {
+        return lastCmp;
       }
     });
 
-    this.house.downloadCsv(`${this.signed_up_year}-freaking-${group.years}-years.csv`, CSV_COLUMNS, data);
+    this.house.downloadCsv(`${this.signed_up_year}-freaking-years.csv`, CSV_COLUMNS, people);
   }
 }

--- a/app/controllers/training/session/index.js
+++ b/app/controllers/training/session/index.js
@@ -193,8 +193,7 @@ export default class TrainingSlotController extends Controller {
     case 'multiple-enrollment':
       modal.open('modal-multiple-enrollment', 'Multiple Enrollments Not Allowed', {
         slots: result.slots,
-        isMe: (person.id == this.session.user.id),
-        isAlpha: (result.slots[0].position.title == 'Alpha')
+        person,
       });
       break;
 
@@ -231,7 +230,6 @@ export default class TrainingSlotController extends Controller {
         } else if (result.multiple_forced) {
           this.modal.open('modal-multiple-enrollment', 'Sign Up Forced - Other Enrollments Found', {
             slots: result.slots,
-            isMe: (person.id == this.session.user.id),
             forced: true,
           });
         } else {

--- a/app/models/schedule.js
+++ b/app/models/schedule.js
@@ -81,4 +81,9 @@ export default class ScheduleModel extends DS.Model {
 
     return false;
   }
+
+  @computed('position_type')
+  get isTraining() {
+    return (this.position_type == 'Training');
+  }
 }

--- a/app/styles/schedule.scss
+++ b/app/styles/schedule.scss
@@ -42,9 +42,13 @@
   background-color: $table-hover-bg;
 }
 
+.schedule-total {
+  font-size: 0.9rem;
+}
+
 @media print {
   .schedule-table {
-    font-size: 1em;
+    font-size: 1rem;
   }
 }
 

--- a/app/templates/components/ch-box.hbs
+++ b/app/templates/components/ch-box.hbs
@@ -1,5 +1,5 @@
 {{#if title}}
-  <div class="card-header {{if type (concat "bg-" type)}}">{{if icon (fa-icon icon size="lg")}} {{title}}</div>
+  <div class="card-header {{if type (concat "bg-" type)}}{{if (eq type "danger") " text-white"}}">{{if icon (fa-icon icon size="lg")}} {{title}}</div>
 {{/if}}
 {{#if noBody}}
   {{yield}}

--- a/app/templates/components/modal-multiple-enrollment.hbs
+++ b/app/templates/components/modal-multiple-enrollment.hbs
@@ -1,7 +1,7 @@
 {{#modal-dialog title=data.title onClose=onClose}}
   <p>
-    {{#if data.isMe}}You are{{else}}The person is{{/if}} already
-    enrolled in {{pluralize data.slots.length (if data.isAlpha "Alpha shift" "training session") }}:
+    {{#if isMe}}You are{{else}}The person is{{/if}} already
+    enrolled in {{pluralize data.slots.length (if data.isAlpha "Alpha shift" (concat trainingType " session")) }}:
   </p>
   <p>
     {{#each data.slots as |slot|}}
@@ -11,14 +11,21 @@
   <p>
     {{#if data.forced}}
       Because you either have the Admin, Trainer, VC or Mentor role,
-      {{if data.isMe "you have" "the person has"}}
+      {{if isMe "you have" "the person has"}}
       been added to the
-      {{#if data.isAlpha}}Alpha shift{{else}}training sessions{{/if}}.
+      {{#if data.isAlpha}}Alpha shift{{else}}{{trainingType}} session{{/if}}.
       Hope you know what you are doing!
     {{else}}
-      You may only sign up for one {{#if data.isAlpha}}Alpha shift{{else}}training session{{/if}}.
+      {{if isMe "You" "The person"}} may only sign up for one {{#if data.isAlpha}}Alpha shift{{else}}{{trainingType}} session{{/if}}.
       Multiple enrollments are not allowed.
       Contact {{mail-to (config "VCEmail")}} for help.
     {{/if}}
   </p>
+
+  {{#if (and data.person.isRanger (not data.forced))}}
+    <p>
+      {{if isMe "You are" "This person is"}} allowed to sign up for a Training session and different ART Training sessions.
+      For example, you may sign up for one Training session, one ART Green Dot session (if qualified), and one ART Sandman session (if qualified).
+    </p>
+  {{/if}}
 {{/modal-dialog}}

--- a/app/templates/components/schedule-table.hbs
+++ b/app/templates/components/schedule-table.hbs
@@ -8,6 +8,16 @@
   </div>
 </div>
 
+{{#if overlapping}}
+  <p>
+    <span class="text-danger">You are signed up for overlapping shifts, marked with a
+      {{fa-icon "exclamation-triangle"}}.</span>
+    This might be an error, and you
+    didn't mean to be in two places at once. It might be just fine and you plan to work two shifts back-to-back.
+    You only get credit for the time you work, and won't receive double credit for the overlapping time.
+  </p>
+{{/if}}
+
 <div class="schedule-table schedule-itinerary">
   <div class="schedule-row schedule-header">
     <div class="schedule-time">From</div>
@@ -22,7 +32,9 @@
     {{#each viewSlots as |slot| }}
       <div class="schedule-row {{if slot.is_overlapping "schedule-overlapping"}}">
         <div class="schedule-time">
-          {{#if slot.is_overlapping}}{{fa-icon "exclamation-triangle"}}{{/if}}
+          {{#if slot.is_overlapping}}
+            <span class="text-danger">{{fa-icon "exclamation-triangle"}}</span>
+          {{/if}}
           {{shift-format slot.slot_begins}}
         </div>
         <div class="schedule-time">{{shift-format slot.slot_ends}}</div>
@@ -50,9 +62,9 @@
   {{/if}}
   <div class="schedule-row">
     <div class="schedule-total mt-1">
-      <b>Total Time:</b> {{hour-minute-format (sum-column slots "slot_duration")}}
-      <b>Scheduled Credits:</b> {{credits-format creditsTotal}}
-      <b>Earned Credits:</b> {{credits-format creditsEarned}}
+      <span class="mr-2 d-inline-block"><b>Total Schedule Time:</b> {{hour-minute-format (sum-column slots "slot_duration")}}</span>
+      <span class="mr-2 d-inline-block"><b>Scheduled Credits:</b> {{credits-format creditsTotal}}</span>
+      <span class="d-inline-block"><b>Earned Credits:</b> {{credits-format creditsEarned}}</span>
     </div>
     <div class="schedule-actions d-print-none">
       {{#link-to "me.schedule.print" class="btn btn-sm btn-secondary"}}Print{{/link-to}}
@@ -60,13 +72,6 @@
   </div>
 </div>
 
-{{#if overlapping}}
-  <p><span class="text-danger">You are signed up for overlapping shifts</span>, marked with a {{fa-icon "exclamation-triangle"}}.
-    This might be an error, and you
-    didn't mean to be in two places at once. It might be just fine and you plan to work two shifts back-to-back.
-    You only get credit for the time you work, and won"t receive double credit for the overlapping time.</p>
-{{/if}}
-
-{{#if person.isRanger}}
+{{#if (and person.isRanger isCurrentYear)}}
   {{ticket-threshold year=year credits=creditsTotal creditsEarned=creditsEarned}}
 {{/if}}

--- a/app/templates/components/ticket-threshold.hbs
+++ b/app/templates/components/ticket-threshold.hbs
@@ -4,53 +4,54 @@
   for a reduced-price ticket and {{credits-format scThreshold}} credits for a staff credential.
 </p>
 
-{{#if reachedSCThreshold}}
- <p>
- <strong>Congratulations!</strong> You're signed up for {{credits-format credits}} credits
- worth of shifts, which is above the {{credits-format scThreshold}} credits required
- to qualify for a {{ticketYear}} free staff credential.
- {{#if withinSCThreshold}}
-    But since you are close to the threshold, you may want to sign up for
-    one more shift. (See fine print below.)
- {{/if}}
-</p>
-{{else if almostSCThreshold}}
-<p>
-  <strong class="text-danger">Almost there!</strong> You're signed up for
-  {{credits-format credits}} credits worth of shifts, and you need
-  {{credits-format scThreshold}} to qualify for a {{ticketYear}} Staff Credential ticket.
-</p>
-{{else if reachedRPThreshold}}
-<p>
-  <br><strong>Congratulations!</strong> You're signed up for {{credits-format credits}} credits worth of shifts,
-  which is above the {{credits-format rpThreshold}} credits required to qualify for a reduced-price ticket in {{ticketYear}}.
-  You need only {{credits-format scDelta}} credits more to qualify for a staff credential.
-  {{#if withinRPThreshold}}
-    Since you are close to the threshold, you may want to sign up for one more shift.
-    (See fine print below.)
+  {{#if reachedSCThreshold}}
+    <p>
+      <strong>Congratulations!</strong> You're signed up for {{credits-format credits}} credits
+      worth of shifts, which is above the {{credits-format scThreshold}} credits required
+      to qualify for a {{ticketYear}} free staff credential.
+      {{#if withinSCThreshold}}
+        But since you are close to the threshold, you may want to sign up for
+        one more shift. (See fine print below.)
+      {{/if}}
+    </p>
+  {{else if almostSCThreshold}}
+    <p>
+      <strong class="text-danger">Almost there!</strong> You're signed up for
+      {{credits-format credits}} credits worth of shifts, and you need
+      {{credits-format scThreshold}} to qualify for a {{ticketYear}} Staff Credential ticket.
+    </p>
+  {{else if reachedRPThreshold}}
+    <p>
+      <br><strong>Congratulations!</strong> You're signed up for {{credits-format credits}} credits worth of shifts,
+      which is above the {{credits-format rpThreshold}} credits required to qualify for a reduced-price ticket in {{ticketYear}}.
+      You need only {{credits-format scDelta}} credits more to qualify for a staff credential.
+      {{#if withinRPThreshold}}
+        Since you are close to the threshold, you may want to sign up for one more shift.
+        (See fine print below.)
+      {{/if}}
+    </p>
+  {{else if almostRPTicket}}
+    <p>
+      <strong class="text-danger">Almost there!</strong> You're signed up for
+      {{credits-format credits}} credits worth of shifts,
+      and you need {{credits-format rpThreshold}} to qualify for a
+      {{ticketYear}} reduced-price ticket.
+    </p>
   {{/if}}
-</p>
-{{else if almostRPTicket}}
-<p>
-  <strong class="text-danger">Almost there!</strong> You're signed up for
-  {{credits-format credits}} credits worth of shifts, and you need {{credits-format rpThreshold}} to qualify for a
-  {{ticketYear}} reduced-price ticket.
-</p>
-{{/if}}
 
-{{#if (gt credits 0)}}
-<p>
-  <strong>The fine print:</strong> The total credits listed above are based on scheduled
-  shift times,  but ticket qualification credits are based on the hours you
-  actually work.  In other words, if a shift runs longer than the scheduled time,
-  you'll receive more credits -- but  more importantly, if a shift runs shorter
-  than the scheduled time (which is typical for Burn Perimeter  and Art Safety
-  shifts), you'll receive fewer credits.  If by the end of the event your total
-  credits based on actual shift times are less than the required threhhold,  then
-  you won't qualify for a (reduced-price or staff credential) ticket in
-  {{ticketYear}}.  If you're just over a threshold and are depending on Burn
-  Perimeter or Art Safety shifts to get you there, you might consider adding
-  another shift or two to be on the safe side.
-</p>
-{{/if}}
+  {{#if (gt credits 0)}}
+    <p>
+      <strong>The fine print:</strong> The total credits listed above are based on scheduled
+      shift times, but ticket qualification credits are based on the hours you
+      actually work. In other words, if a shift runs longer than the scheduled time,
+      you'll receive more credits -- but more importantly, if a shift runs shorter
+      than the scheduled time (which is typical for Burn Perimeter and Art Safety
+      shifts), you'll receive fewer credits. If by the end of the event your total
+      credits based on actual shift times are less than the required threhhold, then
+      you won't qualify for a (reduced-price or staff credential) ticket in
+      {{ticketYear}}. If you're just over a threshold and are depending on Burn
+      Perimeter or Art Safety shifts to get you there, you might consider adding
+      another shift or two to be on the safe side.
+    </p>
+  {{/if}}
 {{/if}}

--- a/app/templates/me/personal-info.hbs
+++ b/app/templates/me/personal-info.hbs
@@ -40,9 +40,17 @@
     </div>
 
     {{#unless person.isAuditor}}
+      <div class="form-group">
+        List the English names of the  languages you are comfortable speaking with the level of fluency in parenthesis, each separated by a comma.<br>
+        <div class="mt-2 mb-2">
+          Example: "japanese (basic), spanish (fluent)"
+        </div>
+        Keep the list simple:<br>
+        GOOD: "french (fluent), italian (written only), spanish (basic)"<br>
+        BAD: "French - I taught in Paris and can only write in Italian. Took 1 year of high school spanish"<br>
+      </div>
       <div class="form-row">
-        {{f.input "languages" label="Languages Spoken"
-          hint="List the English names of languages you are comfortable speaking separated by a comma. Examples: english, french, japanese"}}
+        {{f.input "languages" label="Languages Spoken" type="text" size=80}}
       </div>
       <div class="form-row col-auto">
         {{f.input "camp_location" type="textarea" label="Camp Name & Location" cols=50 rows=4 maxlength=200 hint=(concat (if f.model.camp_location f.model.camp_location.length "0") " of 200 characters")}}

--- a/app/templates/reports/freaking-years.hbs
+++ b/app/templates/reports/freaking-years.hbs
@@ -12,20 +12,17 @@
   </label>
 </p>
 <p>
-Report on people's service based on years rangered. The "Signed Up" column
-indicates if ANY shift sign up (training, dirt shift, etc) was found for the
-current year which may indicate the person will be working the event.
+  Report on people's service based on years rangered. The "Signed Up" column
+  indicates if ANY shift sign up (training, dirt shift, etc) was found for the
+  current year which may indicate the person will be working the event.
+</p>
+
+<p>
+<button class="btn btn-secondary btn-sm" {{action exportToCsv}}>Export To CSV</button>
 </p>
 
 {{#each freaking as |freaks|}}
-  <div class="row">
-    <div class="col-auto">
-      <strong>{{pluralize freaks.years "year"}} - {{pluralize freaks.people.length "person"}}</strong>
-    </div>
-    <div class="col-auto ml-auto">
-      <button class="btn btn-secondary btn-sm" {{action exportToCsv freaks}}>Export To CSV</button>
-    </div>
-  </div>
+  <strong>{{pluralize freaks.years "year"}} - {{pluralize freaks.people.length "person"}}</strong>
 
   <table class="table table-striped table-sm">
     <thead>

--- a/app/utils/mark-slots-overlap.js
+++ b/app/utils/mark-slots-overlap.js
@@ -1,16 +1,32 @@
 /*
  * Find all slots which overlap with one another, and mark them.
  */
- 
+
+ import * as Position from 'clubhouse/constants/positions';
+
 export default function markSlotsOverlap(slots) {
   let prevEndTime = 0, prevSlot = null;
 
   slots.forEach(function(slot) {
     if (slot.slot_begins_time < prevEndTime) {
-      slot.set('is_overlapping', true);
-      prevSlot.set('is_overlapping', true);
+      console.log(`slot.position_id [${slot.position_id}/${prevSlot.position_id == Position.TRAINING}] ${Position.TRAINING}`);
+      if (slot.isTraining && prevSlot.isTraining
+      && (
+          (slot.position_id == Position.TRAINING && prevSlot.position_id != Position.TRAINING)
+          || (slot.position_id != Position.TRAINING && prevSlot.position_id == Position.TRAINING)
+        )
+      )
+      {
+        // Looks like dirt trainng and ART training.. which is okay.
+        slot.set('is_training_overlap', true);
+        prevSlot.set('is_training_overlap', true);
+      } else {
+        slot.set('is_overlapping', true);
+        prevSlot.set('is_overlapping', true);
+      }
     } else {
       slot.set('is_overlapping', false);
+      slot.set('is_training_overlap', false);
     }
     prevEndTime = slot.slot_ends_time;
     prevSlot = slot;


### PR DESCRIPTION
- Export all the people on freaking years. not by year group.
- Separate first and last name columns on export.
- Don't highlight overlapping training and art training sessions.
- Explain on multiple enrollment denied dialog on what type of training is being denied.
- Moved the shift overlap warning to above the schedule table.
- Try to get people to use a standardize language spoken format. (sigh)