### PR TITLE
DRY'ed up error logging for Ember.onerror & route/error.

### DIFF
--- a/app/routes/error.js
+++ b/app/routes/error.js
@@ -1,16 +1,13 @@
-import { TimeoutError, AbortError } from '@ember-data/adapter/error';
+import {TimeoutError, AbortError} from '@ember-data/adapter/error';
 import Route from '@ember/routing/route';
 import ENV from 'clubhouse/config/environment';
-import {
-  isAbortError,
-  isTimeoutError,
-  isForbiddenError
-} from 'ember-ajax/errors';
+import {isAbortError, isTimeoutError, isForbiddenError} from 'ember-ajax/errors';
+import logError from 'clubhouse/utils/log-error';
 
 //
 // Called by Ember when a route encounters an uncaught exception.
 //
-// Note this is *not* listed in app/router.js
+// Note this is not registered in app/router.js and called explicitly by the Ember framework.
 
 export default class ErrorRoute extends Route {
   setupController(controller, error) {
@@ -24,38 +21,8 @@ export default class ErrorRoute extends Route {
         || isAbortError(error) || isTimeoutError(error));
 
     controller.set('isOffline', isOffline);
-
     controller.set('notAuthorized', (error && (isForbiddenError(error) || error.status == 403)));
 
-    // Try to send the down the error to the server for logging
-    if (!isOffline && ENV.logEmberErrors && navigator.sendBeacon) {
-      const data = new FormData;
-
-      data.append('error_type', 'ember-route-error');
-      data.append('url', window.location.href);
-
-      let route_error;
-      if (error.stack) {
-        route_error = {
-          message: error.message,
-          stack: error.stack
-        };
-      } else {
-        route_error = error;
-      }
-
-      data.append('data', JSON.stringify({
-        build_timestamp: ENV.APP.buildTimestamp,
-        version: ENV.APP.version,
-        route_error
-      }));
-
-      const personId = this.session.userId;
-      if (personId) {
-        data.append('person_id', personId);
-      }
-      navigator.sendBeacon(ENV['api-server'] + '/error-log/record', data);
-    }
-
+    logError(error, 'ember-route-error');
   }
 }

--- a/app/utils/log-error.js
+++ b/app/utils/log-error.js
@@ -1,0 +1,68 @@
+import {TimeoutError, AbortError, ForbiddenError, UnauthorizedError} from '@ember-data/adapter/error';
+import {isAbortError, isTimeoutError, isForbiddenError, isUnauthorizedError} from 'ember-ajax/errors';
+import config from 'clubhouse/config/environment';
+
+/*
+  Log an unresolved error to the backend for later diagnosis.
+ */
+
+export default function logError(error, type) {
+  if (!config.logEmberErrors) {
+    // Might be in a development or test environment. skip logging.
+    return;
+  }
+
+  if (error instanceof TimeoutError  // check ember-model errors
+    || error instanceof AbortError
+    || error instanceof ForbiddenError
+    || error instanceof UnauthorizedError
+    || isAbortError(error)  // and ember-ajax errors
+    || isTimeoutError(error)
+    || isForbiddenError(error)
+    || isUnauthorizedError(error)
+    || error.status == 403) {
+    // Don't record timeouts, unauthorized requests (aka expired authorization tokens), or offline errors.
+    return;
+  }
+
+  const form = new FormData;
+  form.append('url', window.location.href);
+  form.append('error_type', type);
+
+  form.append('data', JSON.stringify({
+    exception: {
+      name: error.name,
+      message: error.message,
+      stack: error.stack
+    },
+    build_timestamp: config.APP.buildTimestamp,
+    version: config.APP.version,
+  }));
+
+  try {
+    // Grab the logged in user id if possible.
+    const personId = window.Clubhouse.__container__.lookup('service:session').get('user.id');
+    form.append('person_id', personId);
+  } catch (exception) {
+    console.error('Session user id exception', exception);
+  }
+
+  const url = config['api-server'] + '/error-log/record';
+
+  if ('sendBeacon' in navigator) {
+    // sendBeacon will continue even if the browser window is closed.
+    navigator.sendBeacon(url, form);
+  } else {
+    // For Safari 11.1 and earlier, Internet Explorer, and other older browsers use good old XMLHttpRequest
+    // if the window is closed before the request is completed, the request may be aborted hence why
+    // sendBeacon is preferred.
+    try {
+      const req = new XMLHttpRequest();
+      req.open('POST', url);
+      req.setRequestHeader('Accept', '*/*');
+      req.send(form);
+    } catch (exception) {
+      console.error('LOG ERROR', exception);
+    }
+  }
+}


### PR DESCRIPTION
- Don't report on Unauthorzied or Forbidden errors. The most common case is the authorization token expired.
- Fallback to using XMLHttpRequest when sendBeacon is not available (Safari 11.1 and older, Internet Explorer, etc.)