### PR TITLE
Clubhouse message layout redesign.

### DIFF
--- a/app/components/autocomplete-input.hbs
+++ b/app/components/autocomplete-input.hbs
@@ -21,6 +21,8 @@
       {{on "blur" this.blurEvent}}
       {{on "input" this.inputEvent}}
       {{did-insert this.inputInsertElement}}
+            autofocus={{@autofocus}}
+           @inputClass="{{this.controlClass}} autocomplete-input {{if (get @model.error @name) "is-invalid"}}"
     />
 
     {{#if @appendSearchIcon}}

--- a/app/components/autocomplete-input.js
+++ b/app/components/autocomplete-input.js
@@ -55,18 +55,10 @@ export default class AutocompleteInputComponent extends Component {
    */
   hasSelected = false;
 
-  /**
-   * CSS classes to be used on the input field
-   *
-   * @type {string}
-   */
-
-
-  constructor() {
-    super(...arguments);
-
-    this.inputClass = this.args.inputClass || 'form-control autocomplete-input';
+  get inputClass() {
+    return this.args.inputClass || 'form-control autocomplete-input';
   }
+
   /**
    * Handle input into the search field.
    *

--- a/app/components/ch-form/field.hbs
+++ b/app/components/ch-form/field.hbs
@@ -106,6 +106,8 @@
                        @onFocus={{@onFocus}}
                        @inputClass={{this.controlClass}}
                        @disabled={{@disabled}}
+                       @autofocus={{@autofocus}}
+                       @inputClass="{{this.controlClass}} {{if (get @model.error @name) "is-invalid"}}"
                        @text={{get @model @name}} as |item|>
       {{item}}
     </AutocompleteInput>

--- a/app/components/clubhouse-messages.hbs
+++ b/app/components/clubhouse-messages.hbs
@@ -1,77 +1,90 @@
+<div class="mail-container">
+  <div class="row mb-2">
+    <div class="col-md-12 col-lg-auto mt-2">
+      {{#if @messages}}
+        {{pluralize @messages.length "message"}}
+        {{#if this.unreadCount}}
+          <b>({{this.unreadCount}} unread)</b>
+        {{else}}
+          (no unread)
+        {{/if}}
+      {{else}}
+        <b>{{if @isMe "You have" "There are"}} no messages.</b>
+      {{/if}}
+    </div>
+    <div class="col-md-12 col-lg-auto">
+    {{#if this.canSendMessages}}
+      <button class="btn btn-primary ml-md-auto btn-md-block" {{on "click" this.newMessageAction}}>{{fa-icon "plus"}}
+        New Message
+      </button>
+    {{/if}}
+    </div>
+  </div>
+
+  {{#each @messages as |message|}}
+    <div class="mail {{if (not message.delivered) "mail-unread"}}">
+        <div class="mail-photo">
+          {{#if message.is_rbs}}
+            {{fa-icon "bullhorn"}}
+          {{else if message.sender_photo_url}}
+            <img src={{message.sender_photo_url}} loading="lazy"  alt="{{message.message_from}} photo" />
+          {{else}}
+            {{fa-icon "user"}}
+          {{/if}}
+        </div>
+        <div class="mail-header {{if message.showing "mail-showing"}}" {{on "click" (fn this.toggleMessage message)}}>
+          <div class="mail-indicator">
+            {{#if message.delivered}}
+              {{fa-icon "check-circle" type="far"}}
+            {{else}}
+              {{fa-icon "arrow-right" color="success"}}
+            {{/if}}
+          </div>
+          <div class="mail-from">
+            {{message.message_from}}
+          </div>
+          <div class="mail-date">
+            {{shift-format message.sent_at}}
+          </div>
+          <div class="mail-subject">
+            {{message.subject}}
+          </div>
+        </div>
+        <div class="mail-body collapse" id="message-text-{{message.id}}">
+          {{#if message.isDictacted}}
+            <div class="mail-written-by">{{fa-icon "pen-alt"}} written by {{message.creator_callsign}}
+              for {{message.message_from}}</div>
+          {{/if}}
+
+          {{message.body}}
+          <div class="mail-actions">
+            {{#if message.delivered}}
+              <button {{on "click" (fn this.markUnreadAction message)}}
+                      type="button" class="btn btn-secondary btn-md-block" disabled={{message.isSubmitting}}>
+                Mark Unread
+                {{#if message.isSubmitting}}
+                  {{fa-icon "spinner" spin=true}}
+                {{/if}}
+              </button>
+            {{else}}
+              <button {{on "click" (fn this.markReadAction message)}}
+                      type="button" class="btn btn-primary btn-md-block" disabled={{message.isSubmitting}}>
+                Mark Read
+                {{#if message.isSubmitting}}
+                  {{fa-icon "spinner" spin=true}}
+                {{/if}}
+              </button>
+            {{/if}}
+          </div>
+        </div>
+    </div>
+  {{/each}}
+</div>
+
+
 {{#if this.newMessage}}
   <MessageNew @message={{this.newMessage}} @onSubmit={{this.submitAction}} @onCancel={{this.cancelAction}}
+              @isMe={{@isMe}}
               @isSubmitting={{this.isSubmitting}} />
 {{/if}}
 
-<div class="row">
-  <div class="col-sm-12 col-md-6 mb-2">
-    <div class="form-check form-check-inline">
-      <RadioButton @value="all" @groupValue={{this.filterMessages}} @radioId="filter-all"
-                   @radioClass="form-check-input"/>
-      <label for="filter-all" class="form-check-label">All</label>
-    </div>
-    <div class="form-check form-check-inline">
-      <RadioButton @value="unread" @groupValue={{this.filterMessages}} @radioId="filter-unread"
-                   @classNames="form-check-label" @radioClass="form-check-input"/>
-      <label for="filter-unread" class="form-check-label">Unread ({{this.unreadCount}})</label>
-    </div>
-
-    <div class="form-check form-check-inline">
-      <RadioButton @value="read" @groupValue={{this.filterMessages}} @radioId="filter-read"
-                   @classNames="form-check-label"
-                   @radioClass="form-check-input"/>
-      <label for="filter-read" class="form-check-label">Read ({{this.readCount}})</label>
-    </div>
-  </div>
-</div>
-{{#if this.canSendMessages}}
-  <p>
-    <a href="#" class="btn btn-primary" {{on "click" this.newMessageAction}}>New Message</a>
-  </p>
-{{/if}}
-
-<p class="text-muted">Showing {{pluralize this.viewMessages.length "message"}}</p>
-{{#if @messages}}
-  {{#each this.viewMessages as |message|}}
-    <div class="card mb-2">
-      <div class="card-body">
-        <div class="row">
-          <div class="col-sm-12 col-md-8">
-            <h5>From: {{message.message_from}}</h5>
-            <h5>{{#unless message.delivered}}<span class="text-danger">&bullet;</span> {{/unless}}
-              Subject: {{message.subject}}</h5>
-            {{#if message.isDictacted}}
-              <div class="text-muted">(written by {{message.creator_callsign}})</div>
-            {{/if}}
-          </div>
-          <div class="col-sm-12 col-md-4 text-md-right">
-            {{shift-format message.sent_at}}
-            <div class="text-muted small">({{moment-from-now message.sent_at}})</div>
-          </div>
-        </div>
-        <div class="mt-2">
-          {{message.body}}
-        </div>
-        <div class="mt-3">
-          {{#if message.delivered}}
-            <button {{on "click" (fn this.markUnreadAction message)}}
-                    type="button" class="btn btn-secondary" disabled={{message.isSubmitting}}>
-              Mark Unread
-            </button>
-          {{else}}
-            <button {{on "click" (fn this.markReadAction message)}}
-                    type="button" class="btn btn-primary" disabled={{message.isSubmitting}}>
-              Mark Read
-            </button>
-          {{/if}}
-          {{#if message.isSubmitting}}
-            <LoadingIndicator/>
-          {{/if}}
-        </div>
-      </div>
-    </div>
-  {{/each}}
-
-{{else}}
-  <b>Congratulations!</b> There are no messages.
-{{/if}}

--- a/app/components/clubhouse-messages.js
+++ b/app/components/clubhouse-messages.js
@@ -3,6 +3,7 @@ import {action, set} from '@ember/object';
 import {inject as service} from '@ember/service';
 import {Role} from 'clubhouse/constants/roles';
 import {tracked} from '@glimmer/tracking';
+import $ from 'jquery';
 
 export default class ClubhouseMessagesComponent extends Component {
   @service store;

--- a/app/components/clubhouse-messages.js
+++ b/app/components/clubhouse-messages.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import {action, computed} from '@ember/object';
+import {action, set} from '@ember/object';
 import {inject as service} from '@ember/service';
 import {Role} from 'clubhouse/constants/roles';
 import {tracked} from '@glimmer/tracking';
@@ -10,33 +10,42 @@ export default class ClubhouseMessagesComponent extends Component {
   @service session;
   @service ajax;
 
-  @tracked filterMessages = 'all';
+//  @tracked filterMessages = 'all';
+//  @tracked sortBy = 'desc';
+
   @tracked isSubmitting = false;
   @tracked newMessage = null;
 
-  get viewMessages() {
-    const messages = this.args.messages;
+  /*
+   get viewMessages() {
+     let messages = this.args.messages;
 
-    switch (this.filterMessages) {
-      case 'read':
-        return messages.filterBy('delivered', true);
-
+     switch (this.filterMessages) {
+     case 'read':
+       messages = messages.filterBy('delivered', true);
+       break;
       case 'unread':
-        return messages.filterBy('delivered', false);
-
-      default:
-        return messages;
+       messages = messages.filterBy('delivered', false);
+       break;
     }
-  }
 
-  @computed('args.messages.@each.delivered')
+    if (this.sortBy === 'asc') {
+      messages.sortBy('sent_at', 'asc');
+    } else {
+      messages.sortBy('sent_at', 'desc');
+    }
+
+     return messages;
+   }
+
+   */
+
   get unreadCount() {
     return this.args.messages.reduce(function (total, msg) {
       return (msg.delivered ? 0 : 1) + total;
     }, 0);
   }
 
-  @computed('args.messages.@each.delivered')
   get readCount() {
     return this.args.messages.reduce(function (total, msg) {
       return (msg.delivered ? 1 : 0) + total;
@@ -54,6 +63,13 @@ export default class ClubhouseMessagesComponent extends Component {
     if (this.session.userId == person.id) {
       this.session.user.set('unread_message_count', unreadCount);
     }
+  }
+
+  @action
+  toggleMessage(message, event) {
+    event.preventDefault();
+    set(message, 'showing', !message.showing);
+    $(`#message-text-${message.id}`).collapse('toggle');
   }
 
   @action

--- a/app/components/message-new.hbs
+++ b/app/components/message-new.hbs
@@ -5,39 +5,35 @@
           @onSubmit={{@onSubmit}}
           @onCancel={{@onCancel}} as |f|>
     <Modal.body>
-      <p>
-        Please take note:
-      <ul>
-        <li><strong class="text-danger">Clubhouse messaging is intended for official Ranger business while the event is
-          happening.</strong></li>
-        <li>Clubhouse messages are NOT private. The message might be seen by the HQ Window staff during the event and
-          the Tech Team doing maintence.
-        </li>
-        <li><b>Use email or the Contact Ranger page</b> if your message is more of a personal nature or
-          the event is over.
-        </li>
-        <li>All messages are logged and archived at the end of each calendar year.</li>
-        <li>
-          Remember that Burning Man and the Rangers have a zero-tolerance policy for behavior that is non-consensual,
-          abusive, harassing, or harmful to others.
-        </li>
-      </ul>
+      <p class="ml-2">
+        Messages <b class="text-danger">are NOT private</b> (will be seen by HQ staff &amp; Tech Team), for official
+        Ranger business only, and archived each year.
+        Burning Man and the Rangers have a zero-tolerance policy for behavior that is non-consensual,
+        abusive, harassing, or harmful to others.
       </p>
-      <div class="forn-group row">
-        <div class="col-sm-12 col-md-6">
-          <f.input @name="message_from" @label="From" @type="text" @size=30 @maxlength=120 @autofocus=true/>
-        </div>
+      <div class="form-row mb-2">
+        {{#unless @isMe}}
+          <f.input @name="message_from" @label="From" @type="text" @size=30 @maxlength=120 @autofocus=true
+                   @gridClass="col-sm-12 col-md-6"/>
+        {{/unless}}
         <div class="col-sm-12 col-md-6">
           <f.input @name="recipient_callsign"
                    @placeholder="Enter a callsign"
                    @label="To"
                    @type="search"
-                   @onSearch={{this.searchCallsignAction}} />
+                   @size={{30}}
+                   @onSearch={{this.searchCallsignAction}}
+                   @autofocus={{@isMe}}
+          />
         </div>
       </div>
-      <f.input @name="subject" @label="Subject" @maxlength=80/>
-      <f.input @name="body" @label="The message (be civil, courteous, polite, & professional)" @type="textarea" @rows=4
-               @cols=80/>
+      <div class="form-row">
+        <f.input @name="subject" @label="Subject" @size={{80}} @maxlength={{80}} @gridClass="col-auto"/>
+      </div>
+      <div class="form-row">
+        <f.input @name="body" @label="The message (be civil, courteous, polite, & professional)"
+                 @type="textarea" @rows={{4}} @cols={{80}} @gridClass="col-auto"/>
+      </div>
     </Modal.body>
     <Modal.footer @noAlign=true>
       <f.submit @label="Send" @disabled={{@isSubmitting}} />

--- a/app/models/person-message.js
+++ b/app/models/person-message.js
@@ -18,7 +18,10 @@ export default class PersonMessageModel extends Model {
   @attr('string') body;
   @attr('date') sent_at;
 
+  @attr('string') sender_photo_url;
+
   @attr('boolean', { readOnly: true }) delivered;
+  @attr('boolean', { readOnly: true }) is_rbs;
 
   @computed('creator_person_id', 'sender_person_id')
   get isDictacted() {

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -82,6 +82,7 @@ $sizes: (
 @import "access-documents";
 @import "alpha-sheet";
 @import "hq";
+@import "mail";
 @import "onboard";
 @import "photo";
 @import "schedule";
@@ -625,4 +626,11 @@ caption {
 
 .autocomplete-option-selected {
   background-color: #ececec;
+}
+
+@include media-breakpoint-down(md) {
+  .btn-md-block {
+    display: block;
+    width: 100%;
+  }
 }

--- a/app/styles/mail.scss
+++ b/app/styles/mail.scss
@@ -1,0 +1,137 @@
+.mail-container {
+  max-width: 750px;
+}
+
+.mail {
+  border: 1px solid #c8d2dc;
+  border-radius: 5px;
+  padding: 5px;
+  margin-bottom: 5px;
+  display: grid;
+  grid-template-columns: 85px auto;
+  grid-template-areas:
+    "mail-photo mail-header"
+    "mail-photo mail-body";
+}
+
+.mail:hover {
+  background-color: #f0f0f0;
+
+  .mail-header {
+    color: #222;
+  }
+}
+
+.mail-showing {
+  background-color: #e9ecef !important;
+}
+
+.mail-header {
+  grid-area: mail-header;
+  font-size: 0.95rem;
+  color: #6c757d;
+
+  display: grid;
+  grid-template-columns: 45px auto 165px;
+  grid-column-gap: 0;
+  grid-row-gap: 0;
+  grid-template-areas:
+    "mail-indicator mail-subject"
+    "mail-indicator mail-from"
+    "mail-indicator mail-date";
+
+}
+
+.mail-photo {
+  grid-area: mail-photo;
+  min-height: 75px;
+  text-align: center;
+
+  img {
+    display: block;
+    margin: 0 auto;
+    max-width: 65px;
+  }
+
+  i {
+    margin-top: 10px;
+    font-size: 3rem;
+  }
+}
+
+.mail-indicator {
+  grid-area: mail-indicator;
+  text-align: center;
+  font-weight: 500;
+  font-size: 1.3rem;
+}
+
+.mail-from {
+  grid-area: mail-from;
+}
+
+.mail-date {
+  grid-area: mail-date;
+}
+
+.mail-subject {
+  grid-area: mail-subject;
+}
+
+
+.mail-body {
+  grid-area: mail-body;
+  padding-top: 10px;
+  padding-left: 45px;
+}
+
+.mail-actions {
+  margin-top: 15px;
+}
+
+.mail-unread {
+  .mail-header {
+    font-weight: 500 !important;
+    color: #000 !important;
+  }
+}
+
+.mail.mail-unread {
+  border-color: #721c24 !important;
+}
+
+.mail-written-by {
+  font-style: italic;
+  color: #666;
+  margin-bottom: 10px;
+}
+
+@include media-breakpoint-down(md) {
+  .mail {
+    grid-template-areas:
+    "mail-photo mail-header"
+    "mail-body mail-body";
+  }
+  .mail-header {
+    font-size: 0.9rem;
+    grid-template-columns: 25px auto;
+    grid-template-areas:
+    "mail-indicator mail-subject"
+    "mail-from mail-from"
+    "mail-date mail-date";
+  }
+
+  .mail-indicator {
+    font-size: 1.1rem;
+  }
+
+  .mail-subject, .mail-date {
+    display: block;
+    padding: 0;
+    width: 100%;
+  }
+
+  .mail-body {
+    padding-left: 5px;
+  }
+}

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -4,7 +4,10 @@
             data-target="#navbarNavDropdown" aria-controls="navbarNavDropdown" aria-expanded="false"
             aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
-      Menu
+      Menu {{#if this.session.user.unread_message_count}}
+      <span class="badge badge-pill badge-success">{{fa-icon
+              "envelope"}} {{this.session.user.unread_message_count}}</span>
+    {{/if}}
     </button>
     <LinkTo @route="me.overview" class="navbar-brand">
       {{#if (eq (config "DeploymentEnvironment") "Staging")}}
@@ -20,11 +23,17 @@
       {{#if session.isAuthenticated}}
       {{! Show callsign and logout button on small screens with collapsed navbar}}
         <div class="navbar-text d-md-none float-right">
-          <LinkTo @route="logout" class="btn btn-sm btn-secondary text-white">Logout</LinkTo>
+          <LinkTo @route="logout" class="btn btn-secondary text-white">Logout</LinkTo>
         </div>
-        <div class="navbar-text d-md-none h4 text-black">
+        <div class="navbar-text d-md-none h4 text-black mt-2">
           {{session.user.callsign}}
         </div>
+        {{#if this.session.user.unread_message_count}}
+          <div class="navbar-item d-md-none h4 text-black mt-2">
+            <LinkTo @route="me.messages" class="btn btn-success btn-block text-white">Read {{pluralize
+                    this.session.user.unread_message_count "Message"}}</LinkTo>
+          </div>
+        {{/if}}
       {{/if}}
 
       <ul class="navbar-nav mr-auto">
@@ -353,8 +362,20 @@
       {{#if session.isAuthenticated}}
         <ul class="navbar-nav d-none d-md-inline">
           <li class="nav-item dropdown">
-            <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#">{{session.user.callsign}}</a>
+            <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#">
+              {{#if this.session.user.unread_message_count}}
+                <span class="badge badge-pill badge-success">{{fa-icon
+                        "envelope"}} {{this.session.user.unread_message_count}}</span>
+              {{/if}}
+              {{session.user.callsign}}
+            </a>
             <div class="dropdown-menu">
+              {{#if this.session.user.isRanger}}
+                <LinkTo @route="me.messages" class="dropdown-item">
+                  {{pluralize this.session.user.unread_message_count "message"}}
+                </LinkTo>
+                <div class="dropdown-divider"></div>
+              {{/if}}
               <a href="#" class="dropdown-item" {{action "logout"}}>Logout</a>
             </div>
           </li>

--- a/app/templates/me/messages.hbs
+++ b/app/templates/me/messages.hbs
@@ -1,9 +1,9 @@
-<h1>Clubhouse Messages for <span class="d-inline-block">{{this.person.callsign}}</span></h1>
+<h1>Messages for <span class="d-inline-block">{{this.person.callsign}}</span></h1>
 <BackToHome/>
 
+<ClubhouseMessages @person={{this.person}} @messages={{this.messages}} @isMe={{true}} />
+
 <p>
-  Clubhouse messages are way for various departments to communicate with Rangers
+  Clubhouse messages are way for various Ranger departments to communicate with Rangers
   while the event is happening.
 </p>
-
-<ClubhouseMessages @person={{this.person}} @messages={{this.messages}} />


### PR DESCRIPTION
- New layout using sender photos, and read/unread indicators mirroring the Ranger dashboard.
- Added unread message indicators on top navigation Menu button for mobile screens, and before the callsign dropdown menu on desktops.
- Removed 'from/subject' labels on display.
- Don't ask for sender's callsign when sending from Me > Messages.
- Moved page explanation to below message list.
- Reduced warning text ("be nice or else") from bullet points to two sentences.