### PR TITLE
 Timesheet correction bug fixes. Minor HQ tweaks.

### DIFF
--- a/app/components/me/timesheet-missing-common.js
+++ b/app/components/me/timesheet-missing-common.js
@@ -81,9 +81,15 @@ export default class MeTimesheetMissingCommonComponent extends Component {
       return;
     }
 
+    const isNew = model.get('isNew');
     this.toast.clear();
 
-    const isNew = model.get('isNew');
+    if (!model.get('isDirty')) {
+      this.set('entry', null);
+      this.modal.info('', `You did not enter any ${isNew ? 'new' : ''} information.`);
+      return;
+    }
+
     this.set('isSubmitting', true);
 
     model.save().then(() => {

--- a/app/components/me/timesheet-review-common.js
+++ b/app/components/me/timesheet-review-common.js
@@ -52,8 +52,18 @@ export default class MeTimesheetReviewCommonComponent extends Component {
     }
 
     this.toast.clear();
+
+    if (!model.get('isDirty')) {
+      this.set('entry', null);
+      this.modal.info('', 'You did not enter a new correction note. The correction was not submitted.');
+      return;
+    }
+
     model.set('verified', 0);
+    model.set('is_incorrect', 1);
+
     this.set('isSubmitting', true);
+
     model.save().then(() => {
       this.set('entry', null);
       this.set('isSubmitting', false);

--- a/app/components/shift-check-in-out.js
+++ b/app/components/shift-check-in-out.js
@@ -105,6 +105,8 @@ export default class ShiftCheckInOutComponent extends Component {
   _startShift(positionId) {
     const position = this.positions.find((p) => p.id == positionId);
 
+    const callsign = this.person.callsign;
+
     this.toast.clear();
     this.ajax.request('timesheet/signin', {
       method: 'POST',
@@ -123,7 +125,7 @@ export default class ShiftCheckInOutComponent extends Component {
           } else {
             reason = `has not completed '${result.required_training}'`;
           }
-          this.toast.error(`WARNING: The person ${reason}. Because you are an admin, we have signed them in anyways. Hope you know what you're doing! ${callsign} is now on duty.`);
+          this.modal.info(`${callsign} not trained - sign in forced', 'WARNING: The person ${reason}. Because you are an admin, we have signed them in anyways. Hope you know what you're doing! ${callsign} is now on duty.`);
         } else {
           this.toast.success(`${callsign} is on shift. Happy Dusty Adventures!`);
         }
@@ -131,23 +133,23 @@ export default class ShiftCheckInOutComponent extends Component {
         break;
 
       case 'position-not-held':
-        this.toast.error(`The person does hold the '${position.title}' in order to start the shift.`);
+        this.modal.info('Position Not Held', `${callsign} does hold the '${position.title}' in order to start the shift.`);
         break;
 
       case 'already-on-duty':
-        this.toast.error('The person is already on duty.');
+        this.modal.info('Already On Shift', 'The person is already on duty.');
         break;
 
       case 'not-trained':
-        this.toast.error(`The person has has not completed "${result.position_title}"`);
+        this.modal.info('Not Trained', `${callsign} has has not completed "${result.position_title}" and cannot be signed into the shift.`);
         break;
 
       case 'not-qualified':
-        this.toast.error(`The person is not qualified to sign in: ${result.unqualified_reason}`);
+        this.modal.info('Not Qualified', `${callsign} has not meet one or more of the qualifiers needed to sign into the shift.<br>Reason: ${result.unqualified_reason}`);
         break;
 
       default:
-        this.toast.error(`An unknown status [${result.status}] from the server.`);
+        this.modal.info('Unknown Server Status', `An unknown status [${result.status}] from the server. This is a bug. Please report this to the Tech Ninjas.`);
         break;
       }
     }).catch((response) => this.house.handleErrorResponse(response));

--- a/app/components/shift-check-in-out.js
+++ b/app/components/shift-check-in-out.js
@@ -105,8 +105,6 @@ export default class ShiftCheckInOutComponent extends Component {
   _startShift(positionId) {
     const position = this.positions.find((p) => p.id == positionId);
 
-    const callsign = this.person.callsign;
-
     this.toast.clear();
     this.ajax.request('timesheet/signin', {
       method: 'POST',
@@ -125,7 +123,7 @@ export default class ShiftCheckInOutComponent extends Component {
           } else {
             reason = `has not completed '${result.required_training}'`;
           }
-          this.modal.info(`${callsign} not trained - sign in forced', 'WARNING: The person ${reason}. Because you are an admin, we have signed them in anyways. Hope you know what you're doing! ${callsign} is now on duty.`);
+          this.modal.info('Sign in forced', `WARNING: The person ${reason}. Because you are an admin, we have signed them in anyways. Hope you know what you're doing! ${callsign} is now on duty.`);
         } else {
           this.toast.success(`${callsign} is on shift. Happy Dusty Adventures!`);
         }

--- a/app/models/timesheet.js
+++ b/app/models/timesheet.js
@@ -19,6 +19,8 @@ export default class TimesheetModel extends DS.Model {
   @attr('boolean') verified;
   @attr('string') verified_at;
 
+  @attr('boolean') is_incorrect;  // Mark entry as incorrect
+
   @attr('', { readOnly: true}) verified_person;
   @attr('', { readOnly: true}) reviewer_person;
   @attr('', { readOnly: true}) position;

--- a/app/templates/components/me/timesheet-missing-common.hbs
+++ b/app/templates/components/me/timesheet-missing-common.hbs
@@ -23,29 +23,37 @@
               <span class="text-info font-weight-bold">The request is pending review.</span>
             {{else}}
               {{#if tsm.isApproved}}
-                The request has been APPROVED. Your timesheet has been updated with the missing shift.
+                <span class="text-success">{{fa-icon "check"}} The request has been APPROVED. Your timesheet has been updated with the missing shift.</span>
               {{else}}
                 The request has been rejected.
               {{/if}}
-              <p>
+              <p class="mt-2">
                 <strong>Response from the reviewer:</strong><br>
-                {{tsm.reviewer_note}}
+                {{nl2br tsm.reviewer_notes}}
               </p>
             {{/if}}
           </div>
         </div>
-        {{#if tsm.isPending}}
-          <div class="timesheet-row timesheet-actions">
-            <button type="button" class="btn btn-primary" {{action "editAction" tsm}} disabled={{tsm.isSaving}}>Edit</button>
-            <button type="button" class="btn btn-light-red" {{action "deleteAction" tsm}} disabled={{tsm.isSaving}}>
-              {{#if tsm.isSaving}}
-                Deleting {{fa-icon "spinner" spin=true}}
+        <div class="timesheet-row timesheet-actions">
+          {{#if (or tsm.isPending tsm.isRejected)}}
+            <button type="button" class="btn btn-primary" {{action "editAction" tsm}} disabled={{tsm.isSaving}}>
+              {{#if tsm.isRejected}}
+                Submit Appeal
               {{else}}
-                Delete
+                Edit
               {{/if}}
             </button>
-          </div>
-        {{/if}}
+            {{#if tsm.isPending}}
+              <button type="button" class="btn btn-danger" {{action "deleteAction" tsm}} disabled={{tsm.isSaving}}>
+                {{#if tsm.isSaving}}
+                  Deleting {{fa-icon "spinner" spin=true}}
+                {{else}}
+                  Delete
+                {{/if}}
+              </button>
+            {{/if}}
+          {{/if}}
+        </div>
       </div>
     {{/each}}
   </div>
@@ -88,7 +96,16 @@
       <li>Was another person responsible for checking you in, and why did they fail to do that?</li>
       <li>If you called Ranger HQ on the radio to check you in for the shift, who was the Ranger on the other end?</li>
     </ul>
-    {{f.input "notes" label="Why is this new entry needed?" type="textarea" cols=80 rows=4}}
+    {{#if entry.isRejected}}
+      <b class="text-danger">The correction request has been rejected.</b>
+      <div class="card mb-4">
+        <div class="card-header">The timesheet correction team has left you a note:</div>
+        <div class="card-body">
+          {{entry.reviewer_notes}}
+        </div>
+      </div>
+    {{/if}}
+    {{f.input "notes" label=(if entry.isRejected "Supply additional information for an appeal:" "Why is this new entry needed?") type="textarea" cols=80 rows=4}}
     {{f.submit label=(if f.model.isNew "Submit New Request" "Update Request") disabled=isSubmitting}}
     {{f.cancel disabled=isSubmitting}}
     {{#if isSubmitting}}

--- a/app/templates/components/me/timesheet-review-common.hbs
+++ b/app/templates/components/me/timesheet-review-common.hbs
@@ -36,29 +36,22 @@
         <div class="timesheet-row d-print-none">
           <div>
             {{#if ts.off_duty}}
-              {{#if ts.isApproved}}
+              {{#if ts.verified}}
+                <span class="text-success">{{fa-icon "check"}} Entry was marked correct on {{shift-format ts.verified_at}}</span>
+              {{else if ts.isApproved}}
                 The correction request has been APPROVED.
-                The timesheet has been updated with the new times.
+                The timesheet has been updated.
               {{else if ts.isRejected}}
-                The correction request has been denied. Contact
-                {{general-support-email}} if you wish to appeal this decision.
-
-                {{#if ts.haveReviewerResponse}}
-                  <p class="text-bold">Response from the timesheet review team:</p>
-                  <p>{{ts.reviewer_notes}}</p>
-                {{/if}}
-
+                The correction request has been denied.
               {{else if ts.isPendingReview }}
                 <span class="text-info font-weight-bold">The correction request is pending review.</span>
               {{else if ts.isUnverified}}
                 <strong>This entry has not been verified.</strong>
-              {{else if ts.verified}}
-                <span class="text-success">{{fa-icon "check"}} Entry was marked correct on {{shift-format ts.verified_at}}</span>
               {{else}}
                 Unknown state?
               {{/if}}
 
-              {{#if (and ts.haveReviewerResponse (not ts.verified) (or ts.isApproved ts.isRejected))}}
+              {{#if (and ts.haveReviewerResponse (not ts.verified))}}
                 <p class="text-bold">Response from the timesheet review team:</p>
                 <p>{{ts.reviewer_notes}}</p>
               {{/if}}
@@ -72,12 +65,14 @@
           {{#if ts.off_duty}}
             {{#unless ts.verified}}
               <button type="button" class="btn btn-success" {{action markCorrectAction ts}} disabled={{isSubmitting}}>
-                  Mark Entry Correct
+                Mark Entry Correct
               </button>
             {{/unless}}
             <button type="button" class="btn btn-secondary" {{action markIncorrectAction ts}} disabled={{isSubmitting}}>
               {{#if ts.isPendingReview}}
                 Edit Correction Note
+              {{else if (and ts.isRejected (not ts.verified))}}
+                Submit Appeal
               {{else}}
                 Mark Entry Incorrect
               {{/if}}
@@ -129,14 +124,6 @@
       <dd class="col-sm-10">{{credits-format entry.credits}}</dd>
     </dl>
 
-    {{#if entry.reviewer_notes}}
-      <div class="card mb-4">
-        <div class="card-header">The timesheet correction team has left you a note:</div>
-        <div class="card-body">
-          {{entry.reviewer_notes}}
-        </div>
-      </div>
-    {{/if}}
     <div class="form-row">
       Use the following area to explain why this entry is incorrect. Provide as
       much information as possible to help us understand why this entry should be fixed.
@@ -154,8 +141,17 @@
         {{/if}}
       </ul>
     </div>
-    {{f.input "notes" label="Your correction note:" type="textarea" cols=80 rows=3}}
-    {{f.submit label="Submit Correction" disabled=isSubmitting}}
+    {{#if entry.isRejected}}
+      <b class="text-danger">The correction request has been rejected.</b>
+      <div class="card mb-4">
+        <div class="card-header">The timesheet correction team has left you a note:</div>
+        <div class="card-body">
+          {{entry.reviewer_notes}}
+        </div>
+      </div>
+    {{/if}}
+    {{f.input "notes" label=(if entry.isRejected "Supply additional information for an apeal:" "Your correction note:") type="textarea" cols=80 rows=3}}
+    {{f.submit label="Submit Correction Request" disabled=isSubmitting}}
     {{f.cancel}}
     {{#if isSubmitting}}
       <span class="text-muted">Submitting {{fa-icon "spinner" spin=true}} . . .</span>

--- a/app/templates/components/person/timesheet-missing.hbs
+++ b/app/templates/components/person/timesheet-missing.hbs
@@ -1,6 +1,6 @@
 <div class="border rounded p-2 mt-2 mb-2">
   <h3>Missing Timesheet Requests</h3>
-  <div class="float-right"><button class="btn btn-secondary btn-sm" {{action newEntryAction}}>New Request</button></div>
+  <div class="float-right"><button class="btn btn-secondary" {{action newEntryAction}}>New Request</button></div>
   {{pluralize timesheetMissing.length "missing entry request"}}
   {{#if timesheetMissing}}
     <table class="table table-striped table-sm">

--- a/app/templates/me/timesheet-corrections.hbs
+++ b/app/templates/me/timesheet-corrections.hbs
@@ -1,7 +1,7 @@
 <h1>Timesheet Corrections for <span class="d-inline-block">{{person.callsign}}</span></h1>
 
 {{#if (or unverifiedCount correctionPendingReviewCount missingPendingReviewCount)}}
-  <div class="text-danger">
+  <p class="h4 text-danger">
     {{#if unverifiedCount}}
       You need to review {{pluralize unverifiedCount "timesheet entry"}}.<br>
     {{/if}}
@@ -12,7 +12,7 @@
     {{#if missingPendingReviewCount}}
       {{pluralize missingPendingReviewCount "missing timesheet entry request"}} {{if (eq missingPendingReviewCount 1) "is" "are"}} pending review.<br>
     {{/if}}
-  </div>
+  </p>
 {{else if timesheetInfo.timesheet_confirmed}}
   {{#ch-alert "success"}}
     {{fa-icon "thumbs-up" type="far"}} <strong>Congratulations!</strong> All your timesheet


### PR DESCRIPTION
- Allow a person to appeal a missing timesheet request.
- Complain if the person hit submit on a correction dialog and did not actual change/enter anything.
- Use new is_incorrect flag (meta column) to differentiate between simply changing the verify flag versus
  marking an incorrect incorrect.
- Give the person more info and change the field labels ) when editing/appealing a rejected correction.
- On a shift sign in error (untrained, unqualified, etc.) use modal dialog instead of toast errors.
041da28
