### PR TITLE
Timesheet corrections work. Clubhouse messages tweaks.

### DIFF
--- a/app/components/clubhouse-messages.js
+++ b/app/components/clubhouse-messages.js
@@ -57,15 +57,30 @@ export default class ClubhouseMessagesComponent extends Component {
 
   @action
   markReadAction(message) {
+    this._markMessage(message, true);
+  }
+
+  @action
+  markUnreadAction(message) {
+    this._markMessage(message, false);
+  }
+
+  _markMessage(message, delivered) {
     message.set('isSubmitting', true);
-    return message.markRead().then(() => {
+    this.ajax.request(`messages/${message.id}/markread`, {
+      method: 'PATCH',
+      data: { delivered }
+    }).then(() => {
       message.set('isSubmitting', false);
-      message.set('delivered', true);
+      message.set('delivered', delivered);
       this._updateUnreadCount();
-    }).catch((response) => {
-      message.set('isSubmitting', false);
+    })
+    .catch((response) => {
       this.house.handleErrorResponse(response);
     })
+    .finally(() => {
+      message.set('isSubmitting', false);
+    });
   }
 
   @action

--- a/app/components/message-new.js
+++ b/app/components/message-new.js
@@ -15,6 +15,12 @@ export default class MessageNewComponent extends Component {
   personMessageValidations = PersonMessageValidations;
 
   _performSearch(callsign, resolve, reject) {
+    callsign = callsign.trim();
+
+    if (callsign.length < 2) {
+      return reject();
+    }
+
     return this.ajax
           .request('callsigns', { data: {query: callsign, type: "message", limit: 20} })
           .then((result) => {

--- a/app/controllers/reports/timesheet-correction-requests.js
+++ b/app/controllers/reports/timesheet-correction-requests.js
@@ -1,33 +1,53 @@
 import Controller from '@ember/controller';
-import { action, computed } from '@ember/object';
+import { computed } from '@ember/object';
 
 export default class ReportsTimesheetCorrectionRequestsController extends Controller {
   queryParams = [ 'year' ];
 
-  @computed('corrections')
+  @computed('requests')
   get groupedCorrections() {
     const groups = [];
 
-    if (this.corrections == null) {
+    if (this.requests == null) {
       return groups;
     }
 
-    this.corrections.forEach((correction) => {
-      const value = correction.person.callsign;
+    this.requests.forEach((request) => {
+      const value = request.person.callsign;
       let group = groups.findBy('callsign', value);
 
       if (group) {
-        group.requests.push(correction);
+        group.requests.push(request);
       } else {
-        groups.push({callsign: value, requests: [ correction ]});
+        groups.push({callsign: value, requests: [ request ]});
       }
     });
 
     return groups;
   }
 
-  @action
-  changeYear(year) {
-    this.set('year', year);
+  @computed('groupedCorrections')
+  get letterOptions() {
+    let letters = {};
+    this.groupedCorrections.forEach((group) => {
+        letters[group.callsign.charAt(0).toUpperCase()] = 1;
+    });
+
+    letters = Object.keys(letters).sort();
+    letters.unshift('All');
+
+    return letters;
+  }
+
+  @computed('groupedCorrections', 'callsignFilter')
+  get viewGroupCorrections() {
+    const requests = this.groupedCorrections;
+    const filter = this.callsignFilter;
+
+    if (filter == 'All') {
+      return requests;
+    }
+
+    return requests.filter((group) => (group.callsign.charAt(0).toUpperCase() == filter));
   }
 }

--- a/app/models/person-message.js
+++ b/app/models/person-message.js
@@ -1,7 +1,6 @@
 import DS from 'ember-data';
 import { computed } from '@ember/object';
 const { attr } = DS;
-import { memberAction } from 'ember-api-actions';
 
 export default class PersonMessageModel extends DS.Model {
   @attr('number') person_id;
@@ -26,6 +25,4 @@ export default class PersonMessageModel extends DS.Model {
   get isDictacted() {
       return (this.creator_person_id != this.sender_person_id);
   }
-
-  markRead = memberAction({ path: 'markread', type: 'patch'});
 }

--- a/app/routes/hq/timesheet.js
+++ b/app/routes/hq/timesheet.js
@@ -14,6 +14,7 @@ export default class HqTimesheetRoute extends Route {
         data: { person_id }
       }).then((result) => result.info),
       timesheetsMissing: this.store.query('timesheet-missing', { person_id, year }).then((result) => result.toArray()),
+      correctionPositions: this.ajax.request(`person/${person_id}/positions`,{ data: { include_mentee: 1 } }).then((results) => results.positions),
     });
   }
 

--- a/app/routes/me/timesheet-corrections.js
+++ b/app/routes/me/timesheet-corrections.js
@@ -29,7 +29,7 @@ export default class MeTimesheetCorrectionsRoute extends Route.extend(MeRouteMix
 
       data.timesheets = this.store.query('timesheet', queryParams);
       data.timesheetsMissing = this.store.query('timesheet-missing', queryParams).then((result) => result.toArray());
-      data.positions =  this.ajax.request(`person/${person_id}/positions`).then((result) => result.positions);
+      data.positions =  this.ajax.request(`person/${person_id}/positions`, { data: { include_mentee: 1 }}).then((result) => result.positions);
       data.timesheetSummary = this.ajax.request(`person/${person_id}/timesheet-summary`, { data: { year }}).then((result) => result.summary);
 
       return RSVP.hash(data);

--- a/app/routes/person/timesheet.js
+++ b/app/routes/person/timesheet.js
@@ -24,7 +24,7 @@ export default class PersonTimesheetRoute extends Route {
       timesheetInfo: this.ajax.request('timesheet/info', { data: { person_id } })
         .then((result) => result.info),
       timesheetMissing: this.store.query('timesheet-missing', queryParams),
-      positions: this.ajax.request(`person/${person_id}/positions`,{ data: { include_training: 1, year } })
+      positions: this.ajax.request(`person/${person_id}/positions`,{ data: { include_mentee: 1, year } })
         .then((results) => results.positions),
       timesheetSummary: this.ajax.request(`person/${person_id}/timesheet-summary`, { data: { year }})
         .then((result) => result.summary),

--- a/app/routes/reports/timesheet-correction-requests.js
+++ b/app/routes/reports/timesheet-correction-requests.js
@@ -21,6 +21,7 @@ export default class ReportsTimesheetCorrectionRequestsRoute extends Route {
   setupController(controller, model) {
     // corrections, missing_requests
     controller.setProperties(model);
+    controller.set('callsignFilter', 'All');
   }
 
   resetController(controller, isExiting) {

--- a/app/templates/components/clubhouse-messages.hbs
+++ b/app/templates/components/clubhouse-messages.hbs
@@ -36,16 +36,14 @@
     <div class="card mb-2">
       <div class="card-body">
         <div class="row">
-          <div class="col-sm-12 col-md-6">
-            From: <strong>{{message.message_from}}</strong>
+          <div class="col-sm-12 col-md-8">
+            <h5>From: {{message.message_from}}</h5>
+            <h5>{{#unless message.delivered}}<span class="text-danger">&bullet;</span> {{/unless}}Subject: {{message.subject}}</h5>
             {{#if message.isDictacted}}
-              <small class="text-muted">(written by {{message.creator_callsign}})</small>
+              <div class="text-muted">(written by {{message.creator_callsign}})</div>
             {{/if}}
-            <div class="font-weight-bold">
-              {{#unless message.delivered}}<span class="text-danger">&bullet;</span> {{/unless}}Subject: {{message.subject}}
-            </div>
           </div>
-          <div class="col-sm-12 col-md-4">
+          <div class="col-sm-12 col-md-4 text-md-right">
             {{shift-format message.sent_at}}
             <div class="text-muted small">({{moment-from-now message.sent_at}})</div>
           </div>
@@ -54,15 +52,18 @@
           {{message.body}}
         </div>
         <div class="mt-3">
-          {{#unless message.delivered}}
-            <button {{action "markReadAction" message}} type="button" class="btn btn-secondary" disabled={{isSubmitting}}>
-              {{#if message.isSubmitting}}
-                Marking Read {{fa-icon "spinner" spin=true}}
-              {{else}}
-                Mark Read
-              {{/if}}
+          {{#if message.delivered}}
+            <button {{action markUnreadAction message}} type="button" class="btn btn-secondary" disabled={{isSubmitting}}>
+              Mark Unread
             </button>
-          {{/unless}}
+          {{else}}
+            <button {{action markReadAction message}} type="button" class="btn btn-primary" disabled={{isSubmitting}}>
+              Mark Read
+            </button>
+          {{/if}}
+          {{#if message.isSubmitting}}
+            <SubmittingIndicator />
+          {{/if}}
         </div>
       </div>
     </div>

--- a/app/templates/components/message-new.hbs
+++ b/app/templates/components/message-new.hbs
@@ -27,6 +27,9 @@
   </div>
   {{f.input "subject" label="Subject" maxlength=80}}
   {{f.input "body" label="The message (be civil, courteous, polite, & professional)" type="textarea" rows=4 cols=8}}
-  {{f.submit label=(if isSubmitting "Sending" "Send") disabled=isSubmitting}}
+  {{f.submit label="Send" disabled=isSubmitting}}
   {{f.cancel disabled=isSubmitting}}
+  {{#if isSubmitting}}
+    <SubmittingIndicator @text="Sending Message" />
+  {{/if}}
 {{/ch-form}}

--- a/app/templates/hq/timesheet.hbs
+++ b/app/templates/hq/timesheet.hbs
@@ -12,4 +12,4 @@
 
 <hr class="mb-4">
 <h3>Missing Timesheet Entry Requests  {{help-popover slug="hq-missing-timesheets"}}</h3>
-{{me/timesheet-missing-common person=person timesheetsMissing=timesheetsMissing timesheetInfo=timesheetInfo positions=positions}}
+{{me/timesheet-missing-common person=person timesheetsMissing=timesheetsMissing timesheetInfo=timesheetInfo positions=correctionPositions}}

--- a/app/templates/me.hbs
+++ b/app/templates/me.hbs
@@ -1,6 +1,6 @@
 {{! Besure to keep application.hbs in sync with the links}}
 {{#ch-sidebar}}
-  {{#ch-sidebar-group "RANGERING"}}
+  {{#ch-sidebar-group "ME MENU"}}
     {{ch-sidebar-link "me.schedule" title="Schedule / Sign Up" icon="clipboard"}}
     {{#if (or user.isAlpha user.isNonRanger user.isRanger)}}
       {{ch-sidebar-link "me.timesheet-corrections.index" title="Timesheet Corrections" icon="list-ol" iconType="s"}}

--- a/app/templates/reports/timesheet-correction-requests.hbs
+++ b/app/templates/reports/timesheet-correction-requests.hbs
@@ -1,10 +1,19 @@
-{{year-select "Timesheet Corrections Report" year=year onChange=(action "changeYear")}}
+{{year-select "Timesheet Corrections Report" year=year onChange=(action (mut year))}}
+
+<div class="form-row mb-1">
+  <div class="col-auto">
+    <label class="col-form-label">Filter requests by callsigns starting with</label>
+  </div>
+  <div class="col-auto mb-2">
+    {{ch-form/select name="callsignFilter" value=callsignFilter options=letterOptions onChange=(action (mut callsignFilter)) controlClass="form-control"}}
+  </div>
+</div>
 
 <table class="table table-hover table-box">
-  <caption>Timesheet Entry Corrections</caption>
   <thead>
     <tr>
       <th>Callsign</th>
+      <th>Type</th>
       <th>Position</th>
       <th>On Duty</th>
       <th>Off Duty</th>
@@ -13,87 +22,33 @@
     </tr>
   </thead>
   <tbody>
-    {{#each groupedCorrections as |corrections|}}
-      {{#each corrections.requests as |correction idx|}}
+    {{#each viewGroupCorrections as |person|}}
+      {{#each person.requests as |request idx|}}
         <tr class="{{if idx "no-border"}}">
           <td>
             {{#unless idx}}
-              {{person-link person=correction.person page="timesheet" year=year}}
+              {{person-link person=request.person page="timesheet" year=year}}
             {{else}}
               &nbsp;
             {{/unless}}
           </td>
-          <td>{{correction.position.title}}</td>
-          <td>{{shift-format correction.on_duty}}</td>
-          <td>{{shift-format correction.off_duty}}</td>
-          <td>{{hour-minute-format correction.duration}}</td>
-          <td>{{credits-format correction.credits}}</td>
+          <td>{{if request.is_missing "Missing Entry" "Correction"}}</td>
+          <td>{{request.position.title}}</td>
+          <td>{{shift-format request.on_duty}}</td>
+          <td>{{shift-format request.off_duty}}</td>
+          <td>{{hour-minute-format request.duration}}</td>
+          <td>{{credits-format request.credits}}</td>
         </tr>
         <tr class="no-border">
           <td>&nbsp;</td>
-          <td colspan="5">
-            Note: {{correction.notes}}
+          <td colspan="6">
+            Note: {{request.notes}}
           </td>
         </tr>
       {{/each}}
     {{else}}
       <tr>
-        <td colspan="6">Congratulations! There are no timesheet corrections.</td>
-      </tr>
-    {{/each}}
-  </tbody>
-</table>
-
-
-<table class="table table-hover table-box">
-  <caption>Missing Timesheet Entry Requests</caption>
-  <thead>
-    <tr>
-      <th>Callsign</th>
-      <th>Position</th>
-      <th>On Duty</th>
-      <th>Off Duty</th>
-      <th>Duration</th>
-      <th>Credits</th>
-    </tr>
-  </thead>
-  <tbody>
-    {{#each missing_requests as |missing|}}
-      <tr>
-        <td>
-          {{person-link person=missing.person page="timesheet" year=year}}
-        </td>
-        <td>{{missing.position.title}}</td>
-        <td>{{shift-format missing.on_duty}}</td>
-        <td>{{shift-format missing.off_duty}}</td>
-        <td>{{hour-minute-format missing.duration}}</td>
-        <td>{{credits-format missing.credits}}</td>
-      </tr>
-      <tr class="no-border">
-        <td>&nbsp;</td>
-        <td colspan="5">
-          {{#if missing.partner_info}}
-            {{#each missing.partner_info as |partner|}}
-              Partner:
-              {{#if partner.person_id}}
-                {{person-link personId=partner.person_id callsign=partner.callsign page="timesheet"}}
-                {{#if partner.timesheet_id}}
-                  {{partner.position_title}} {{shift-format partner.on_duty}} to {{shift-format partner.off_duty}}
-                {{else}}
-                  <i class="text-muted">no corresponding timesheet found starting within 30 mins.</i>
-                {{/if}}
-              {{else}}
-                <i>Callsign "{{partner.callsign}}" not found</i>
-              {{/if}}
-              <br>
-            {{/each}}
-          {{/if}}
-          <p>Note: {{missing.notes}}</p>
-        </td>
-      </tr>
-    {{else}}
-      <tr>
-        <td colspan="5">Congratulations! There are no missing timesheet requests.</td>
+        <td colspan="7" class="text-success">Congratulations! There are no outstanding timesheet corrections or missing timesheet requests.</td>
       </tr>
     {{/each}}
   </tbody>

--- a/config/deploy.js
+++ b/config/deploy.js
@@ -9,27 +9,7 @@ module.exports = function (deployTarget) {
     build: {},
     // include other plugin configuration that applies to all deploy targets here
 
-    // Do not try to DRY up s3 & s3-index - both object are manipulated as the buid proceeds.
-    s3: {
-      filePattern: '**/*.{js,css,png,gif,ico,jpg,map,xml,txt,svg,swf,eot,ttf,woff,woff2,html}',
-      accessKeyId: process.env.RANGER_CLUBHOUSE_S3_ACCESS_KEY,
-      secretAccessKey: process.env.RANGER_CLUBHOUSE_S3_SECRET_KEY,
-      bucket: (process.env.RANGER_CLUBHOUSE_AWS_S3_BUCKET || 'ranger-town'),
-      region: (process.env.RANGER_CLUBHOUSE_AWS_S3_REGION || 'us-west-2'),
-      prefix: s3Prefix,
-    },
-
-    's3-index': {
-      accessKeyId: process.env.RANGER_CLUBHOUSE_S3_ACCESS_KEY,
-      secretAccessKey: process.env.RANGER_CLUBHOUSE_S3_SECRET_KEY,
-      bucket: (process.env.RANGER_CLUBHOUSE_S3_BUCKET || 'ranger-town'),
-      region: (process.env.RANGER_CLUBHOUSE_S3_REGION || 'us-west-2'),
-      prefix: s3Prefix,
-
-      allowOverwrite: true,
-    },
-
-    };
+  };
 
   if (deployTarget === 'development') {
     ENV.build.environment = 'development';

--- a/config/deploy.js
+++ b/config/deploy.js
@@ -2,9 +2,6 @@
 'use strict';
 
 module.exports = function (deployTarget) {
-
-  let s3Prefix = (process.env.RANGER_CLUBHOUSE_CLIENT_PREFIX || 'client').replace(/^\//, '');
-
   let ENV = {
     build: {},
     // include other plugin configuration that applies to all deploy targets here

--- a/config/targets.js
+++ b/config/targets.js
@@ -1,18 +1,22 @@
 'use strict';
 
 const browsers = [
-//  'last 1 edge versions',
+  'last 1 edge versions',
   'last 1 Chrome versions',
   'last 1 Firefox versions',
   'last 1 Safari versions'
 ];
 
+/*
 const isCI = !!process.env.CI;
 const isProduction = process.env.EMBER_ENV === 'production';
+
+IE 11 is no longer supported..
 
 if (isCI || isProduction) {
   browsers.push('ie 11');
 }
+*/
 
 module.exports = {
   browsers


### PR DESCRIPTION
- Timesheet correction report combines corrections and missing timesheet requests into one table per suggestion from the timesheet correction team.
- Said report has a callsign letter filter to narrow down the report.
- Include all mentee positions when creating a new missing timesheet entry
- Allow a Clubhouse message to be mark as unread.
- Removed IE11 as a build target. (No user has logged in with said browser - less than 2% world usage.)