### PR TITLE
More timesheet work.

### DIFF
--- a/app/components/me/timesheet-missing-common.js
+++ b/app/components/me/timesheet-missing-common.js
@@ -65,7 +65,13 @@ export default class MeTimesheetMissingCommonComponent extends Component {
   // Edit an existing request
   @action
   editAction(timesheetMissing) {
-    this.set('entry', timesheetMissing);
+    timesheetMissing.reload().then(() => {
+      if (timesheetMissing.isApproved) {
+        this.modal.info('Missing Timesheet Entry Request Approved!', 'Hold up! The timesheet entry has been approved since this page has been refreshed.');
+        return;
+      }
+      this.set('entry', timesheetMissing);
+    }).catch((response) => this.house.handleErrorResponse(response));
   }
 
   // Cancel the form

--- a/app/components/me/timesheet-review-common.js
+++ b/app/components/me/timesheet-review-common.js
@@ -41,7 +41,9 @@ export default class MeTimesheetReviewCommonComponent extends Component {
   // Setup to mark an entry as incorrect - i.e. display the form
   @action
   markIncorrectAction(timesheet) {
-    this.set('entry', timesheet);
+    timesheet.reload().then(() => {
+      this.set('entry', timesheet);
+    }).catch((response) => this.house.handleErrorResponse(response))
   }
 
   // Save correction notes
@@ -54,13 +56,11 @@ export default class MeTimesheetReviewCommonComponent extends Component {
     this.toast.clear();
 
     if (!model.get('isDirty')) {
-      this.set('entry', null);
-      this.modal.info('', 'You did not enter a new correction note. The correction was not submitted.');
+      this.modal.info('Enter More Information', 'You did not add to the correction note.');
       return;
     }
 
     model.set('verified', 0);
-    model.set('is_incorrect', 1);
 
     this.set('isSubmitting', true);
 

--- a/app/components/person/timesheet-manage.js
+++ b/app/components/person/timesheet-manage.js
@@ -58,8 +58,10 @@ export default class PersonTimesheetManageComponent extends Component {
   // Edit a timesheet - i.e. display the form
   @action
   editEntryAction(timesheet) {
-    this.set('editVerification', false);
-    this.set('editEntry', timesheet);
+    timesheet.reload().then(() => {
+      this.set('editVerification', false);
+      this.set('editEntry', timesheet);
+    }).catch((response) => this.house.handleErrorResponse(response));
   }
 
   // Cancel editing - i.e. hide the form

--- a/app/components/person/timesheet-missing.js
+++ b/app/components/person/timesheet-missing.js
@@ -52,15 +52,20 @@ export default class PersonTimesheetMissingComponent extends Component {
       }
     }
 
-    timesheet.set('new_on_duty', timesheet.on_duty);
-    timesheet.set('new_off_duty', timesheet.off_duty);
-    timesheet.set('new_position_id', timesheet.position_id);
-    timesheet.set('create_entry', 0);
+    timesheet.reload().then(() => {
+      timesheet.set('new_on_duty', timesheet.on_duty);
+      timesheet.set('new_off_duty', timesheet.off_duty);
+      timesheet.set('new_position_id', timesheet.position_id);
+      timesheet.set('create_entry', 0);
 
-    this.set('nextEntry', nextEntry);
-    this.set('editEntry', timesheet);
-    this.set('partnerInfo', timesheet.partner_info);
-    this.set('havePartnerTimesheet', false);
+      this.set('nextEntry', nextEntry);
+      this.set('editEntry', timesheet);
+      this.set('partnerInfo', timesheet.partner_info);
+      this.set('havePartnerTimesheet', false);
+    }).catch((response) => {
+      this.house.handleErrorResponse(response);
+      this.set('editEntry', null);
+    });
   }
 
   @action

--- a/app/components/shift-check-in-out.js
+++ b/app/components/shift-check-in-out.js
@@ -123,7 +123,7 @@ export default class ShiftCheckInOutComponent extends Component {
           } else {
             reason = `has not completed '${result.required_training}'`;
           }
-          this.modal.info('Sign in forced', `WARNING: The person ${reason}. Because you are an admin, we have signed them in anyways. Hope you know what you're doing! ${callsign} is now on duty.`);
+          this.modal.info('Sign In Forced', `WARNING: The person ${reason}. Because you are an admin, we have signed them in anyways. Hope you know what you're doing! ${callsign} is now on duty.`);
         } else {
           this.toast.success(`${callsign} is on shift. Happy Dusty Adventures!`);
         }

--- a/app/controllers/admin/bulk-upload.js
+++ b/app/controllers/admin/bulk-upload.js
@@ -36,7 +36,7 @@ export default class AdminBulkUploadController extends Controller {
       groupName: 'Vehicle Paperwork Flags',
       options: [
         { id: 'vehicle_paperwork', title: 'Signed Motorpool Agreement (gators/golf carts)' },
-        { id: 'vehicle_insurance_paperwork', title: 'Has Org Vehicle Insurance (trucks/SUVs)' },
+        { id: 'vehicle_insurance_paperwork', title: 'Has Motor Vehicle Record (MVR)' },
       ]
     },
     {

--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -135,7 +135,7 @@ export default class ApplicationController extends Controller {
    _modeRoutes = {
      'account':   'person.index',
      'hq':        'hq.index',
-     'timesheet': 'hq.timesheet'
+     'timesheet': 'person.timesheet'
    };
 
   _showPerson(person) {

--- a/app/models/timesheet.js
+++ b/app/models/timesheet.js
@@ -19,8 +19,6 @@ export default class TimesheetModel extends DS.Model {
   @attr('boolean') verified;
   @attr('string') verified_at;
 
-  @attr('boolean') is_incorrect;  // Mark entry as incorrect
-
   @attr('', { readOnly: true}) verified_person;
   @attr('', { readOnly: true}) reviewer_person;
   @attr('', { readOnly: true}) position;

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -105,6 +105,12 @@ $sizes: (
     margin: 0px !important;
     padding: 0px !important;
   }
+
+  a {
+      text-decoration: none !important;
+      color: #000 !important;
+  }
+
 }
 
 @media not print {

--- a/app/templates/admin/bulk-upload.hbs
+++ b/app/templates/admin/bulk-upload.hbs
@@ -1,17 +1,14 @@
 <h1>Bulk Upload</h1>
 
 <p>This page allows you to bulk upload a list of Rangers who should have
-  their Ranger vehicle paperwork checked, or their Org vehicle insurance
+  their Ranger vehicle paperwork checked, or their Motor Vehicle Record (MVR)
   checked, or who should be marked as eligible for an event radio, etc.</p>
 
 <p>Please select which action you want to take, and then enter Ranger
   callsigns in the big text input area below. Some actions require you to have
   comma-separated parameters after each Ranger's callsign.</p>
-
-<p>If you don't check the "Really, do the thing" box before clicking
-  "Submit" at the very bottom, the database won't be updated.
-  This is useful as a "dry run" feature to make sure that you don't
-  have typos in your list of callsigns.
+<p>
+  No changes will be made until you click on the 'Commit' button which appears after clicking on 'Verify Upload'.
 </p>
 
 {{#if actionResults}}
@@ -75,7 +72,7 @@
     <label class="col-form-label">Select bulk action:</label>
   </div>
   <div class="col-auto">
-      {{ch-form/select name="uploadAction" value=uploadAction options=uploadOptions
+    {{ch-form/select name="uploadAction" value=uploadAction options=uploadOptions
         includeBlank=true onChange=(action (mut uploadAction)) controlClass="form-control"}}
   </div>
 </div>

--- a/app/templates/components/me/timesheet-missing-common.hbs
+++ b/app/templates/components/me/timesheet-missing-common.hbs
@@ -36,15 +36,17 @@
         </div>
         <div class="timesheet-row timesheet-actions">
           {{#if (or tsm.isPending tsm.isRejected)}}
-            <button type="button" class="btn btn-primary" {{action "editAction" tsm}} disabled={{tsm.isSaving}}>
+            <button type="button" class="btn btn-primary" {{action "editAction" tsm}} disabled={{or tsm.isReloading tsm.isSaving}}>
               {{#if tsm.isRejected}}
                 Submit Appeal
+              {{else if tsm.isReloading}}
+                {{fa-icon "spinner" spin=true}}
               {{else}}
                 Edit
               {{/if}}
             </button>
             {{#if tsm.isPending}}
-              <button type="button" class="btn btn-danger" {{action "deleteAction" tsm}} disabled={{tsm.isSaving}}>
+              <button type="button" class="btn btn-danger" {{action "deleteAction" tsm}} disabled={{or tsm.isReloading tsm.isSaving}}>
                 {{#if tsm.isSaving}}
                   Deleting {{fa-icon "spinner" spin=true}}
                 {{else}}

--- a/app/templates/components/me/timesheet-review-common.hbs
+++ b/app/templates/components/me/timesheet-review-common.hbs
@@ -68,7 +68,7 @@
                 Mark Entry Correct
               </button>
             {{/unless}}
-            <button type="button" class="btn btn-secondary" {{action markIncorrectAction ts}} disabled={{isSubmitting}}>
+            <button type="button" class="btn btn-secondary" {{action markIncorrectAction ts}} disabled={{ts.isLoading}}>
               {{#if ts.isPendingReview}}
                 Edit Correction Note
               {{else if (and ts.isRejected (not ts.verified))}}
@@ -77,6 +77,9 @@
                 Mark Entry Incorrect
               {{/if}}
             </button>
+            {{#if ts.isReloading}}
+              <span class="text-muted">Loading {{fa-icon "spinner" spin=true}}</span>
+            {{/if}}
           {{/if}}
           {{#if ts.isSaving}}
             <span class="ml-2 text-muted">Submitting {{fa-icon "spinner" spin=true}}</span>

--- a/app/templates/components/person/timesheet-manage.hbs
+++ b/app/templates/components/person/timesheet-manage.hbs
@@ -7,7 +7,7 @@
   <span class="d-inline-block">{{fa-icon "thumbs-up" type="far"}} = correction approved, awaiting verify.</span>
   <span class="d-inline-block">{{fa-icon "question-circle" type="far"}} = correction needs more info.</span>
   <span class="d-inline-block">(hh:mm) = time in parentheses indicates the time does not count towards appreciations.
-</span>
+  </span>
 
   {{#if timesheets}}
     <table class="table table-striped table-sm">
@@ -65,9 +65,17 @@
               {{#if (is-empty ts.off_duty)}}
                 <button type="button" class="btn btn-danger btn-sm" {{action "signoffAction" ts}}>End Shift</button>
               {{else }}
-                <button type="button" class="btn btn-primary btn-sm" {{action "editEntryAction" ts}}>Edit</button>
+                <button type="button" class="btn btn-primary btn-sm" {{action "editEntryAction" ts}} disabled={{ts.isReloading}}>
+                  {{#if ts.isReloading}}
+                    {{fa-icon "spinner" spin=true}}
+                  {{else}}
+                    Edit
+                  {{/if}}
+                </button>
                 {{#if canManageTimesheets}}
-                  <button type="button" class="btn btn-secondary btn-sm" {{action "removeEntryAction" ts}} title="Delete timesheet entry">{{fa-icon "trash"}}</button>
+                  <button type="button" class="btn btn-secondary btn-sm" {{action "removeEntryAction" ts}} title="Delete timesheet entry" disabled={{ts.isReloading}}>
+                    {{fa-icon "trash"}}
+                  </button>
                 {{/if}}
               {{/if}}
             </td>
@@ -138,7 +146,8 @@
             </div>
           </div>
           <div class="form-row">
-            {{f.input "notes" label="Correction Request Notes:" type="textarea" cols=80 rows=3}}
+            <div class="col-12 text-danger">Updating the correction note will automatically mark the entry as incorrect / unverified</div>
+            {{f.input "notes" label="Correction Request Notes:" type="textarea" cols=80 rows=5}}
           </div>
         {{else}}
           <div class="form-row">

--- a/app/templates/components/person/timesheet-missing.hbs
+++ b/app/templates/components/person/timesheet-missing.hbs
@@ -35,8 +35,14 @@
             <td class="text-right">{{credits-format tm.credits}}</td>
             <td>{{tm.position.title}}</td>
             <td>
-              <button class="btn btn-primary btn-sm" {{action editEntryAction tm}}>Manage</button>
-              <button class="btn btn-secondary btn-sm" {{action removeEntryAction tm}} title="Delete">{{fa-icon "trash"}}</button>
+              <button class="btn btn-primary btn-sm" {{action editEntryAction tm}} disabled={{tm.isReloading}}>
+                {{#if tm.isReloading}}
+                  {{fa-icon "spinner" spin=true}}
+                {{else}}
+                  Manage
+                {{/if}}
+              </button>
+              <button class="btn btn-secondary btn-sm" {{action removeEntryAction tm}} title="Delete" disabled={{tm.isReloading}}>{{fa-icon "trash"}}</button>
             </td>
           </tr>
         {{/each}}


### PR DESCRIPTION
- Change button labeling to 'Submit Appeal' when entering a new note after request was denied.
- Reload the timesheet and missing timesheet request when editing to pick up the most recent changes.
  (Person may be idled on the timesheet corrections page and a correction may have happened during that time.)
- Corrected text on bulk uploader.
- Removed hyperlink blue and underline when printing the page.