### PR TITLE
HQ, Vehicle, and TRS tweaks.

### DIFF
--- a/app/controllers/reports/vehicle-paperwork.js
+++ b/app/controllers/reports/vehicle-paperwork.js
@@ -9,7 +9,7 @@ export default class ReportsVehiclePaperworkController extends  Controller {
         { title: 'Callsign', key: 'callsign' },
         { title: 'Status', key: 'status' },
         { title: `${year} Motorpool Agreement`, key: 'vehicle_paperwork', yesno: true },
-        { title: `${year} Org Insurance`, key: 'vehicle_insurance_paperwork', yesno: true },
+        { title: `${year} Motor Vehicle Record (MVR)`, key: 'vehicle_insurance_paperwork', yesno: true },
       ];
 
       this.house.downloadCsv(`${year}-vehicle-paperwork.csv`, CSV_COLUMNS, this.people);

--- a/app/templates/hq.hbs
+++ b/app/templates/hq.hbs
@@ -132,7 +132,7 @@
             {{/if}}
           </dd>
 
-          <dt>Motorpool</dt>
+          <dt>Motorpool Policy</dt>
           <dd>
             {{#if person.vehicle_blacklisted}}
               {{badge "danger" "Blacklisted"}} Vehicle is blacklisted. May not drive gators, cars, or trucks on playa for Ranger business.
@@ -146,7 +146,7 @@
             {{/if}}
           </dd>
 
-          <dt>Org Vehicle Insurance</dt>
+          <dt>Motor Vehicle Record (MVR)</dt>
           <dd>
             {{#if person.vehicle_insurance_paperwork}}
               {{badge "success" "Authorized" }}

--- a/app/templates/hq/shift.hbs
+++ b/app/templates/hq/shift.hbs
@@ -29,7 +29,7 @@
       </div>
       <div class="mt-1">
         <h5> {{person.callsign}} is not signed up for a Burn Weekend shift</h5>
-      Ask {{person.callsign}} if they are interested in signing up for a weekend shift.
+        Ask {{person.callsign}} if they are interested in signing up for a weekend shift.
       </div>
     </div>
   {{/ch-alert}}
@@ -112,7 +112,11 @@
 
 <hr>
 <h3 class="mb-2">Radio &amp; Assets {{help-popover slug="hq-assets"}}</h3>
-
+{{#unless eventInfo.radio_info_available}}
+  {{#ch-alert "danger"}}
+    Warning: Event radio information has not been posted yet. Radio eligibility cannot be determined.
+  {{/ch-alert}}
+{{/unless}}
 {{#if radioCount}}
   {{#if shiftRadios}}
     <h3 class="text-danger">Collect {{pluralize shiftRadios "radio"}} at end of shift</h3>

--- a/app/templates/hq/site-checkin.hbs
+++ b/app/templates/hq/site-checkin.hbs
@@ -49,6 +49,12 @@
 
 </div>
 
+{{#unless eventInfo.radio_info_available}}
+  {{#ch-alert "danger"}}
+    Warning: Event radio information has not been posted yet. Radio eligibility cannot be determined.
+  {{/ch-alert}}
+{{/unless}}
+
 {{#if eventInfo.radio_eligible}}
   <h4>Event Radio Checkout {{help-popover slug="hq-site-checkin-radios"}}</h4>
   <p class="text-success"><b>{{person.callsign}} is authorized For {{pluralize eventInfo.radio_max "Event Radio"}}</b></p>

--- a/app/templates/me/event-info.hbs
+++ b/app/templates/me/event-info.hbs
@@ -91,21 +91,22 @@ Positions indicate which shifts you are allowed to sign up for and what ART trai
     Radio eligibility for this year is not yet available.
   {{/if}}
 
-  <h3 class="mt-4">{{fa-icon "car"}} Motorpool</h3>
+  <h3 class="mt-4">{{fa-icon "car"}} Motorpool Policy</h3>
   {{#if person.vehicle_blacklisted}}
     {{badge "danger" "Blacklisted"}} We're sorry, but you cannot drive gators, cars, or trucks on playa for Ranger business.
   {{else}}
     {{#if person.vehicle_paperwork}}
-      {{badge "success" "Authorized"}} You are authorized to drive golf carts &amp; gators (UTVs) on playa for Ranger business
+      {{badge "success" "Authorized"}} You are authorized to drive golf carts &amp; gators (UTVs) on playa for Ranger business. Vehicle must have a valid Burning Man driving sticker.
     {{else}}
       {{badge "warning" "Not Authorized"}} You are NOT authorized to drive golf carts &amp; gators (UTVs) on the playa for Ranger business. You can fix this by agreeing to the
       {{#link-to "me.motorpool-policy"}}Motorpool Policy{{/link-to}}.
     {{/if}}
 
-    <h3 class="mt-4">{{fa-icon "car-crash"}} Organization Vehicle Insurance</h3>
+    <h3 class="mt-4">{{fa-icon "car-crash"}} Motor Vehicle Record (MVR)</h3>
     {{#if person.vehicle_insurance_paperwork}}
       {{badge "success" "Authorized" }} You are authorized to drive cars and
       trucks (including your own personal vehicle) on playa for Ranger business.
+      Vehicle must have a valid Burning Man driving sticker.
     {{else}}
       {{badge "warning" "Not Authorized" }} You are NOT authorized to drive cars
       and trucks (including your own personal vehicle) on playa for Ranger

--- a/app/templates/person/event-info.hbs
+++ b/app/templates/person/event-info.hbs
@@ -49,7 +49,7 @@
     {{/if}}
   </dd>
 
-  <dt class="col-md-2">Motorpool</dt>
+  <dt class="col-md-2">Motorpool Policy</dt>
   {{#if person.vehicle_blacklisted}}
     <dd class="col-md-9">
       {{badge "danger" "Blacklisted"}} Vehicle is blacklisted. May not drive gators, cars, or trucks on playa for Ranger business.
@@ -61,17 +61,17 @@
       {{else}}
         {{badge "warning" "Not Authorized"}}
       {{/if}}
-      to drive golf carts &amp; gators (UTVs) on playa for Ranger business
+      to drive golf carts &amp; gators (UTVs) on playa for Ranger business. Vehicle must have a valid Burning Man driving sticker.
     </dd>
 
-    <dt class="col-md-2">Org Vehicle Insurance</dt>
+    <dt class="col-md-2">Motor Vehicle Record (MVR)</dt>
     <dd class="col-md-9">
       {{#if person.vehicle_insurance_paperwork}}
         {{badge "success" "Authorized" }}
       {{else}}
         {{badge "warning" "Not Authorized" }}
       {{/if}}
-      to drive cars and trucks (including own personal vehicle) on playa for Ranger business.
+      to drive cars and trucks (including own personal vehicle) on playa for Ranger business. Vehicle must have a valid Burning Man driving sticker.
     </dd>
   {{/if}}
 </dl>

--- a/app/templates/person/index.hbs
+++ b/app/templates/person/index.hbs
@@ -199,7 +199,7 @@
     <div class="col-md-9 col-sm-12">
       {{#if (has-role "admin")}}
         {{f.input "vehicle_paperwork" label="Motorpool Policy" type="checkbox" inline=true}}
-        {{f.input "vehicle_insurance_paperwork" label="Vehicle Insurance Paperwork" type="checkbox" inline=true}}
+        {{f.input "vehicle_insurance_paperwork" label="Motor Vehicle Record (MVR)" type="checkbox" inline=true}}
         {{f.input "vehicle_blacklisted" label="Vehicle Blacklisted" type="checkbox" inline=true}}
       {{else}}
         {{#if person.vehicle_paperwork}}
@@ -207,7 +207,7 @@
         {{else}}
           Motorpool Policy NOT agreed to
         {{/if}}<br>
-        {{if person.vehicle_insurance_paperwork "Has" "No"}} org insurance<br>
+        {{if person.vehicle_insurance_paperwork "Has" "No"}} Motor Vehicle Record (MVR)br>
         {{#if person.vehicle_blacklisted}}
           <strong class="text-danger">VEHICLE BLACKLISTED</strong>
         {{/if}}

--- a/app/templates/reports/vehicle-paperwork.hbs
+++ b/app/templates/reports/vehicle-paperwork.hbs
@@ -1,6 +1,6 @@
-<h1>Motorpool Policy &amp; Org Insurance Report</h1>
+<h1>Motorpool Policy &amp; Motor Vehicle Record (MVR) Report</h1>
 <p>
-  This report will show who has signed the Motorpool Policy Agreement and/or who has Burning Man vehicle insurance.
+  This report will show who has signed the Motorpool Policy Agreement and/or who has a Motor Vehicle Record (MVR).
 </p>
 <p>
   <button class="btn btn-primary" {{action exportToCsv}}>Export to CSV</button>
@@ -13,7 +13,7 @@
       <th>Callsign</th>
       <th>Status</th>
       <th>{{year}} Motorpool</th>
-      <th>{{year}} Org Ins.</th>
+      <th>{{year}} Motor Vehicle Record</th>
     </tr>
   </thead>
 

--- a/app/templates/vc/access-documents/loading.hbs
+++ b/app/templates/vc/access-documents/loading.hbs
@@ -1,0 +1,1 @@
+{{loading-dialog "the access documents"}}


### PR DESCRIPTION
- Org Insurance has been renamed to "Motor Vehicle Record" on person manage, event info, and other pages.
- On HQ Interface warn if radio eligibility info has not been posted.
- Fake up address when missing for TRS export. 'Will Call' has been replaced with 'Credential Pick Up'.