### PR TITLE
Slot form tweaks for trainer's slot usage. Various fixes.

### DIFF
--- a/app/components/modal-multiple-enrollment.js
+++ b/app/components/modal-multiple-enrollment.js
@@ -3,11 +3,14 @@ import { argument } from '@ember-decorators/argument';
 import { optional } from '@ember-decorators/argument/types';
 import { alias } from '@ember-decorators/object/computed';
 import { computed } from '@ember-decorators/object';
+import { inject as service } from '@ember-decorators/service';
 
 export default class ModalMultipleEnrollmentComponent extends Component {
   @argument(optional('object')) dialog;
   @argument(optional('object')) onClose;
   @argument(optional('object')) onConfirm;
+
+  @service session;
 
   @alias('dialog.data') data;
 

--- a/app/controllers/login.js
+++ b/app/controllers/login.js
@@ -29,7 +29,7 @@ export default class LoginController extends Controller {
       .catch((response) => {
         if (response.status == 401) {
           const data = response.json ? response.json : response.payload;
-          this.set('loginError', data.status);
+          this.set('loginError', (data ? data.status : `Unknown error ${JSON.stringify(data)}`));
         } else {
           this.house.handleErrorResponse(response)
         }

--- a/app/controllers/training/session/index.js
+++ b/app/controllers/training/session/index.js
@@ -191,9 +191,10 @@ export default class TrainingSlotController extends Controller {
       break;
 
     case 'multiple-enrollment':
-      modal.open('modal-multiple-enrollment', 'Multiple Enrollments Not Allowed', {
+      modal.open('modal-multiple-enrollment', {
+        title: 'Multiple Enrollments Not Allowed',
         slots: result.slots,
-        person,
+        person
       });
       break;
 
@@ -228,8 +229,10 @@ export default class TrainingSlotController extends Controller {
         } else if (result.trainer_forced) {
           this.toast.success('Successfully signed up, and the trainer is now signed up for multiple training sessions.');
         } else if (result.multiple_forced) {
-          this.modal.open('modal-multiple-enrollment', 'Sign Up Forced - Other Enrollments Found', {
+          this.modal.open('modal-multiple-enrollment', {
+            title: 'Sign Up Forced - Other Enrollments Found',
             slots: result.slots,
+            person,
             forced: true,
           });
         } else {

--- a/app/routes/admin/event-dates.js
+++ b/app/routes/admin/event-dates.js
@@ -8,7 +8,7 @@ export default class AdminEventDatesRoute extends Route {
 
   model() {
     this.store.unloadAll('event-date');
-    return this.store.findAll('event-date').then((results) => results.toArray());
+    return this.store.findAll('event-date', { reload: true }).then((results) => results.toArray());
   }
 
   setupController(controller, model) {

--- a/app/routes/error.js
+++ b/app/routes/error.js
@@ -20,15 +20,19 @@ export default class ErrorRoute extends Route {
       data.append('error_type', 'ember-route-error');
       data.append('url', window.location.href);
 
-      const route_error = {
-        message: error.message,
-        stack: error.stack
-      };
+      let route_error;
+      if (error.stack) {
+        route_error = {
+          message: error.message,
+          stack: error.stack
+        };
+      } else {
+        route_error = error;
+      }
 
       data.append('data', JSON.stringify({
         build_timestamp: ENV.APP.buildTimestamp,
         version: ENV.APP.version,
-        user_agent: navigator.userAgent,
         route_error
       }));
 

--- a/app/templates/admin/error-log.hbs
+++ b/app/templates/admin/error-log.hbs
@@ -46,7 +46,10 @@
 
           {{#if log.showing}}
           <tr>
-            <td colspan="6"> {{json-format json=log.data}} </td>
+            <td colspan="6">
+              User Agent: {{log.user_agent}}<br>
+              {{json-format json=log.data}}
+            </td>
           </tr>
           {{/if}}
         {{/each}}

--- a/app/templates/admin/slots.hbs
+++ b/app/templates/admin/slots.hbs
@@ -65,7 +65,8 @@
           <th>ID</th>
           <th>From</th>
           <th>To</th>
-          <th class="text-right">Max / Sign ups</th>
+          <th class="text-right">Max</th>
+          <th class="text-right">Count</th>
           <th class="text-right">Credits</th>
           <th>Description</th>
           <th>Active</th>
@@ -78,7 +79,8 @@
             <td>{{slot.id}}</td>
             <td>{{shift-format slot.begins}}</td>
             <td>{{shift-format slot.ends}}</td>
-            <td class="text-right">{{slot.max}} / {{slot.signed_up}}</td>
+            <td class="text-right">{{slot.max}}</td>
+            <td class="text-right">{{slot.signed_up}}</td>
             <td class="text-right">{{credits-format slot.credits}}</td>
             <td>
               {{slot-info-link slot.description slot.url}}
@@ -100,7 +102,7 @@
           {{#if slot.trainer_slot}}
             <tr class="{{if slot.trainer_slot "tr-no-border"}}">
               <td colspan="8">
-                Trainer slot: <a href="#slot-{{slot.trainer_slot.id}}">#{{slot.trainer_slot.id}} {{slot.trainer_slot_title}} {{slot.trainer_slot.description}} {{shift-format slot.trainer_slot.begins}}</a>
+                Multipler slot: <a href="#slot-{{slot.trainer_slot.id}}">#{{slot.trainer_slot.id}} {{slot.trainer_slot_title}} {{slot.trainer_slot.description}} {{shift-format slot.trainer_slot.begins}}</a>
               </td>
             </tr>
           {{/if}}

--- a/app/templates/components/admin/slot-form.hbs
+++ b/app/templates/components/admin/slot-form.hbs
@@ -2,11 +2,12 @@
   <div class="form-row">
     {{f.input "position_id" label="Position" type="select" options=positionOptions grid="col-md-auto"}}
     {{f.input "trainer_slot_id"
-      label="Trainer's Slot"
+      label="Sign Up Multiplier Trainer's Slot"
       type="select"
       options=trainerSlotsOptions
       includeBlank=true
-      grid="col-md-auto"}}
+      grid="col-md-auto"
+    }}
   </div>
 
   <div class="form-row">
@@ -15,7 +16,18 @@
     }}
     {{f.input "begins" label="Begining Time" type="datetime" maxlength=25 grid="col-md-auto col-sm-12"}}
     {{f.input "ends" label="Ending Time" type="datetime"  maxlength=20 grid="col-md-auto col-sm-12"}}
-    {{f.input "max" label="Max" type="text" size=3 maxlength=3 grid="col-md-auto col-sm-12"}}
+    {{f.input "max" label=(if f.model.trainer_slot_id "Multiplier" "Max Sign Ups") type="text" size=3 maxlength=3 grid="col-md-2 col-sm-12"}}
+    {{#if f.model.trainer_slot_id}}
+    <div class="col-md-9 col-sm-12">
+      <span class="text-danger">NOTE:</span>
+       The Trainer's Slot has been set and the Max Sign Ups is acting as a multiplier instead of a
+      hard count. The total sign ups allowed will be computed as the number of trainers signed up in
+      the trainer's slot TIMES the Max Sign Ups limit.
+      (e.g., if 2 trainers are signed up, and the sign up limitis 10, the total signups allowed will
+      be 20.)
+    </div>
+    {{/if}}
+
   </div>
 
   <div class="form-row">

--- a/app/templates/components/modal-multiple-enrollment.hbs
+++ b/app/templates/components/modal-multiple-enrollment.hbs
@@ -10,7 +10,7 @@
   </p>
   <p>
     {{#if data.forced}}
-      Because you either have the Admin, Trainer, VC or Mentor role,
+      Because you either have the Admin, Trainer, VC or Mentor role, OR are a Trainer,
       {{if isMe "you have" "the person has"}}
       been added to the
       {{#if data.isAlpha}}Alpha shift{{else}}{{trainingType}} session{{/if}}.

--- a/app/utils/mark-slots-overlap.js
+++ b/app/utils/mark-slots-overlap.js
@@ -9,7 +9,6 @@ export default function markSlotsOverlap(slots) {
 
   slots.forEach(function(slot) {
     if (slot.slot_begins_time < prevEndTime) {
-      console.log(`slot.position_id [${slot.position_id}/${prevSlot.position_id == Position.TRAINING}] ${Position.TRAINING}`);
       if (slot.isTraining && prevSlot.isTraining
       && (
           (slot.position_id == Position.TRAINING && prevSlot.position_id != Position.TRAINING)


### PR DESCRIPTION
- Change the labeling on the Trainer's Slot option. Explanation now appears when a Trainer's Slot is selected describing the effects.
- On login attempt check if the payload is actually present for a 401 error (usually incorrect credentials) as a safe guard.
- Show the user agent in the error log.
- The trainer's pages were not passing the right parameters to the multiple enrollment dialog.
- remove console.log from mark-slots-overlap.js