### PR TITLE
Better error message for 403 responses. Minor timesheet UI tweaks.

### DIFF
--- a/app/routes/error.js
+++ b/app/routes/error.js
@@ -1,6 +1,6 @@
 import Route from '@ember/routing/route';
 import ENV from 'clubhouse/config/environment';
-import { isAbortError, isTimeoutError } from 'ember-ajax/errors';
+import { isAbortError, isTimeoutError, isForbiddenError } from 'ember-ajax/errors';
 import DS from 'ember-data';
 
 //
@@ -21,9 +21,7 @@ export default class ErrorRoute extends Route {
 
     controller.set('isOffline', isOffline);
 
-    if (!isOffline) {
-      console.error('Uncaught routing error', error);
-    }
+    controller.set('notAuthorized', (error && (isForbiddenError(error) || error.status == 403)));
 
     // Try to send the down the error to the server for logging
     if (!isOffline && ENV.logEmberErrors && navigator.sendBeacon) {

--- a/app/templates/components/me/timesheet-review-common.hbs
+++ b/app/templates/components/me/timesheet-review-common.hbs
@@ -96,7 +96,10 @@
   {{/if}}
 
   <div class="row mb-4">
-    <div class="col"><strong>Position Summary:</strong> {{timesheet-position-summary timesheets=timesheets}}</div>
+    <div class="col">
+      <strong>Position Summary:</strong><br>
+      {{timesheet-position-summary timesheets=timesheets}}
+    </div>
   </div>
 
 {{else}}

--- a/app/templates/components/person/timesheet-manage.hbs
+++ b/app/templates/components/person/timesheet-manage.hbs
@@ -78,6 +78,7 @@
     {{timesheet-summary summary=timesheetSummary}}
     <div class="row">
       <div class="col-auto">
+        <b>Position Summary:</b><br>
         {{timesheet-position-summary timesheets=timesheets}}
       </div>
     </div>
@@ -137,7 +138,7 @@
             </div>
           </div>
           <div class="form-row">
-            {{f.input "notes" label="Correciton request notes:" type="textarea" cols=80 rows=3}}
+            {{f.input "notes" label="Correction Request Notes:" type="textarea" cols=80 rows=3}}
           </div>
         {{else}}
           <div class="form-row">

--- a/app/templates/components/timesheet-summary.hbs
+++ b/app/templates/components/timesheet-summary.hbs
@@ -1,26 +1,29 @@
-<div class="row my-2">
+<div class="row my-1">
+  <div class="col-auto">
+    {{#if summary.event_start}}
+      <b>Event Week:</b> {{shift-format summary.event_start}} to {{shift-format summary.event_end}}
+    {{else}}
+      <strong class="text-danger">Event dates have not been entered for the year. Hour &amp; credit breakdowns will not be accurate.</strong>
+    {{/if}}
+  </div>
+</div>
+
+<div class="row my-1">
   <div class="col-auto"><strong>Total Time:</strong> {{hour-minute-format summary.total_duration}}</div>
   <div class="col-auto"><strong>Time Counted Towards Appreciations:</strong> {{hour-minute-format summary.counted_duration}}</div>
   <div class="col-auto"><strong>Total Credits:</strong> {{credits-format summary.total_credits}}</div>
 </div>
 
 <div class="row my-1">
-  <div class="col-12">
+  <div class="col-auto">
     <span class="d-inline-block"><b>Credits Breakdown (Pre-Event / Event / Post-Event):</b></span>
     {{credits-format summary.pre_event_credits}} / {{credits-format summary.event_credits}} / {{credits-format summary.post_event_credits}}
   </div>
+</div>
 
-  <div class="col-12">
+<div class="row my-1">
+  <div class="col-auto">
     <span class="d-inline-block"><b>Hours Breakdown (Pre-Event / Event / Post-Event / Other):</b></span>
     {{hour-minute-format summary.pre_event_duration}} / {{hour-minute-format summary.event_duration}} / {{hour-minute-format summary.post_event_duration}} / {{hour-minute-format summary.other_duration}}
-  </div>
-</div>
-<div class="row my-1">
-  <div class="col-12">
-    {{#if summary.event_start}}
-      <b>{{year}} Event Week:</b> <span class="d-inline-block">{{shift-format summary.event_start}} to {{shift-format summary.event_end}}</span>
-    {{else}}
-      <strong class="text-danger">{{year}} event dates have not been determined. Hour and credit breakdowns will not be accurate.</strong>
-    {{/if}}
   </div>
 </div>

--- a/app/templates/error.hbs
+++ b/app/templates/error.hbs
@@ -4,6 +4,22 @@
       Uh oh, the request to the Clubhouse server could not be completed. The server might be offline or the Internet connection is spotty.
     </p>
     <button class="btn btn-primary" {{action reload}}>Reload the page</button>
+  {{else if notAuthorized}}
+    <h1>You are not authorized.</h1>
+    <p>
+      It appears you do not have the appropriate Clubhouse privilieges to perform that action.
+    </p>
+    <p>
+      Error message from the server: {{error.message}}
+    </p>
+    <p>
+      Please contact the Tech Team Ninjas at {{admin-email}} if you believe this is a mistake.
+    </p>
+    {{#if session.user}}
+      <p>
+        {{#link-to "me.overview" class="btn btn-primary"}}Back To The Home Page{{/link-to}}
+      </p>
+    {{/if}}
   {{else}}
     <h1>Khaki, Khaki, Clubhouse - I need a Tech Ninja for a crash.</h1>
     <p>Sorry! The clubhouse experienced an unrecoverable error while trying to process your request.</p>
@@ -49,8 +65,10 @@
     <p>
       Its recommended at this time that you do not attempt the request again until you hear from the tech ninjas.
     </p>
-    <p>
-      {{#link-to "me.overview"}}Back To The Home Page{{/link-to}}
-    </p>
+    {{#if session.user}}
+      <p>
+        {{#link-to "me.overview" class="btn btn-primary"}}Back To The Home Page{{/link-to}}
+      </p>
+    {{/if}}
   {{/if}}
 </main>

--- a/app/templates/me/timesheet.hbs
+++ b/app/templates/me/timesheet.hbs
@@ -2,6 +2,11 @@
 
 {{#if timesheets}}
 
+  <div class="row mt-4 mb-2">
+    <div class="col-auto">
+      (hh:mm) = time in parentheses indicates the time does not count towards appreciations.
+    </div>
+  </div>
   <div class="timesheet-table">
     <div class="timesheet-row timesheet-header">
       <div class="timesheet-time">From</div>
@@ -38,14 +43,12 @@
       </div>
     {{/each}}
   </div>
-  <div class="row my-2">
-    <div class="col-auto">
-      (hh:mm) = time in parentheses indicates the time does not count towards appreciations.
-    </div>
-  </div>
   {{timesheet-summary summary=timesheetSummary}}
   <div class="row">
-    <div class="col"><strong>Position Summary:</strong> {{timesheet-position-summary timesheets=timesheets}}</div>
+    <div class="col-auto">
+      <b>Position Summary:</b><br>
+      {{timesheet-position-summary timesheets=timesheets}}
+    </div>
   </div>
 
 
@@ -55,6 +58,6 @@
   </div>
 {{else}}
   <p class="mt-3 text-danger">
-    No timesheet entries were found for {{year}}.
+    <b>No timesheet entries were found for {{year}}.</b>
   </p>
 {{/if}}

--- a/app/templates/person/timesheet.hbs
+++ b/app/templates/person/timesheet.hbs
@@ -1,9 +1,9 @@
 <div class="float-right mt-1">
-  {{#link-to "person.timesheet-log" (query-params year=year) class="btn btn-secondary btn-sm"}}Timesheet Log{{/link-to}}
+  {{#link-to "person.timesheet-log" (query-params year=year) class="btn btn-primary"}}Timesheet Log{{/link-to}}
 </div>
 {{year-select "Timesheet" year=year years=person.all_years onChange=(action "changeYearAction") subheader=true}}
 
-<div class="border rounded p-2 mt-2 mb-2">
+<div class="border rounded p-2 mt-3 mb-2">
   <h3>Shift Manage</h3>
   {{#if (is-current-year year)}}
     {{shift-check-in-out positions=positions timesheets=timesheets person=person eventInfo=eventInfo}}


### PR DESCRIPTION
- Show a "you are not authorized" message when the server responds with 403 (not authorized).
- Bring the timesheet hours/credits summary layout in line with the scehdule summary.
- increase timesheet log button size.