### PR TITLE
Minor tweaks for photos, bulk uploader and onboarding checklist.

### DIFF
--- a/app/components/dashboard-pnv.js
+++ b/app/components/dashboard-pnv.js
@@ -58,25 +58,30 @@ const SETUP_ACCOUNT_TASKS = [{
       if (!milestones.photo_upload_enabled) {
         return { result: WAITING, message: 'Photo uploading is not available at this time. Check back later.' }
       }
-      return { result: ACTION_NEEDED, isPhotoUpload: true, isPhotoTask: true };
+      return { result: ACTION_NEEDED,  isPhotoUpload: true, isPhotoTask: true };
     }
   },
 
   {
     name: 'Photo Approval',
     check(milestones, prevCompleted, photo) {
-      let reasons;
+      let reasons, message;
       switch (milestones.photo_status) {
       case 'approved':
         return { result: COMPLETED };
       case 'submitted':
         return { result: WAITING, message: 'The photo is being reviewed. Usually photos are approved within 2 to 3 days.' }
       case 'rejected':
-        reasons = photo.rejections.map((reason) => `<li>${reason}</li>`).join();
+        reasons = photo.rejections.map((reason) => `<li>${reason}</li>`).join('');
+        message = `Your photo was rejected for the following reasons: <ul>${reasons}</ul>`;
+        if (photo.reject_message) {
+          message += `The photo reviewer left you an additional message:<br>${photo.reject_message}<br><br>`;
+        }
+        message += 'Please upload a new photo which conforms to the BMID requirements.';
         return {
           result: URGENT,
-          message: htmlSafe(`Your photo was rejected for the following reasons: <ul>${reasons}</ul> Please upload a new photo which comforms to the BMID requirements.`),
-          isPhotoUpload: true
+          isPhotoUpload: true,
+          message: htmlSafe(message)
         };
       default:
         return { result: NOT_AVAILABLE, message: 'Upload a photo first.' };

--- a/app/controllers/admin/bulk-upload.js
+++ b/app/controllers/admin/bulk-upload.js
@@ -78,6 +78,7 @@ export default class AdminBulkUploadController extends Controller {
     this.toast.clear();
 
     this.set('isSubmitting', true);
+    this.set('isCommitting', commit);
     this.set('actionResults', []);
     this.ajax.request('bulk-upload', {
       method: 'POST',
@@ -101,7 +102,7 @@ export default class AdminBulkUploadController extends Controller {
         }
       }
     }).catch((response) => this.house.handleErrorResponse(response))
-    .finally(() => this.set('isSubmitting', false));
+    .finally(() => { this.set('isSubmitting', false); this.set('isCommitting', false); });
   }
 
   @action

--- a/app/controllers/person/onboard.js
+++ b/app/controllers/person/onboard.js
@@ -1,0 +1,9 @@
+import Controller from '@ember/controller';
+import { action } from '@ember/object';
+
+export default class PersonOnboardController extends Controller {
+  @action
+  noUploadAction() {
+    this.modal.info('Upload Disabled', 'The upload button can only be used by the actual PNV/Auditor.');
+  }
+}

--- a/app/routes/person/onboard.js
+++ b/app/routes/person/onboard.js
@@ -1,15 +1,19 @@
 import Route from '@ember/routing/route';
+import RSVP from 'rsvp';
 
 export default class PersonOnboardRoute extends Route {
 
   model() {
     const personId = this.modelFor('person').id;
-    return this.ajax.request(`person/${personId}/milestones`);
+    return RSVP.hash({
+      milestones: this.ajax.request(`person/${personId}/milestones`).then((results) => results.milestones),
+      photo: this.ajax.request(`person/${personId}/photo`).then((results) => results.photo)
+    });
   }
 
   setupController(controller, model) {
-    super.setupController(...arguments);
     controller.set('milestones', model.milestones);
+    controller.set('photo', model.photo);
     controller.set('person', this.modelFor('person'));
   }
 }

--- a/app/styles/photo.scss
+++ b/app/styles/photo.scss
@@ -1,6 +1,5 @@
 @import "cropper";
 
-
 .mugshot {
   background: #fcfcfc;
   padding: 5px;
@@ -22,11 +21,11 @@
 
 .mugshot-icon {
 
-img {
-  display: block;
-  max-width: 75px;
-  margin: 0 auto;
-}
+  img {
+    display: block;
+    max-width: 75px;
+    margin: 0 auto;
+  }
 }
 
 #photo-edit-container {
@@ -68,6 +67,7 @@ img {
 
 #photo-review {
   padding: 5px;
+
   img {
     margin: 0 auto;
     max-width: 80%;
@@ -79,8 +79,8 @@ img {
 }
 
 .photo-vc-review {
-    margin: 0 auto;
-    width: 250px;
+  margin: 0 auto;
+  width: 250px;
 }
 
 /*
@@ -95,23 +95,23 @@ img {
     object-fit: cover;
     display: block;
     margin: 0 auto;
-   // Have the video be a mirror image
+    // Have the video be a mirror image
     transform: scaleX(-1);
   }
 }
 
 #camera-container::before {
-    position: absolute;
-    content: '';
-    top: 0;
-    left: 0;
-    bottom: 0;
-    right: 0;
-    z-index: 9999;
-    background-image: url("images/headshot-template.png");
-    background-repeat: no-repeat;
-    background-position: center center;
-    background-size: auto 100%;
-    opacity: 0.5;
-    pointer-events: none;
+  position: absolute;
+  content: '';
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  z-index: 9999;
+  background-image: url("images/headshot-template.png");
+  background-repeat: no-repeat;
+  background-position: center center;
+  background-size: auto 100%;
+  opacity: 0.5;
+  pointer-events: none;
 }

--- a/app/templates/admin/bulk-upload.hbs
+++ b/app/templates/admin/bulk-upload.hbs
@@ -11,10 +11,12 @@
   No changes will be made until you click on the 'Commit' button which appears after clicking on 'Verify Upload'.
 </p>
 
-{{#if actionResults}}
+{{#if this.isSubmitting}}
+  <LoadingDialog @customMessage={{if this.isCommitting "Submitting the upload." "Verifying the request."}} />
+{{else if this.actionResults}}
   <div class="border rounded p-2 mt-2 mb-2">
-    {{#if resultFailures}}
-      <h4 class="text-danger">{{pluralize resultFailures.length "error"}} encountered</h4>
+    {{#if this.resultFailures}}
+      <h4 class="text-danger">{{pluralize this.resultFailures.length "error"}} encountered</h4>
       <table class="table table-sm table-striped mt-4">
         <thead>
           <tr>
@@ -23,7 +25,7 @@
           </tr>
         </thead>
         <tbody>
-          {{#each resultFailures as |result|}}
+          {{#each this.resultFailures as |result|}}
             <tr>
               <td class="w-25">
                 {{#if (eq result.status "callsign-not-found")}}
@@ -46,23 +48,23 @@
           {{/each}}
         </tbody>
       </table>
-    {{else if resultsCommitted}}
+    {{else if this.resultsCommitted}}
       <h4 class="text-success">Bulk Upload SUCCESS!</h4>
     {{else}}
       <h4>Review Upload - Nothing submitted yet</h4>
     {{/if}}
 
-    {{#if resultSuccesses}}
-      <h4>{{pluralize resultSuccesses.length "callsign" }} {{if resultsCommitted "successfully uploaded" "with no errors"}}</h4>
+    {{#if this.resultSuccesses}}
+      <h4>{{pluralize this.resultSuccesses.length "callsign" }} {{if this.resultsCommitted "successfully uploaded" "with no errors"}}</h4>
       <div class="row">
-        {{#each resultSuccesses as |result|}}
+        {{#each this.resultSuccesses as |result|}}
           <div class="col-sm-6 col-md-3 col-lg-2 m-2"><PersonLink @person={{result}} /></div>
         {{/each}}
       </div>
     {{/if}}
 
-    {{#if (and resultSuccesses (not resultFailures) (not resultsCommitted))}}
-      <button class="btn btn-success" {{action commitAction}} disabled={{isSubmitting}}>Commit Upload</button>
+    {{#if (and this.resultSuccesses (not this.resultFailures) (not this.resultsCommitted))}}
+      <button class="btn btn-success" {{action this.commitAction}} disabled={{this.isSubmitting}}>Commit Upload</button>
     {{/if}}
   </div>
 {{/if}}
@@ -72,7 +74,7 @@
     <label class="col-form-label">Select bulk action:</label>
   </div>
   <div class="col-auto">
-    <ChForm::Select @name="uploadAction" @value={{uploadAction}} @options={{uploadOptions}} @includeBlank={{true}} @onChange={{action (mut uploadAction)}} @controlClass="form-control" />
+    <ChForm::Select @name="uploadAction" @value={{this.uploadAction}} @options={{this.uploadOptions}} @includeBlank={{true}} @onChange={{action (mut this.uploadAction)}} @controlClass="form-control" />
   </div>
 </div>
 
@@ -85,7 +87,11 @@
 
 <div class="form-group row">
   <div class="col-auto">
-    <button type="button" class="btn btn-primary" disabled={{or isSubmitting disableSubmit}} {{action submitAction}}>{{if isSubmitting "Submitting" "Verify Upload"}}</button>
+    <button type="button" class="btn btn-primary" disabled={{or this.isSubmitting this.disableSubmit}} {{action this.submitAction}}>{{if this.isSubmitting "Submitting" "Verify Upload"}}</button>
+    {{#if this.isSubmitting}}
+      <LoadingIndicator />
+    {{/if}}
+
   </div>
 </div>
 <p>

--- a/app/templates/components/dashboard-pnv.hbs
+++ b/app/templates/components/dashboard-pnv.hbs
@@ -132,13 +132,11 @@
                   {{task.message}}
                 {{/if}}
                 {{#if task.isPhotoUpload}}
-                  <p>
                     {{#if @photo.upload_enabled}}
                       <a href="#" {{on "click" (fn @uploadAction)}}>Submit a headshot </a> to use on a BMID.
                     {{else}}
                       Unfortunately, photo upload is currently disabled.
                     {{/if}}
-                  </p>
                 {{/if}}
                 {{#if task.email}}
                   <p>{{mail-to task.email}}</p>

--- a/app/templates/person/index.hbs
+++ b/app/templates/person/index.hbs
@@ -8,15 +8,14 @@
 {{/if}}
 
 {{#if person.unread_message_count}}
-  {{#ch-alert "warning" bold=true}}
+  <ChAlert @type="warning" @bold=true>
     {{fa-icon "envelope"}} {{pluralize person.unread_message_count "unread Clubhouse message"}}
     <LinkTo @route="person.messages" class="btn btn-success">Read Now</LinkTo>
-  {{/ch-alert}}
+  </ChAlert>
 {{/if}}
 
 {{#ch-form "person" person  onSubmit=(action "savePersonAction") as |f|}}
   <PersonPhoto @photo={{photo}} @person={{person}} @uploadAction={{this.showUploadDialogAction}} />
-
 
   {{! The following block is floated left on md or larger screen to ensure
     the photo is on the right and the form flows around it.

--- a/app/templates/person/onboard.hbs
+++ b/app/templates/person/onboard.hbs
@@ -3,7 +3,7 @@ Note: this is the onboarding view a person will see after logging in. <b>Links &
 </ChAlert>
 
 {{#if (or this.person.isProspective this.person.isAlpha this.person.isBonked)}}
-  <DashboardPnv @milestones={{this.milestones}} @person={{this.person}} />
+  <DashboardPnv @milestones={{this.milestones}} @photo={{this.photo}} @person={{this.person}} @uploadAction={{this.noUploadAction}}/>
 {{else if this.person.isAuditor}}
   <DashboardAuditor @milestones={{this.milestones}} @person={{this.person}} />
 {{else}}

--- a/app/templates/vc/photo-review.hbs
+++ b/app/templates/vc/photo-review.hbs
@@ -9,7 +9,7 @@
     <div class="border bg-light-gray mb-4 p-2">
       <div class="row">
         <div class="col-auto">
-          <img id={{concat "photo-" photo.id}} src="{{photo.image_url}}" class="photo-vc-review" />
+          <img id={{concat "photo-" photo.id}} src="{{photo.image_url}}" class="photo-vc-review"/>
         </div>
         <div class="col-auto">
           <h3>
@@ -17,104 +17,112 @@
             &lt;{{photo.person.first_name}} {{photo.person.last_name}}, {{photo.person.status}}&gt;
           </h3>
           <p>
-            <table class="table table-width-auto">
-              <thead>
-                <tr>
-                  <th>Status</th>
-                  <th>ID</th>
-                  <th>Uploaded</th>
-                  <th>Reviewed</th>
-                  <th>Edited</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td>
-                    {{#if (eq photo.status "approved")}}
-                      <b class="text-success">{{fa-icon "check"}} {{photo.status}}</b>
-                    {{else if (eq photo.status "rejected")}}
-                      <b class="text-danger">{{fa-icon "times"}} {{photo.status}}</b>
-                    {{else}}
-                      {{photo.status}}
-                    {{/if}}
-                  </td>
-                  <td class="text-right">
-                    {{photo.id}}
-                  </td>
-                  <td>
-                    {{#if photo.uploaded_at}}
-                      {{photo.uploaded_at}}<br>
-                      by {{#if photo.upload_person}}
-                        <PersonLink @person={{photo.upload_person}} />
-                      {{else}}
-                        <i>unknown</i>
-                      {{/if}}
-                    {{else}}
-                      <i>never</i>
-                    {{/if}}
-                  </td>
-                  <td>
-                    {{#if photo.reviewed_at}}
-                      {{photo.reviewed_at}}<br>
-                      by {{#if photo.review_person}}
-                        <PersonLink @person={{photo.review_person}} />
-                      {{else}}
-                        <i>unknown</i>
-                      {{/if}}
-                    {{else}}
-                      <i>never</i>
-                    {{/if}}
-                  </td>
-                  <td>
-                    {{#if photo.edited_at}}
-                      {{photo.edited_at}}<br>
-                      by {{#if photo.edit_person}}
-                        <PersonLink @person={{photo.edit_person}} />
-                      {{else}}
-                        <i>unknown</i>
-                      {{/if}}
-                    {{else}}
-                      <i>never</i>
-                    {{/if}}
-                  </td>
-                </tr>
-              </tbody>
-            </table>
+          <table class="table table-width-auto">
+            <thead>
+            <tr>
+              <th>Status</th>
+              <th>ID</th>
+              <th>Uploaded</th>
+              <th>Reviewed</th>
+              <th>Edited</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr>
+              <td>
+                {{#if (eq photo.status "approved")}}
+                  <b class="text-success">{{fa-icon "check"}} {{photo.status}}</b>
+                {{else if (eq photo.status "rejected")}}
+                  <b class="text-danger">{{fa-icon "times"}} {{photo.status}}</b>
+                {{else}}
+                  {{photo.status}}
+                {{/if}}
+              </td>
+              <td class="text-right">
+                {{photo.id}}
+              </td>
+              <td>
+                {{#if photo.uploaded_at}}
+                  {{photo.uploaded_at}}<br>
+                  by {{#if photo.upload_person}}
+                  <PersonLink @person={{photo.upload_person}} />
+                {{else}}
+                  <i>unknown</i>
+                {{/if}}
+                {{else}}
+                  <i>never</i>
+                {{/if}}
+              </td>
+              <td>
+                {{#if photo.reviewed_at}}
+                  {{photo.reviewed_at}}<br>
+                  by {{#if photo.review_person}}
+                  <PersonLink @person={{photo.review_person}} />
+                {{else}}
+                  <i>unknown</i>
+                {{/if}}
+                {{else}}
+                  <i>never</i>
+                {{/if}}
+              </td>
+              <td>
+                {{#if photo.edited_at}}
+                  {{photo.edited_at}}<br>
+                  by {{#if photo.edit_person}}
+                  <PersonLink @person={{photo.edit_person}} />
+                {{else}}
+                  <i>unknown</i>
+                {{/if}}
+                {{else}}
+                  <i>never</i>
+                {{/if}}
+              </td>
+            </tr>
+            </tbody>
+          </table>
           </p>
           <p>
-            <button type="button" class="btn btn-secondary mr-1" disabled={{photo.isSaving}} {{on "click" (fn this.editPhotoAction photo)}}>{{fa-icon "edit"}} Edit</button>
+            <button type="button" class="btn btn-secondary mr-1" disabled={{photo.isSaving}} {{on "click"
+                                                                                                  (fn this.editPhotoAction photo)}}>{{fa-icon
+                    "edit"}} Edit
+            </button>
             {{#if (not-eq photo.status "rejected")}}
-              <button type="button" class="btn btn-danger mr-1" {{on "click" (fn this.showReviewPhoto photo)}} disabled={{photo.isSaving}}>{{fa-icon "times"}} Reject</button>
+              <button type="button" class="btn btn-danger mr-1" {{on "click" (fn this.showReviewPhoto photo)}}
+                      disabled={{photo.isSaving}}>{{fa-icon "times"}} Reject
+              </button>
             {{/if}}
             {{#if (not-eq photo.status "approved")}}
-              <button type="button" class="btn btn-success mr-1" {{on "click" (fn this.approveAction photo)}} disabled={{photo.isSaving}}>{{fa-icon "check"}} Approve</button>
+              <button type="button" class="btn btn-success mr-1" {{on "click" (fn this.approveAction photo)}}
+                      disabled={{photo.isSaving}}>{{fa-icon "check"}} Approve
+              </button>
             {{/if}}
             {{#if photo.isSaving}}
-              <LoadingIndicator />
+              <LoadingIndicator/>
             {{/if}}
           </p>
-          <p>
-            {{#if photo.rejection_history}}
-              <b>{{pluralize photo.rejection_history.length "previously rejected photo"}}</b>
-              <div class="row mt-2">
-                {{#each photo.rejection_history as |reject|}}
-                  <div class="col-auto">
-                    <div class="mugshot-icon">
-                      <img src={{reject.image_url}} {{on "click" (fn this.showPhotoInfoAction reject)}} />
-                      {{moment-format reject.uploaded_at "YYYY-MM-DD"}}
-                    </div>
+        <p>
+          {{#if photo.rejection_history}}
+            <b>{{pluralize photo.rejection_history.length "previously rejected photo"}}</b>
+            <div class="row mt-2">
+              {{#each photo.rejection_history as |reject|}}
+                <div class="col-auto">
+                  <div class="mugshot-icon">
+                    <img src={{reject.image_url}} {{on "click" (fn this.showPhotoInfoAction reject)}} />
+                    {{moment-format reject.uploaded_at "YYYY-MM-DD"}}
                   </div>
-                {{/each}}
-              </div>
-            {{else}}
-              <b>No prior rejected photos.</b>
-            {{/if}}
+                </div>
+              {{/each}}
+            </div>
+          {{else}}
+            <b>No prior rejected photos.</b>
+          {{/if}}
           </p>
           {{#if (eq photo.status "rejected")}}
             <p>
               Rejection reasons:
               {{#each photo.reject_reasons as |reason idx|~}}
-                {{~if idx ", " ~}}{{present-or-not (get this.rejectionLabels reason) (concat "Unknown reason " reason)~}}
+                {{~if idx ", " ~}}{{present-or-not (get this.rejectionLabels reason)
+                                                   (concat "Unknown reason " reason)~}}
               {{else}}
                 <i>none given</i>
               {{/each}}
@@ -133,22 +141,30 @@
 </main>
 
 {{#if this.reviewPhoto}}
-  <ModalDialog @title={{concat "Review Photo for " this.reviewPhoto.person.callsign}} @noButtons=true>
-    <ChForm @formId="photo" @originalModel={{this.reviewForm}} @changeSet={{false}} @onSubmit={{this.onRejectSubmit}} @onCancel={{this.onClose}} as |f|>
+  <ModalDialog @title={{concat "Reject Photo for " this.reviewPhoto.person.callsign}} @noButtons=true>
+    <ChForm @formId="photo" @originalModel={{this.reviewForm}} @changeSet={{false}} @onSubmit={{this.onRejectSubmit}}
+            @onCancel={{this.onClose}} as |f|>
       <div class="form-row">
-        <label>Rejection reason(s):</label>
       </div>
       <div class="form-row">
-        <f.input @name="reasons" @type="checkboxGroup" @cols=3 @options={{this.rejectionOptions}} />
+        <div class="col-3">
+          <img src={{this.reviewPhoto.image_url}} class="mugshot"/>
+        </div>
+        <div class="col-8">
+          <div class="form-row ml-2">
+            <f.input @name="reasons" @type="checkboxGroup" @cols=2 @options={{this.rejectionOptions}} />
+          </div>
+        </div>
       </div>
       <div class="form-row mt-2">
-        <f.input @name="message" @label="Custom message to include in the rejection email:" @type="textarea" @rows=10 @cols=80 @hint="All email addresses and links in the message will be hyperlinked." />
+        <f.input @name="message" @label="Custom message to include in the rejection email:" @type="textarea" @rows=5
+                 @cols=80 @hint="All email addresses and links in the message will be hyperlinked."/>
       </div>
       <div class="form-group mt-4">
         <f.submit @label="Reject Photo" @submitClass="btn-danger" disabled={{this.reviewPhoto.isSaving}} />
         <f.cancel disabled={{this.reviewPhoto.isSaving}} />
         {{#if this.reviewPhoto.isSaving}}
-          <LoadingIndicator />
+          <LoadingIndicator/>
         {{/if}}
       </div>
     </ChForm>
@@ -156,14 +172,17 @@
 {{/if}}
 
 {{#if this.editPhoto}}
-  <ModalDialog @title={{concat "Edit Photo for " this.editPhoto.person.callsign}} @closeLabel="Cancel" @onClose={{this.closeEditPhotoAction}}>
-    <PhotoEdit @imageDataUrl={{this.editPhoto.orig_url}} @submitAction={{this.submitEditedPhotoAction}} @width={{this.width}} @height={{this.height}} />
+  <ModalDialog @title={{concat "Edit Photo for " this.editPhoto.person.callsign}} @closeLabel="Cancel"
+               @onClose={{this.closeEditPhotoAction}}>
+    <PhotoEdit @imageDataUrl={{this.editPhoto.orig_url}} @submitAction={{this.submitEditedPhotoAction}}
+               @width={{this.width}} @height={{this.height}} />
   </ModalDialog>
 {{/if}}
 
 
 {{#if this.showPhoto}}
-  <ModalDialog @title={{concat "Photo ID #" this.showPhoto.id}} @closeLabel="Cancel" @onClose={{this.closePhotoInfoAction}}>
+  <ModalDialog @title="Previously Rejected Photo" @closeLabel="Cancel"
+               @onClose={{this.closePhotoInfoAction}}>
     <div class="row">
       <div class="col-auto">
         <img src={{this.showPhoto.image_url}} />
@@ -171,10 +190,10 @@
       <div class="col-auto">
         <h3>ID #{{this.showPhoto.id}}</h3>
         <p>
-          <b>Uploaded at</b> {{present-or-not this.showPhoto.uploaded_at}}
+          <b>Uploaded</b> {{present-or-not this.showPhoto.uploaded_at}}
         </p>
         <p>
-          <b>Reviewed at</b> {{present-or-not this.showPhoto.reviewed_at}}
+          <b>Reviewed</b> {{present-or-not this.showPhoto.reviewed_at}}
         </p>
         <p>
           <b>Rejection reasons</b><br>
@@ -183,6 +202,10 @@
           {{else}}
             <i>none given</i>
           {{/each}}
+        </p>
+        <p>
+          <b>Rejection Message:</b><br>
+          {{present-or-not this.showPhoto.reject_message "none given"}}
         </p>
       </div>
     </div>

--- a/tests/unit/controllers/person/onboard-test.js
+++ b/tests/unit/controllers/person/onboard-test.js
@@ -1,0 +1,12 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Controller | person/onboard', function(hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function(assert) {
+    let controller = this.owner.lookup('controller:person/onboard');
+    assert.ok(controller);
+  });
+});


### PR DESCRIPTION
- The VC onboarding checklist view broke when Clubhouse photos came online.
- Show additional loading indicators when the bulk uploader is running.
- Fixed onboarding checklist  pnv photo upload message position, extra line was introduced between the dash and text.
- onboarding checklist pnv was not showing the reviewer's message, only stock reasons.
- Show the soon-to-be-rejected photo on the rejection modal.