### PR TITLE
Restructure training table on the Event/Training info pages.

### DIFF
--- a/app/components/shift-check-in-out.js
+++ b/app/components/shift-check-in-out.js
@@ -93,7 +93,7 @@ export default class ShiftCheckInOutComponent extends Component {
       return true;
     }
 
-    return !!this.eventInfo.trainings.find((training) => (training.position_id == Position.DIRT && training.status == 'pass'));
+    return !!this.eventInfo.trainings.find((training) => (training.position_id == Position.TRAINING && training.status == 'pass'));
   }
 
   // Find the on duty shift

--- a/app/components/training-info.js
+++ b/app/components/training-info.js
@@ -1,6 +1,20 @@
-import Component from '@ember/component';
-
+import Component from '@glimmer/component';
+import { computed } from '@ember/object';
 
 export default class TrainingInfoComponent extends Component {
-  trainings = null;
+  @computed('args.trainings')
+  get hasNotGrantedPositions() {
+    let notGranted = false;
+    this.args.trainings.forEach((training) => {
+      if (!training.required_by) {
+        return;
+      }
+
+      if (training.required_by.find((p) => p.not_granted)) {
+        notGranted = true;
+      }
+    });
+
+    return notGranted
+  }
 }

--- a/app/controllers/hq/site-checkin.js
+++ b/app/controllers/hq/site-checkin.js
@@ -10,7 +10,7 @@ export default class HqSiteCheckinController extends Controller {
 
   @computed('eventInfo.trainings')
   get dirtTraining() {
-    return this.eventInfo.trainings.find((training) => training.position_id == Position.DIRT);
+    return this.eventInfo.trainings.find((training) => training.position_id == Position.TRAINING);
   }
 
   @computed('eventInfo.training.@each.position_id')

--- a/app/controllers/me/event-info.js
+++ b/app/controllers/me/event-info.js
@@ -1,17 +1,30 @@
 import Controller from '@ember/controller';
 import { action, computed } from '@ember/object';
+import * as Position from 'clubhouse/constants/positions';
 
 export default class MeRangerInfoShowController extends Controller {
-  queryParams = [ 'year' ];
+  queryParams = ['year'];
 
   @computed('eventInfo.trainings')
   get dirtTraining() {
-    return this.eventInfo.trainings.find((training) => training.position_id == 2);
+    return this.eventInfo.trainings.find((training) => training.position_id == Position.TRAINING);
   }
 
   @computed('eventInfo.trainings')
   get artTrainings() {
-    return this.eventInfo.trainings.filter((training) => training.position_id != 2);
+    return this.eventInfo.trainings.filter((training) => training.position_id != Position.TRAINING);
+  }
+
+  @computed('eventInfo.trainings')
+  get artPositionCount() {
+    let count = 0;
+
+    this.eventInfo.trainings.forEach((t) => {
+      if (t.position_id != Position.TRAINING) {
+        count += t.required_by.length;
+      }
+    });
+    return count;
   }
 
   @computed('year')

--- a/app/templates/components/training-info.hbs
+++ b/app/templates/components/training-info.hbs
@@ -1,43 +1,75 @@
-<div class="table-responsive mt-2">
+<div class="table-responsive my-2">
   <table class="table table-sm table-width-auto">
     <thead>
       <tr>
-        <th>Position</th>
-        <th>Pass</th>
+        <th>Training</th>
+        <th>Required For</th>
+        <th>Trained?</th>
         <th>Date</th>
         <th>Location</th>
       </tr>
     </thead>
     <tbody>
-      {{#each trainings as |training|}}
+      {{#each @trainings as |training|}}
         <tr>
           <td>{{training.position_title}}</td>
           <td>
-            {{#if (eq training.status "pass")}}
-              <span class="text-success">YES</span>
-            {{else if (eq training.status "pending")}}
-              Pending
-            {{else if (eq training.status "no-shift")}}
+            {{#each training.required_by as |position|}}
+              {{#if position.not_granted}}
+                <i>*{{position.title}}</i>
+              {{else}}
+                {{position.title}}
+              {{/if}}
+              <br>
+            {{/each}}
+          </td>
+          {{#if (eq training.status "no-shift")}}
+            <td colspan="3">
               <span class="text-danger">No training sign up found</span>
-            {{else if (eq training.status "no-show")}}
-              <span class="text-danger">No show</span>
-            {{else}}
-              <span class="text-danger">NO</span>
-            {{/if}}
-            {{#if training.is_trainer}}
-              (as trainer)
-            {{/if}}
-          </td>
-          <td>
-            {{#if training.date}}
-              {{mdy-format training.date}}
-            {{else}}
-              -
-            {{/if}}
-          </td>
-          <td>{{present-or-not training.location "-"}}</td>
+            </td>
+          {{else}}
+            <td>
+              {{#if (eq training.status "pass")}}
+                <span class="text-success">{{fa-icon "check"}} TRAINED</span>
+              {{else if (eq training.status "pending")}}
+                Pending
+              {{else if (eq training.status "no-show")}}
+                <span class="text-danger">{{fa-icon "ban"}} No Show</span>
+              {{else}}
+                <span class="text-danger">{{fa-icon "ban"}} UNTRAINED</span>
+              {{/if}}
+              {{#if training.is_trainer}}
+                (as trainer)
+              {{/if}}
+            </td>
+            <td>
+              {{#if training.date}}
+                {{mdy-format training.date}}
+              {{else}}
+                -
+              {{/if}}
+            </td>
+            <td>{{present-or-not training.location "-"}}</td>
+          {{/if}}
         </tr>
+        {{#if training.is_green_dot_pnv}}
+          <tr class="tr-no-border">
+            <td colspan="5">
+              In order to become a Green Dot, a person must be Green Dot TRAINED and PASS a Green Dot mentee shift.<br>
+              {{#if training.mentee_timesheet}}
+                A mentee shift was worked on {{shift-format training.mentee_timesheet.on_duty}}. Check with a Green Dot trainer to see if the mentee shift was passed.
+              {{else if training.mentee_slot}}
+                A mentee shift has been signed up for starting {{shift-format training.mentee_slot.begins}} but no mentee shift has been walked (yet).
+              {{else}}
+                <span class="text-danger">No Green Dot Mentee shift sign up was found.</span>
+              {{/if}}
+            </td>
+          </tr>
+        {{/if}}
       {{/each}}
     </tbody>
   </table>
+  {{#if this.hasNotGrantedPositions}}
+    * = The position will be granted once all ART training requirements have been passed.
+  {{/if}}
 </div>

--- a/app/templates/hq/training-info.hbs
+++ b/app/templates/hq/training-info.hbs
@@ -1,7 +1,7 @@
-<h3>Training Information   {{help-popover slug="hq-training-info"}}</h3>
+<h3>Training Information {{help-popover slug="hq-training-info"}}</h3>
 
 {{#if person.isNonRanger}}
-<p>Non Rangers are not required to pass training.</p>
+  <p>Non Rangers are not required to pass training.</p>
 {{/if}}
 
-{{training-info trainings=eventInfo.trainings}}
+<TrainingInfo @trainings={{eventInfo.trainings}} />

--- a/app/templates/me/event-info.hbs
+++ b/app/templates/me/event-info.hbs
@@ -49,15 +49,13 @@
 
 {{#if artTrainings}}
   <h3 class="mt-4">{{fa-icon "university"}} Advanced Ranger Training (ART)</h3>
-  The following {{if (eq artTrainings.length 1) "position" (concat artTrainings.length " positions")}}
-  require ART Training. Although you can sign up for an
-  ART-required shift at any time, you will not be allowed to work such a shift
-  until you have passed the relevant ART training.
-  {{training-info trainings=artTrainings}}
+  You are allowed to attend the following ART trainings. 
+  <TrainingInfo @trainings={{artTrainings}} />
 {{/if}}
 
 <h3>{{fa-icon "list"}} Positions</h3>
-Positions indicate which shifts you are allowed to sign up for and what ART trainings you may attend. You have
+Positions indicate which shifts you are allowed to sign up for and what ART
+trainings you may attend. You have
 {{pluralize personPositions.length "position"}} granted:
 <div class="form-row mt-2">
   {{#each personPositions as |position| }}

--- a/app/templates/person/event-info.hbs
+++ b/app/templates/person/event-info.hbs
@@ -26,7 +26,7 @@
     {{#if person.isNonRanger}}
       <p>Non Rangers are not required to pass training.</p>
     {{/if}}
-    {{training-info trainings=eventInfo.trainings}}
+    <TrainingInfo @trainings={{eventInfo.trainings}} />
   </dd>
 
   <dt class="col-md-2">Meals</dt>

--- a/app/templates/reports/people-by-status.hbs
+++ b/app/templates/reports/people-by-status.hbs
@@ -7,11 +7,9 @@
     </div>
 
     <div class="row p-2 {{unless status.showing "d-none"}}">
-      {{#each status.people as |person|}}
-        <div class="col-sm-6 col-md-3 col-lg-2">
-          {{person-link person=person}}
-        </div>
-      {{/each}}
+      {{#each status.people as |person|~}}
+        <div class="col-sm-6 col-md-3 col-lg-2"><PersonLink @person={{person}} /></div>
+      {{~/each}}
     </div>
   </div>
 {{/each}}


### PR DESCRIPTION
This commits addresses various issues raised by the Green Dot 2019 AAR concerning Green Dot mentees.
- Table is now training centric versus positions-needing-training
- All granted trainings are now shown
- Pass indicator text has been changed to 'Trained'
- Added text clarifying what needs to happen for possible GD mentees. ("You need to be trained
- Show if a GD mentee shift was signed up for or worked in addition to GD Training.
- Converted training-info component into a glimmer one.