### PR TITLE
Switch the view immediately when the user selects a new search mode

### DIFF
--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -339,7 +339,7 @@
             {{/power-select-typeahead}}
           </div>
           <div class="col-auto mt-2 mt-sm-0 no-gutters">
-            {{f.input "mode" type="select" options=modeOptions controlClass="form-control form-control-sm"}}
+            {{f.input "mode" type="select" options=modeOptions onChange=this.modeChange controlClass="form-control form-control-sm"}}
           </div>
         </div>
         {{#if showSearchOptions}}

--- a/app/templates/loading.hbs
+++ b/app/templates/loading.hbs
@@ -1,0 +1,1 @@
+<LoadingDialog />


### PR DESCRIPTION
in the search bar, and the current page is hq or person page.
(e..g, The user is viewing Hubcap under Person Mange, and they
really wanted the HQ Window view -- when they select 'HQ Window'
in the search bar, immediately change to the HQ Window view for
Hubcap.)