### PR TITLE
People by position report implementation

### DIFF
--- a/app/controllers/reports/people-by-position.js
+++ b/app/controllers/reports/people-by-position.js
@@ -25,6 +25,7 @@ class ViewPosition extends EmberObject {
 
 export default class PeopleByPositionController extends Controller {
   queryParams = ['onPlaya'];
+  onPlaya = false;
 
   @computed('positions', 'people')
   get viewPositions() {

--- a/app/controllers/reports/people-by-position.js
+++ b/app/controllers/reports/people-by-position.js
@@ -1,0 +1,85 @@
+import Controller from '@ember/controller';
+import { later } from '@ember/runloop';
+import EmberObject from '@ember/object';
+import { action, computed } from '@ember/object';
+import _ from 'lodash';
+
+class ViewPosition extends EmberObject {
+  expanded = false;
+
+  @computed('statuses.@each.selected', 'people')
+  get visiblePeople() {
+    const statuses = this.get('statuses');
+    const visibleStatuses = new Set(statuses.filterBy('selected').mapBy('name'));
+    if (statuses.length === visibleStatuses.length) {
+      return this.get('people');
+    }
+    return this.get('people').filter((p) => visibleStatuses.has(p.status));
+  }
+
+  @computed('missingPeople')
+  get missingOnPlayaCount() {
+    return this.get('missingPeople').filterBy('on_site').length;
+  }
+}
+
+export default class PeopleByPositionController extends Controller {
+  queryParams = ['onPlaya'];
+
+  @computed('positions', 'people')
+  get viewPositions() {
+    const people = this.get('people');
+    const lookupPeople = (ids) => ids ? ids.map((id) => people[id]).sortBy('callsign') : [];
+    return this.get('positions').map((position) =>
+      ViewPosition.create({
+        id: position.id,
+        title: position.title,
+        type: position.type,
+        allRangers: position.all_rangers,
+        allPeople: position.new_user_eligible,
+        totalPeople: position.num_people,
+        onPlayaCount: position.num_on_site,
+        people: lookupPeople(position.personIds),
+        missingPeople: lookupPeople(position.missingPersonIds),
+        statuses: this.get('statuses'),
+      }))
+      .sortBy('title');
+  }
+
+  @computed('positions')
+  get positionTypes() {
+    return this.get('positions').mapBy('type').uniq().sort()
+      .map((type) => EmberObject.create({name: type, selected: true}));
+  }
+
+  @computed('viewPositions', 'positionTypes.@each.selected')
+  get visiblePositions() {
+    const selected = new Set(this.get('positionTypes').filterBy('selected').mapBy('name'));
+    const positions = this.get('viewPositions');
+    return selected.size === 0 ? positions : positions.filter((p) => selected.has(p.type));
+  }
+
+  @computed('people')
+  get statuses() {
+    return _.map(_.uniq(_.map(_.values(this.get('people')), 'status')).sort(),
+      (status) => EmberObject.create({name: status, selected: true}));
+  }
+
+  @action
+  toggleExpanded(position) {
+    position.set('expanded', !position.get('expanded'));
+  }
+
+  @action
+  expandAllPositions(expanded) {
+    // Expand or collapse all iteratively asynchronously because rendering the contents takes awhile
+    const positions = this.get('viewPositions');
+    const advance = (i) => ( () => {
+      if (i < positions.length) {
+        positions[i].set('expanded', expanded);
+        later(advance(i+1), 1);
+      }
+    });
+    later(advance(0), 1);
+  }
+}

--- a/app/router.js
+++ b/app/router.js
@@ -143,23 +143,24 @@ Router.map(function() {
 
 
   this.route('reports', function() {
-    this.route('timesheet-correction-requests');
-    this.route('timesheet-unconfirmed');
+    this.route('alpha-shirts');
     this.route('asset-history');
     this.route('assets-outstanding');
-    this.route('radio-assets');
-    this.route('radio-checkout');
-    this.route('shirts');
     this.route('freaking-years');
-    this.route('alpha-shirts');
-    this.route('shift-lead');
     this.route('hq-forecast');
     this.route('on-duty');
+    this.route('people-by-position');
+    this.route('radio-assets');
+    this.route('radio-checkout');
     this.route('sandman-qualified');
-    this.route('vehicle-paperwork');
     this.route('shift-coverage');
+    this.route('shift-lead');
     this.route('shift-signups');
+    this.route('shirts');
     this.route('special-teams');
+    this.route('timesheet-correction-requests');
+    this.route('timesheet-unconfirmed');
+    this.route('vehicle-paperwork');
   });
 
   this.route('vc', function() {

--- a/app/routes/reports/people-by-position.js
+++ b/app/routes/reports/people-by-position.js
@@ -1,0 +1,20 @@
+import Route from '@ember/routing/route';
+import _ from 'lodash';
+
+export default class PeopleByPositionRoute extends Route {
+  queryParams = {
+    onPlaya: { refreshModel: true }
+  };
+
+  model(params) {
+    const onPlaya = !!params.onPlaya;
+    this.set('onPlaya', onPlaya);
+    return this.ajax.request('position/people-by-position', {data: {onPlaya: onPlaya ? 1 : 0}});
+  }
+
+  setupController(controller, model) {
+    controller.set('positions', model.positions);
+    controller.set('people', _.keyBy(model.people, 'id'));
+    controller.set('onPlaya', this.onPlaya);
+  }
+}

--- a/app/routes/reports/people-by-position.js
+++ b/app/routes/reports/people-by-position.js
@@ -7,14 +7,11 @@ export default class PeopleByPositionRoute extends Route {
   };
 
   model(params) {
-    const onPlaya = !!params.onPlaya;
-    this.set('onPlaya', onPlaya);
-    return this.ajax.request('position/people-by-position', {data: {onPlaya: onPlaya ? 1 : 0}});
+    return this.ajax.request('position/people-by-position', {data: {onPlaya: params.onPlaya ? 1 : 0}});
   }
 
   setupController(controller, model) {
     controller.set('positions', model.positions);
     controller.set('people', _.keyBy(model.people, 'id'));
-    controller.set('onPlaya', this.onPlaya);
   }
 }

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -222,7 +222,7 @@
                     </div>
                     <div class="col-sm-12 col-md-4 col-lg-3">
                       <div class="navbar-text">People</div>
-                      <a href="{{cgo "timesheet" "selectByPosition"}}" class="dropdown-item">People by Position</a>
+                      {{#link-to "reports.people-by-position" class="dropdown-item"}}People by Position{{/link-to}}
                       <a href="{{cgo "person" "selectByRole"}}" class="dropdown-item">People by Role</a>
                       <a href="{{cgo "person" "selectByStatus"}}" class="dropdown-item">People by Status</a>
                       <a href="{{cgo "person" "selectByLocation"}}" class="dropdown-item">People by Location</a>

--- a/app/templates/reports/people-by-position.hbs
+++ b/app/templates/reports/people-by-position.hbs
@@ -62,6 +62,10 @@
   &ndash; {{position.type}}
   {{#if position.expanded}}
     {{#if position.people}}
+      {{#if (and position.allRangers position.visiblePeople.length)}}
+        <br>Note: {{position.title}} is granted to all active and inactive rangers.
+        The following list is just people who aren't active/inactive.
+      {{/if}}
       <table class="table table-md table-hover table-width-auto">
         <thead>
           <tr>

--- a/app/templates/reports/people-by-position.hbs
+++ b/app/templates/reports/people-by-position.hbs
@@ -1,0 +1,114 @@
+<div class="form-group row">
+  <legend>Options</legend>
+  <div class="form-check form-check-inline d-inline-block">
+    {{input type="checkbox" id="on-playa-only" class="form-check-input" checked=onPlaya}}
+    <label for="on-playa-only" class="form-check-label">On playa only</label>
+  </div>
+  <div class="col-md d-inline-block">
+    <a href {{action "expandAllPositions" true}}>Expand all</a>
+    &ndash; <a href {{action "expandAllPositions" false}}>Collapse all</a>
+  </div>
+</div>
+
+<div class="form-group row">
+  <legend>Position types</legend>
+  {{#each positionTypes as |type|}}
+    <div class="form-check form-check-inline">
+      {{#let (concat "show-type-" type) as |id|}}
+        {{input type="checkbox" id=id class="form-check-input" checked=type.selected}}
+        <label for="{{id}}" class="form-check-label">{{type.name}}</label>
+      {{/let}}
+    </div>
+  {{/each}}
+</div>
+
+<div class="form-group row">
+  <legend>Person statuses</legend>
+  {{#each statuses as |status|}}
+    <div class="form-check form-check-inline">
+      {{#let (concat "show-status-" status) as |id|}}
+        {{input type="checkbox" id=id class="form-check-input" checked=status.selected}}
+        <label for="{{id}}" class="form-check-label">{{status.name}}</label>
+      {{/let}}
+    </div>
+  {{/each}}
+</div>
+
+<h1>People by Position</h1>
+{{#each visiblePositions as |position|}}
+  <h2 class="d-inline-block">
+    <a href {{action toggleExpanded position}}>
+      {{fa-icon (if position.expanded "caret-down" "caret-right")}}
+      {{position.title}}
+    </a>
+  </h2>
+  {{#if position.allRangers}}
+    &ndash; all rangers
+  {{/if}}
+  {{#if position.allPeople}}
+    &ndash; all people
+  {{/if}}
+  &ndash; {{pluralize position.totalPeople "person"}}
+  ({{position.onPlayaCount}} on playa)
+  {{#if (not-eq position.visiblePeople.length position.people.length)}}
+    {{pluralize position.visiblePeople.length "person"}} shown
+  {{/if}}
+  {{#if (or position.allRangers position.allPeople)}}
+    &ndash; {{pluralize position.missingPeople.length "unassigned person"}}
+    ({{position.missingOnPlayaCount}} on playa)
+  {{/if}}
+  &ndash; {{position.type}}
+  {{#if position.expanded}}
+    {{#if position.people}}
+      <table class="table table-md table-hover table-width-auto">
+        <thead>
+          <tr>
+            <th>Callsign</th>
+            <th>Status</th>
+            <th>On playa</th>
+          </tr>
+        </thead>
+        <tbody>
+          {{#each position.visiblePeople as |person|}}
+            <tr>
+              <td>{{person-link person=person}}</td>
+              <td>{{person.status}}</td>
+              <td>{{#if person.on_site}}{{fa-icon "check"}}{{/if}}</td>
+            </tr>
+          {{/each}}
+        </tbody>
+      </table>
+    {{/if}}
+    {{#if (and position.missingPeople position.missingPeople.length)}}
+      <table class="table table-md table-hover table-width-auto">
+        <thead>
+          <tr>
+            <td><span class="text-danger">{{fa-icon "exclamation-triangle"}}</span></td>
+            <th>Callsign</th>
+            <th>Status</th>
+            <th>On playa</th>
+            <th>Missing position</th>
+          </tr>
+        </thead>
+        <tbody>
+          {{#each position.missingPeople as |person|}}
+            <tr>
+              <td><span class="text-danger">{{fa-icon "exclamation-triangle"}}</span></td>
+              <td>{{person-link person=person}}</td>
+              <td>{{person.status}}</td>
+              <td>{{#if person.on_site}}{{fa-icon "check" title="On playa"}}{{/if}}</td>
+              <td>{{position.title}} not assigned</td>
+            </tr>
+          {{/each}}
+        </tbody>
+      </table>
+    {{/if}}
+    <a href {{action toggleExpanded position}}>
+      {{fa-icon (if position.expanded "caret-up" "caret-right")}}
+      {{position.title}}
+      &ndash; {{pluralize position.totalPeople "person"}}
+      ({{position.onPlayaCount}} on playa)
+    </a>
+  {{/if}}
+  <hr>
+{{/each}}

--- a/app/templates/reports/people-by-position.hbs
+++ b/app/templates/reports/people-by-position.hbs
@@ -1,8 +1,10 @@
 <div class="form-group row">
   <legend>Options</legend>
   <div class="form-check form-check-inline d-inline-block">
-    {{input type="checkbox" id="on-playa-only" class="form-check-input" checked=onPlaya}}
-    <label for="on-playa-only" class="form-check-label">On playa only</label>
+    <label class="form-check-label">
+      {{input type="checkbox" class="form-check-input" checked=onPlaya}}
+      On playa only
+    </label>
   </div>
   <div class="col-md d-inline-block">
     <a href {{action "expandAllPositions" true}}>Expand all</a>
@@ -14,10 +16,10 @@
   <legend>Position types</legend>
   {{#each positionTypes as |type|}}
     <div class="form-check form-check-inline">
-      {{#let (concat "show-type-" type) as |id|}}
-        {{input type="checkbox" id=id class="form-check-input" checked=type.selected}}
-        <label for="{{id}}" class="form-check-label">{{type.name}}</label>
-      {{/let}}
+      <label class="form-check-label">
+        {{input type="checkbox" class="form-check-input" checked=type.selected}}
+        {{type.name}}
+      </label>
     </div>
   {{/each}}
 </div>
@@ -26,10 +28,10 @@
   <legend>Person statuses</legend>
   {{#each statuses as |status|}}
     <div class="form-check form-check-inline">
-      {{#let (concat "show-status-" status) as |id|}}
+      <label for="{{id}}" class="form-check-label">
         {{input type="checkbox" id=id class="form-check-input" checked=status.selected}}
-        <label for="{{id}}" class="form-check-label">{{status.name}}</label>
-      {{/let}}
+        {{status.name}}
+      </label>
     </div>
   {{/each}}
 </div>


### PR DESCRIPTION
Positions are shown with a disclosure triangle, initially collapsed
so that the page is easy to scroll.  Positions can be filtered by type,
e.g. to see just HQ positions.  Positions that not everyone gets show
a table of those people, their status, and whether they're on playa.
All-rangers and all-people positions just show the people who DON'T have
the position so as to avoid printing the same 1400 Rangers 18 times.
Positions also show summary counts.  People can be filtered by status.

This implementation should make it significantly easier to get useful
information.  The main downside is that Ember is S L O W when rendering
thousands of objects, so clicking "Expand all" is a good time to nosh on
a tasty snack from Echelon.