### PR TITLE
Person Manage landing and sidebar updates.

### DIFF
--- a/app/components/clubhouse-messages.hbs
+++ b/app/components/clubhouse-messages.hbs
@@ -14,7 +14,7 @@
     </div>
     <div class="col-md-12 col-lg-auto">
     {{#if this.canSendMessages}}
-      <button class="btn btn-primary ml-md-auto btn-md-block" {{on "click" this.newMessageAction}}>{{fa-icon "plus"}}
+      <button class="btn btn-primary ml-md-auto btn-responsive" {{on "click" this.newMessageAction}}>{{fa-icon "plus"}}
         New Message
       </button>
     {{/if}}
@@ -60,7 +60,7 @@
           <div class="mail-actions">
             {{#if message.delivered}}
               <button {{on "click" (fn this.markUnreadAction message)}}
-                      type="button" class="btn btn-secondary btn-md-block" disabled={{message.isSubmitting}}>
+                      type="button" class="btn btn-secondary btn-responsive" disabled={{message.isSubmitting}}>
                 Mark Unread
                 {{#if message.isSubmitting}}
                   {{fa-icon "spinner" spin=true}}
@@ -68,7 +68,7 @@
               </button>
             {{else}}
               <button {{on "click" (fn this.markReadAction message)}}
-                      type="button" class="btn btn-primary btn-md-block" disabled={{message.isSubmitting}}>
+                      type="button" class="btn btn-primary btn-responsive" disabled={{message.isSubmitting}}>
                 Mark Read
                 {{#if message.isSubmitting}}
                   {{fa-icon "spinner" spin=true}}

--- a/app/components/dashboard-group.hbs
+++ b/app/components/dashboard-group.hbs
@@ -7,6 +7,6 @@
     {{yield}}
   </div>
   {{#if @includeSidePhoto}}
-    <PersonPhoto @photo={{@photo}} @person={{@person}} @uploadAction={{@uploadAction}} @noFloat={{true}}/>
+    <PersonPhoto @photo={{@photo}} @person={{@person}} @uploadAction={{@uploadAction}}/>
   {{/if}}
 </div>

--- a/app/components/dashboard-motd.hbs
+++ b/app/components/dashboard-motd.hbs
@@ -20,7 +20,7 @@
         {{nl2br motd.message allowHtml=true}}
         {{#if (not motd.has_read)}}
           <div class="mt-2">
-            <button class="btn btn-secondary btn-md-block" {{action this.markMotdAsRead motd}} disabled={{motd.isMarking}}>
+            <button class="btn btn-secondary btn-responsive" {{action this.markMotdAsRead motd}} disabled={{motd.isMarking}}>
               {{#if motd.isMarking}}
                 <LoadingIndicator @text="Marking read"/>
               {{else}}

--- a/app/components/dashboard-ranger.hbs
+++ b/app/components/dashboard-ranger.hbs
@@ -38,7 +38,7 @@
 {{/if}}
 
 
-<PersonPhoto @photo={{@photo}} @person={{@person}} @uploadAction={{@uploadAction}} />
+<PersonPhoto @photo={{@photo}} @person={{@person}} @uploadAction={{@uploadAction}} @containerClass="ml-2 float-lg-right" />
 
 <div class="mt-1 mb-1">
   {{#if (lte @person.years.length 1)}}

--- a/app/components/dashboard-step.hbs
+++ b/app/components/dashboard-step.hbs
@@ -1,5 +1,5 @@
 {{#if (and @includePhoto (eq @photoPosition "above"))}}
-  <PersonPhoto @photo={{@photo}} @person={{@person}} @uploadAction={{@uploadAction}} />
+  <PersonPhoto @photo={{@photo}} @person={{@person}} @uploadAction={{@uploadAction}} @containerClass="ml-2 float-lg-right" />
 {{/if}}
 <div class="dashboard-step-row {{if @isActive "dashboard-step-active"}}">
   <div class="dashboard-step-title">

--- a/app/components/person-photo.hbs
+++ b/app/components/person-photo.hbs
@@ -1,4 +1,4 @@
-<div class="mugshot {{unless @noFloat "float-sm-right"}}">
+<div class="mugshot {{@containerClass}}">
   {{#if (and (not-eq @photo.photo_status "missing") @photo.photo_url)}}
     <img src="{{@photo.photo_url}}" class="mx-auto d-block" alt="profile photo">
     {{#if (eq @photo.photo_status "approved")}}

--- a/app/components/person/full-form.hbs
+++ b/app/components/person/full-form.hbs
@@ -1,0 +1,235 @@
+{{!
+The Admin, Mentor, and VC form. Not all team may every field listed here.
+
+Everyone else will see person/simple-form
+}}
+{{#if (has-role "admin" "vc" "view-pii" "view-email")}}
+  <div class="row mb-1">
+    <div class="col-sm-6 col-lg-auto">
+      email {{#if @person.email}}
+      {{mail-to @person.email}}
+    {{else}}
+      <i class="text-muted">missing</i>
+    {{/if}}
+    </div>
+    {{#if (has-role "admin" "vc" "view-pii")}}
+      <div class="col-sm-6 col-lg-auto">
+        phone
+        {{#if @person.home_phone}}
+          {{phone-link @person.home_phone}}
+        {{else}}
+          n/a
+        {{/if}}
+      </div>
+      {{#if @person.alt_phone}}
+        <div class="col-sm-6 col-lg-auto">
+          alt phone {{phone-link @person.alt_phone}}
+        </div>
+      {{/if}}
+    {{/if}}
+  </div>
+  <div class="row mb-1">
+    <div class="col-sm-6 col-lg-auto">
+      Last seen
+      {{#if @person.last_seen_at}}
+        {{moment-format @person.last_seen_at "MMM DD, YYYY @ HH:mm"}}
+      {{else}}
+        <i>never</i>
+      {{/if}}
+    </div>
+    <div class="col-sm-6 col-lg-auto">
+      Created
+      {{#if person.create_date}}
+        {{moment-format person.create_date "MMM DD, YYYY @ HH:mm"}}
+      {{else}}
+        <i>prior to 2010</i>
+      {{/if}}
+    </div>
+  </div>
+{{/if}}
+<div class="row mb-3">
+  <div class="col-auto">
+    {{#if @person.years}}
+      {{pluralize @person.years.length 'year'}} worked [{{year-range @person.years}}]
+    {{else}}
+      Has not worked yet
+    {{/if}}
+  </div>
+</div>
+
+<ChForm @formId="person" @formFor={{@person}} @onSubmit={{action @savePersonAction}} as |f|>
+  <div class="form-row mb-2">
+    <label class="col-form-label col-form-label-fixed">Callsign</label>
+    <f.input @name="callsign" @type="text" @size=36 @maxlength=100 @wrapClass="col-sm-12 col-lg-auto"/>
+    <f.input @name="callsign_approved" @type="select" @wrapClass="col-sm-12 col-lg-auto"
+             @options={{@callsignApprovedOptions}} />
+  </div>
+
+  <div class="form-row mb-2">
+    <label class="col-form-label col-form-label-fixed">FKA</label>
+    <f.input @name="formerly_known_as" @type="text" @size=55 @maxlength=200 @wrapClass="col-sm-12 col-lg-auto"/>
+  </div>
+
+  <div class="form-row mb-2">
+    <label class="col-form-label col-form-label-fixed">Status</label>
+    <f.input @name="status" @type="select" @options={{@statusOptions}} @wrapClass="col-auto"/>
+  </div>
+
+  <div class="form-row mb-1">
+    <label class="col-form-label col-form-label-fixed">Personnel</label>
+    {{#if (has-role "admin")}}
+      <div class="col-auto mt-2">
+        <f.input @name="has_note_on_file" @label="Note on file" @value=1 @type="checkbox" @inline={{true}}/>
+      </div>
+    {{else}}
+      <div class="mt-2 col-auto">
+        {{#if @person.has_note_on_file}}
+          <b class="text-danger">Note on file</b>
+        {{else}}
+          <i class="text-muted">no note on file</i>
+        {{/if}}
+      </div>
+    {{/if}}
+  </div>
+
+  <div class="form-row mb-1">
+    <label class="col-form-label col-form-label-fixed">On Site</label>
+    <div class="col-auto mt-2">
+      <f.input @name="on_site" @type="radioGroup" @options={{@onSiteOptions }} @inline={{true}} />
+    </div>
+  </div>
+
+
+  <div class="form-row mb-1">
+    <label for="person_position" class="col-form-label col-form-label-fixed">Positions</label>
+    <div class="col-sm-12 col-lg-9">
+      <div class="row col-12 mt-1 mb-1">
+        <button type="button" {{action @togglePositions}} class="btn btn-secondary btn-sm mr-2">
+          {{if @showPositions "Hide" "Show"}} Positions
+        </button>
+        {{#if (has-role "admin" "grant-position")}}
+          <button type="button" {{action @editPositionsAction}} class="btn btn-secondary btn-sm">
+            Edit Positions
+          </button>
+        {{/if}}
+      </div>
+      {{#unless @personPositions}}
+        <b class="text-danger">No positions granted</b>
+      {{/unless}}
+      {{#if @showPositions}}
+        <div class="row">
+          {{#each @personPositions as |position| }}
+            <div class="col-sm-6 col-xl-4">
+              {{position.title}}
+            </div>
+          {{/each}}
+        </div>
+      {{/if}}
+    </div>
+  </div>
+
+  <div class="form-row mb-1">
+    <label class="col-form-label col-form-label-fixed">Roles</label>
+    <div class="col-sm-12 col-lg-9">
+      <div class="row col-12 mt-1 mb-1">
+        <button type="button" {{action @toggleRoles}} class="btn btn-secondary btn-sm mr-2">
+          {{if @showRoles "Hide" "Show"}} Roles
+        </button>
+        {{#if (has-role "admin")}}
+          <button type="button" {{action @editRolesAction}} class="btn btn-secondary btn-sm">Edit Roles</button>
+        {{/if}}
+      </div>
+      {{#unless @personRoles}}
+        <b class="text-danger">No roles granted</b>
+      {{/unless}}
+      {{#if @showRoles}}
+        <div class="row">
+          {{#each @personRoles as |role| }}
+            <div class="col-sm-6 col-xl-4">
+              {{role.title}}
+            </div>
+          {{/each}}
+        </div>
+      {{/if}}
+    </div>
+  </div>
+
+  <div class="form-row mb-1">
+    <label class="col-form-label col-form-label-fixed">Vehicles</label>
+    <div class="col-sm-12 col-lg-auto mt-2">
+      {{#if (has-role "admin")}}
+        <f.input @name="vehicle_blacklisted" @label="Vehicle Blacklisted" @type="checkbox" @inline={{true}} />
+      {{else if @person.vehicle_blacklisted}}
+        <b class="text-danger">VEHICLE BLACKLISTED</b>
+      {{else}}
+        <i>No blacklisted vehicle</i>
+      {{/if}}
+    </div>
+  </div>
+
+
+  <div class="form-row mb-1">
+    <label class="col-form-label col-form-label-fixed">Certifications</label>
+    <div class="col-sm-12 col-lg-auto mt-2">
+      {{#if (has-role "admin" "vc")}}
+        <f.input @name="osha10" @label="OSHA-10" @type="checkbox" @inline={{true}}  />
+        <f.input @name="osha30" @label="OSHA-30" @type="checkbox" @inline={{true}}  />
+      {{else if (or @person.osha10 @person.osha30)}}
+        {{#if @person.osha10}}OSHA-10{{/if}}
+        {{#if @person.osha30}}OSHA-30{{/if}}
+      {{else}}
+        No OSHA certifications
+      {{/if}}
+    </div>
+  </div>
+
+  <div class="form-row mb-1">
+    <label class="col-form-label col-form-label-fixed">Agreements</label>
+    <div class="col-sm-12 col-lg-9 mt-2">
+      {{#if (has-role "admin" "vc")}}
+        <f.input @name="behavioral_agreement" @label="Burning Man's Behavioral Standards Agreement" @type="checkbox"
+                 @inline={{true}} />
+      {{else}}
+        Behavioral Standards Agreement {{if @person.behavioral_agreement "signed" "NOT SIGNED"}}<br>
+      {{/if}}
+    </div>
+  </div>
+
+  <div class="form-row mb-1">
+    <label class="col-form-label col-form-label-fixed">More Flags</label>
+    <div class="col-sm-12 col-lg-9 mt-2">
+      <LinkTo @route="person.event-info">Person &gt; Event/Training Info</LinkTo>
+      has additional agreements, affidavits, and vehicles flags which are reset every year.
+    </div>
+  </div>
+
+  <div class="form-row mt-2">
+    <label class="col-form-label col-form-label-fixed">&nbsp;</label>
+    <div class="col-sm-12 col-lg-auto mb-4">
+      <f.submit @label="Update" @disabled={{or @person.isSaving (not f.model.isDirty)}} @submitClass="btn-responsive"/>
+    </div>
+    <div class="col-sm-12 col-lg-auto mb-4">
+      {{#if (has-role "admin")}}
+        {{#if @person.message}}
+          <button type="button" class="btn btn-secondary btn-responsive" {{action @editNote}}>
+            Update Note
+          </button>
+        {{else}}
+          <button type="button" class="btn btn-secondary btn-responsive" {{action @confirmNoteOrMessage}}>
+            Add Note
+          </button>
+        {{/if}}
+      {{/if}}
+      {{#if @person.isSaving}}
+        <p>
+          <LoadingIndicator/>
+        </p>
+      {{/if}}
+    </div>
+    {{#if (has-role "admin")}}
+      <div class="col-sm-12 col-lg-auto ml-auto mt-1">
+        <button type="button" class="btn btn-secondary btn-sm" {{action @removePersonAction}}>Remove</button>
+      </div>
+    {{/if}}
+  </div>
+</ChForm>

--- a/app/components/person/simple-form.hbs
+++ b/app/components/person/simple-form.hbs
@@ -1,0 +1,123 @@
+<dl class="row">
+  {{#if (has-role "view-pii" "view-email")}}
+    <dt class="col-sm-12 col-lg-3">Contact</dt>
+    <dd class="col-sm-12 col-lg-9">
+      {{#if @person.email}}
+        email {{mail-to @person.email}}
+      {{else}}
+        <i class="text-muted">missing</i>
+      {{/if}}
+      {{#if (has-role "view-pii")}}
+        <div>
+          phone
+          {{#if @person.home_phone}}
+            {{phone-link @person.home_phone}}
+          {{else}}
+            n/a
+          {{/if}}
+        </div>
+        {{#if @person.alt_phone}}
+          <div>
+            alt phone {{phone-link @person.alt_phone}}
+          </div>
+        {{/if}}
+      {{/if}}
+    </dd>
+  {{/if}}
+  <dt class="col-sm-12 col-lg-3">Years ({{@person.years.length}})</dt>
+  <dd class="col-sm-12 col-lg-9">
+    {{#if @person.years}}
+      {{year-range @person.years}}
+    {{else}}
+      Has not worked yet
+    {{/if}}
+  </dd>
+  <dt class="col-sm-12 col-lg-3">Callsign</dt>
+  <dd class="col-sm-12 col-lg-9">
+    {{#if @person.callsign_approved}}
+      <span class="text-success">{{fa-icon "check"}} Approved</span>
+    {{else}}
+      <span class="text-danger">{{fa-icon "times"}} Not approved</span>
+    {{/if}}
+  </dd>
+  <dt class="col-sm-12 col-lg-3">FKAs</dt>
+  <dd class="col-sm-12 col-lg-9">
+    <PresentOrNot @value={{@person.formerly_known_as}} @empty="no previous callsigns"/>
+  </dd>
+  {{#if @person.has_note_on_file}}
+    <dt class="col-sm-12 col-lg-3">Personnel Note</dt>
+    <dd class="col-sm-12 col-lg-9">
+      <b class="text-danger">Has note on file</b>. Contact the Personnel Manager for more information:
+      {{mail-to (config "PersonnelEmail")}}
+    </dd>
+  {{/if}}
+  <dt class="col-sm-12 col-lg-3">On Site</dt>
+  <dd class="col-sm-12 col-lg-9">
+    <ChForm @formId="person" @formFor={{@person}} @onSubmit={{@savePersonAction}} as |f|>
+      <f.input @name="on_site" @type="radioGroup" @options={{@onSiteOptions}} @inline={{true}} />
+      <f.submit @label="Update" @disabled={{@person.isSaving}} />
+      {{#if @person.isSaving}}
+        <LoadingIndicator/>
+      {{/if}}
+    </ChForm>
+  </dd>
+  <dt class="col-sm-12 col-lg-3">Positions</dt>
+  <dd class="col-sm-12 col-lg-9">
+    <div>
+      <button type="button" {{action @togglePositions}} class="btn btn-secondary btn-sm mr-2">
+        {{if @showPositions "Hide" "Show"}} Positions
+      </button>
+      {{#if (has-role "grant-position")}}
+        <button type="button" {{action @editPositionsAction}} class="btn btn-secondary btn-sm">
+          Edit Positions
+        </button>
+      {{/if}}
+    </div>
+    {{#unless @personPositions}}
+      <b class="text-danger">No positions granted</b>
+    {{/unless}}
+    {{#if @showPositions}}
+      <div class="row">
+        {{#each @personPositions as |position| }}
+          <div class="col-sm-6 col-xl-4">
+            {{position.title}}
+          </div>
+        {{/each}}
+      </div>
+    {{/if}}
+  </dd>
+  <dt class="col-sm-12 col-lg-3">Roles</dt>
+  <dd class="col-sm-12 col-lg-9">
+    <div>
+      <button type="button" {{action @toggleRoles}} class="btn btn-secondary btn-sm mr-2">
+        {{if @showRoles "Hide" "Show"}} Roles
+      </button>
+    </div>
+    {{#unless @personRoles}}
+      <b class="text-danger">No roles granted</b>
+    {{/unless}}
+    {{#if @showRoles}}
+      <div class="row">
+        {{#each @personRoles as |role| }}
+          <div class="col-sm-6 col-xl-4">
+            {{role.title}}
+          </div>
+        {{/each}}
+      </div>
+    {{/if}}
+  </dd>
+  <dt class="col-sm-12 col-lg-3">Certifications</dt>
+  <dd class="col-sm-12 col-lg-9">
+    {{#if (or @person.osha10 @person.osha30)}}
+      {{#if @person.osha10}}OSHA-10{{/if}}
+      {{#if @person.osha30}}OSHA-30{{/if}}
+    {{else}}
+      No OSHA certifications
+    {{/if}}
+  </dd>
+  <dt class="col-sm-12 col-lg-3">&nbsp;</dt>
+  <dd class="col-sm-12 col-lg-9">
+    <LinkTo @route="person.event-info">Person &gt; Event/Training Info</LinkTo>
+    has additional agreements, affidavits, and vehicles flags.
+  </dd>
+</dl>

--- a/app/components/sidebar/link.hbs
+++ b/app/components/sidebar/link.hbs
@@ -6,14 +6,14 @@
 {{else}}
 {{! ARG.. link-to cannot accept an empty dynamic segment}}
   {{#if @routeArg}}
-    <LinkTo @route={{@route}} @model={{@routeArg}}
+    <LinkTo @route={{@route}} @model={{@routeArg}} @query={{@query}}
             class="sidebar-link list-group-item list-group-item-action"
             @activeClass="sidebar-active">
       <Sidebar::LinkText  @iconUrl={{@iconUrl}} @icon={{@icon}} @iconType={{this.iconType}} @title={{@title}}
                             @badgeText={{@badgeText}} />
     </LinkTo>
   {{else}}
-    <LinkTo @route={{@route}}
+    <LinkTo @route={{@route}}  @query={{@query}}
             class="sidebar-link list-group-item list-group-item-action"
             @activeClass="sidebar-active">
       <Sidebar::LinkText  @iconUrl={{@iconUrl}} @icon={{@icon}} @iconType={{this.iconType}} @title={{@title}}

--- a/app/constants/dashboard-steps.js
+++ b/app/constants/dashboard-steps.js
@@ -22,7 +22,7 @@ export const UPLOAD_PHOTO = {
   immediate: true,
   check({photo, isPNV}) {
     if (photo.photo_status !== 'missing') {
-      return {result: isPNV ? COMPLETED : SKIP};
+      return {result: isPNV ? COMPLETED : SKIP, isPhotoStep: (photo.photo_status === 'approved')};
     }
 
     if (!photo.upload_enabled) {
@@ -46,6 +46,7 @@ export const PHOTO_APPROVAL = {
         return {
           result: WAITING,
           message: 'The photo is being reviewed. Usually photos are approved within 2 to 3 days.',
+          isPhotoStep: true,
         }
       case 'rejected':
         reasons = photo.rejections.map((reason) => `<li>${reason}</li>`).join('');

--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -78,4 +78,8 @@ export default class ApplicationController extends Controller {
   get buildTimestamp() {
     return ENV.APP.buildTimestamp;
   }
+
+  get isDevelopment() {
+    return ENV.environment === 'development';
+  }
 }

--- a/app/controllers/person/external-ids.js
+++ b/app/controllers/person/external-ids.js
@@ -1,0 +1,11 @@
+import Controller from '@ember/controller';
+import {action} from '@ember/object';
+
+export default class PersonExternalIdsController extends Controller {
+  @action
+  saveAction(model) {
+    model.save().then(() => {
+      this.toast.success('Person successfully updated');
+    }).catch((response) => this.house.handleErrorResponse(response, model));
+  }
+}

--- a/app/controllers/person/index.js
+++ b/app/controllers/person/index.js
@@ -1,49 +1,41 @@
 import Controller from '@ember/controller';
-import { action } from '@ember/object';
-import { Role } from 'clubhouse/constants/roles';
+import {action} from '@ember/object';
+import {Role} from 'clubhouse/constants/roles';
 import inGroups from 'clubhouse/utils/in-groups';
-import { tracked } from '@glimmer/tracking';
-
-const CallsignApprovedOptions = [
-  ['Approved', true],
-  ['Not Approved', false]
-];
-
-const StatusOptions = [
-  'active',
-  'alpha',
-  'auditor',
-  'bonked',
-  'deceased',
-  'dismissed',
-  'inactive extension',
-  'inactive',
-  'non ranger',
-  'past prospective',
-  'prospective',
-  'resigned',
-  'retired',
-  'suspended',
-  'uberbonked',
-];
-
-const UserAuthorizedOptions = [
-  ['User Enabled', true],
-  ['User Suspended', false]
-];
-
-const OnSiteOptions = [
-  ['On Site', true],
-  ['Off Site', false],
-];
+import {tracked} from '@glimmer/tracking';
 
 export default class PersonIndexController extends Controller {
   person = null;
 
-  callsignApprovedOptions = CallsignApprovedOptions;
-  statusOptions = StatusOptions;
-  userAuthorizedOptions = UserAuthorizedOptions;
-  onSiteOptions = OnSiteOptions;
+  callsignApprovedOptions = [
+    ['Approved', true],
+    ['Not Approved', false]
+  ];
+
+  statusOptions = [
+    'active',
+    'alpha',
+    'auditor',
+    'bonked',
+    'deceased',
+    'dismissed',
+    'inactive extension',
+    'inactive',
+    'non ranger',
+    'past prospective',
+    'prospective',
+    'resigned',
+    'retired',
+    'suspended',
+    'uberbonked',
+  ];
+
+
+  onSiteOptions = [
+    ['On Site', true],
+    ['Off Site', false],
+  ];
+
 
   @tracked personPositions;
   @tracked showPositions = false;
@@ -139,7 +131,7 @@ export default class PersonIndexController extends Controller {
           .catch((response) => this.house.handleErrorResponse(response));
       }
     }).catch((response) => this.house.handleErrorResponse(response, model))
-      .finally(() => this.iSaving = false );
+      .finally(() => this.iSaving = false);
   }
 
   @action
@@ -156,7 +148,7 @@ export default class PersonIndexController extends Controller {
   editNote() {
     this.showConfirmNoteOrMessage = false;
     this.showEditNote = true;
-    this.personNote = { message: this.person.message };
+    this.personNote = {message: this.person.message};
   }
 
   @action
@@ -176,7 +168,7 @@ export default class PersonIndexController extends Controller {
     this.person.save().then(() => {
       this.toast.success('Note update');
       this.showEditNote = false;
-      this.showConfirmNoteOrMessage =false;
+      this.showConfirmNoteOrMessage = false;
     }).catch((response) => this.house.handleErrorResponse(response));
   }
 
@@ -194,8 +186,12 @@ export default class PersonIndexController extends Controller {
       this.modal.confirm(
         'Confirm Action',
         'You are about to disapprove a previously approved callsign. Are you sure you want to do that?',
-        () => { this._savePersonModel(model); },
-        () => { this.toast.warning('The record has not been saved.'); }
+        () => {
+          this._savePersonModel(model);
+        },
+        () => {
+          this.toast.warning('The record has not been saved.');
+        }
       );
     } else {
       this._savePersonModel(model);
@@ -203,7 +199,7 @@ export default class PersonIndexController extends Controller {
   }
 
   @action
-  removePerson() {
+  removePersonAction() {
     this.modal.confirm('Confirm Person Removal',
       'Removing a person is permanent and cannot be ' +
       'undone. All of the information associated with the person will ' +
@@ -236,7 +232,7 @@ export default class PersonIndexController extends Controller {
     this.toast.clear();
     this.ajax.request(`person/${this.person.id}/positions`, {
       type: 'POST',
-      data: { position_ids: positionIds }
+      data: {position_ids: positionIds}
     }).then((results) => {
       this.toast.success('The positions have been successfully updated.');
       this.personPositions = results.positions;
@@ -245,12 +241,14 @@ export default class PersonIndexController extends Controller {
         // Reload the user.
         this.session.loadUser();
       }
-    }).catch((response) => { this.house.handleErrorResponse(response) });
+    }).catch((response) => {
+      this.house.handleErrorResponse(response)
+    });
   }
 
   @action
   cancelPositions() {
-    this.editPositions =  false;
+    this.editPositions = false;
   }
 
   @action
@@ -270,7 +268,7 @@ export default class PersonIndexController extends Controller {
     this.isSavingRoles = true;
     this.ajax.request(`person/${this.person.id}/roles`, {
       type: 'POST',
-      data: { role_ids: roleIds }
+      data: {role_ids: roleIds}
     }).then((results) => {
       this.toast.success('The roles have been successfully updated.');
       this.personRoles = results.roles;
@@ -279,7 +277,9 @@ export default class PersonIndexController extends Controller {
         // Reload the user.
         this.session.loadUser();
       }
-    }).catch((response) => { this.house.handleErrorResponse(response) })
+    }).catch((response) => {
+      this.house.handleErrorResponse(response)
+    })
       .finally(() => this.isSavingRoles = false);
   }
 

--- a/app/helpers/phone-link.js
+++ b/app/helpers/phone-link.js
@@ -1,8 +1,35 @@
-import { helper } from '@ember/component/helper';
-import { htmlSafe } from '@ember/string';
+import {helper} from '@ember/component/helper';
+import {htmlSafe} from '@ember/string';
+import {parsePhoneNumberFromString, ParseError} from 'libphonenumber-js'
 
-export function phoneLink([ phone ]) {
-    return htmlSafe(`<a href="tel:${phone}">${phone}</a>`)
+export function phoneLink([number]) {
+  let phoneURI, phoneFormatted, suffix = '';
+
+  try {
+    const normalized = number.replace(/[^\w]+/g, '');
+    const phone = parsePhoneNumberFromString(number, (normalized.length === 10 || (normalized.length === 11 && normalized.substr(0,1) === '1'))  ? 'US' : undefined);
+    if (phone) {
+      if (phone.country === 'US') {
+        phoneFormatted = phone.formatNational();
+      } else {
+        phoneFormatted = phone.formatInternational();
+        suffix = ` (${phone.country})`;
+      }
+      phoneURI = phone.getURI();
+    } else {
+      phoneFormatted = number;
+      phoneURI = `tel:${number}`;
+    }
+  } catch (error) {
+    if (error instanceof ParseError) {
+     phoneFormatted = number;
+     phoneURI = `tel:${number}`;
+    } else {
+      throw error;
+    }
+  }
+
+  return htmlSafe(`<a href="${phoneURI}">${phoneFormatted}</a>${suffix}`)
 }
 
 export default helper(phoneLink);

--- a/app/helpers/year-range.js
+++ b/app/helpers/year-range.js
@@ -1,0 +1,38 @@
+import {helper} from '@ember/component/helper';
+
+export default helper(function yearRange([years]) {
+  const ranges = [];
+
+  let currentYear = 0, startYear = 0;
+
+  if (years.length === 0) {
+    return 'none';
+  }
+
+  years.forEach((year) => {
+    if (startYear === 0) {
+      startYear = year;
+      currentYear = year;
+      return;
+    }
+
+    if (currentYear + 1 === year) {
+      currentYear = year;
+      return;
+    }
+
+    if (startYear == currentYear) {
+      ranges.push(startYear);
+    } else {
+      ranges.push(`${startYear} - ${currentYear}`);
+    }
+    startYear = currentYear = year;
+  });
+
+  if (startYear === currentYear) {
+    ranges.push(startYear);
+  } else {
+    ranges.push(`${startYear} - ${currentYear}`);
+  }
+  return ranges.join(', ');
+});

--- a/app/mixins/models/person.js
+++ b/app/mixins/models/person.js
@@ -29,6 +29,10 @@ export default Mixin.create({ // eslint-disable-line ember/no-new-mixins
     return this.status == PersonStatus.DECEASED;
   }),
 
+  isDismissed: computed('status', function () {
+    return this.status == PersonStatus.DISMISSED;
+
+  }),
 
   isSuspended: computed('status', function() {
     return this.status == PersonStatus.SUSPENDED;

--- a/app/router.js
+++ b/app/router.js
@@ -137,6 +137,7 @@ Router.map(function () {
     this.route('photos');
     this.route('status-history');
     this.route('unified-flagging');
+    this.route('external-ids');
   });
 
   this.route('logout');

--- a/app/routes/person/external-ids.js
+++ b/app/routes/person/external-ids.js
@@ -1,0 +1,12 @@
+import Route from '@ember/routing/route';
+import {Role} from 'clubhouse/constants/roles';
+
+export default class PersonExternalIdsRoute extends Route {
+  beforeModel() {
+    this.house.roleCheck(Role.ADMIN);
+
+  }
+  setupController(controller) {
+    controller.set('person', this.modelFor('person'));
+  }
+}

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -142,15 +142,15 @@ $sizes: (
   }
 }
 
-h1 select option {
+h1 select, h1 option, .h1 select, .h1 option {
   font-size: $h1-font-size;
 }
 
-h2 select option {
+h2 select, h2 option, .h2 select, .h2 option {
   font-size: $h2-font-size;
 }
 
-h3 select option {
+h3 select, h3 option, .h3 select, .h3 option {
   font-size: $h3-font-size;
 }
 
@@ -275,15 +275,14 @@ ul.nav-pills li {
 }
 
 legend {
-  padding-left: 10px;
-  border-bottom: 1px solid #ececec;
+  border-bottom: 1px solid #dcdcdc;
   font-size: 1rem;
   font-weight: bold;
 }
 
 .form-group,
 .form-row {
-  padding-left: 10px;
+  //padding-left: 10px;
 }
 
 .form-check-label:hover {
@@ -298,28 +297,8 @@ legend {
   }
 }
 
-/* Messages */
-
-.person-message-box {
-  margin-bottom: 10px;
-}
-
-.person-message-header {
-  padding: 10px 0;
-  margin-bottom: 10px;
-  background-color: #f0f0f0;
-}
-
 .year-select {
   font-size: 1.4em;
-}
-
-.error-pane {
-  margin: 25px auto;
-}
-
-.error-message {
-  color: red;
 }
 
 .loading-pane {
@@ -427,23 +406,31 @@ caption {
   border: 0 !important;
 }
 
-.col-form-label-fixed {
-  width: 100px !important;
-  max-width: 100px;
-  min-width: 100px;
+@include media-breakpoint-down(md) {
+  .col-form-label-fixed {
+    width: 100% !important;
+    display: block;
+  }
 }
+
+@include media-breakpoint-up(lg) {
+  .col-form-label-fixed {
+    width: 120px !important;
+  }
+}
+
 
 /*
  * Toastr message overrides
  */
 
-@media only screen and (max-width: 799px) {
+@include media-breakpoint-down(md) {
   #toast-container > div {
     width: 96% !important;
   }
 }
 
-@media only screen and (min-width: 800px) {
+@include media-breakpoint-up(lg) {
   #toast-container > div {
     width: 500px !important;
   }
@@ -635,17 +622,28 @@ caption {
   }
 }
 
-@include media-breakpoint-down(sm) {
+@include media-breakpoint-down(md) {
   .homepage-title {
-    font-size: 5vw;
+    font-size: 4vw;
   }
 }
 
-
-
 @include media-breakpoint-down(md) {
-  .btn-md-block {
+  .btn-responsive {
     display: block;
     width: 100%;
   }
+}
+
+.person-manage-header {
+  @include make-row();
+  background-color: #f4f4f4 !important;
+  margin-top: -10px;
+  margin-bottom: 10px;
+  padding-top: 10px;
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.max-width-900 {
+  max-width: 900px;
 }

--- a/app/styles/photo.scss
+++ b/app/styles/photo.scss
@@ -25,7 +25,7 @@
 
   img {
     display: block;
-    max-width: 140px;
+    width: 140px;
     margin-bottom:5px;
   }
 }

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -383,7 +383,7 @@
       {{/if}}
     </div>
   </nav>
-  {{#if (has-role "admin" "manage" "view-pii" "mentor")}}
+  {{#if (has-role "admin" "manage" "vc" "mentor")}}
     <SearchItemBar/>
   {{/if}}
 </header>
@@ -393,7 +393,7 @@
     <div class="h4 alert alert-light-red text-center p-2 m-0">
       Training Server - Simulated Time {{moment-format this.groundHogDayTime "dddd, MMMM Do YYYY @ HH:mm"}}
     </div>
-  {{else if (eq (config "DeploymentEnvironment") "Staging")}}
+  {{else if (and (not this.isDevelopment) (eq (config "DeploymentEnvironment") "Staging"))}}
     <div class="h4 alert alert-light-red text-center p-2 m-0 d-print-none">
       You are on the Staging Server used for testing. This is not the production server.
     </div>

--- a/app/templates/person.hbs
+++ b/app/templates/person.hbs
@@ -5,7 +5,8 @@
     <s.link @route="person.event-info" @title="Event/Training Info" @icon="user" @iconType="s"/>
     <s.link @route="person.timesheet" @title="Timesheets" @icon="clock"/>
     <s.link @route="person.assets" @title="Assets" @icon="broadcast-tower" @iconType="s"/>
-    <s.link @route="person.messages" @title="Messages" @icon="envelope" @badgeText={{this.person.unread_message_count}} />
+    <s.link @route="person.messages" @title="Messages" @icon="envelope"
+            @badgeText={{this.person.unread_message_count}} />
     {{#if (has-role "admin" "manage+view-pii")}}
       <s.link @route="person.personal-info" @title="Personal Info" @icon="home" @iconType="s"/>
     {{/if}}
@@ -19,44 +20,88 @@
       <s.link @route="person.password" @title="Change Password" @icon="key" @iconType="s"/>
     {{/if}}
   </s.group>
-</ChSidebar>
 
-<main class="col">
-  {{#if (or this.person.isSuspended this.person.isResigned this.person.isDeceased this.person.isUberBonked this.person.isDismissed)}}
-    <ChAlert @type="danger">
-      {{fa-icon "exclamation-triangle" size="2x"}} The account has the status "{{person.status}}"
-      and is not accessible. Contact the Personnel Manager: {{mail-to (config "PersonnelEmail")}}.
-    </ChAlert>
-  {{else if this.person.needsBpguid}}
-    <ChAlert @type="danger">
-      Account does not have a Burner Profile ID on file. Signups and ticketing are disabled.
-    </ChAlert>
+  {{#if (has-role "admin" "vc" "intake")}}
+    <s.group @title="Vol Coords">
+      {{#if (has-role "intake")}}
+        <s.link @route="person.unified-flagging" @title="Unified Flagging" @icon="flag"/>
+      {{/if}}
+      {{#if (has-role "admin" "vc")}}
+        <s.link @route="person.dashboard" @title="Dashboard" @icon="columns" @iconType="s"/>
+      {{/if}}
+      {{#if (has-role "admin")}}
+        <s.link @route="person.external-ids" @title="External IDs" @icon="external-link-alt" @iconType="s"/>
+      {{/if}}
+    </s.group>
   {{/if}}
 
-  <div class="d-flex flex-lg-row flex-column justify-content-between">
-    <h2 class="align-middle">
-      <PersonLink @person={{this.person}} /> &lt;{{this.person.status}}{{if this.person.vintage "/vintage"}}
-      , {{this.person.first_name}} {{this.person.last_name}}&gt;
+  {{#if  (has-role "edit-bmids" "edit-access-docs")}}
+    <s.group @title="PRE-PLAYA">
+      {{#if (has-role "edit-bmids")}}
+        <s.link @route="person.bmid" @title="BMID" @icon="id-badge" @iconType="s"/>
+      {{/if}}
+      {{#if (has-role "edit-access-docs")}}
+        <s.link @route="person.access-documents" @title="Access Documents" @icon="ticket-alt" @iconType="s"/>
+      {{/if}}
+    </s.group>
+  {{/if}}
+
+  {{#if (has-role "admin" "vc")}}
+    <s.group @title="Logs">
+      {{#if (has-role "admin")}}
+        <s.link @route="admin.action-log" @title="Action Log" @query={{hash person=person.callsign}} @icon="arrows-alt"
+                @iconType="s"/>
+        <s.link @route="person.contact-log" @title="Contact Log" @icon="paper-plane"/>
+        <s.link @route="person.broadcast-log" @title="Broadcast Log" @icon="volume-up" @iconType="s"/>
+      {{/if}}
+      {{#if (has-role "admin" "vc")}}
+        <s.link @route="person.status-history" @title="Status History" @icon="history" @iconType="s"/>
+        <s.link @route="person.photos" @title="Photo History" @icon="portrait" @iconType="s"/>
+      {{/if}}
+    </s.group>
+  {{/if}}
+</ChSidebar>
+
+<main class="col ">
+  <div class="person-manage-header">
+    <h2 class="homepage-title col-sm-12 col-lg-auto">
+      <PersonLink @person={{this.person}} />
+      <span class="d-inline-block">
+        &lt;{{this.person.status}}{{if this.person.vintage "/vintage"}}
+        , {{this.person.first_name}} {{this.person.last_name}}&gt;
+      </span>
       {{#if this.person.callsign_pronounce}}
         <br><i>"{{this.person.callsign_pronounce}}"</i>
       {{/if}}
     </h2>
-    <div class="text-muted align-middle">Person Manage</div>
-    <div class="text-right align-middle">
+    <div class="col-sm-12 col-lg-auto ml-lg-auto">
       <LinkTo @route="hq.index" @model={{this.person.id}}>Switch to HQ Window</LinkTo>
     </div>
+    {{#if (or this.person.isSuspended this.person.isResigned this.person.isDeceased this.person.isUberBonked this.person.isDismissed)}}
+      <div class="col-12 mb-2">
+        <h5 class="text-danger">
+          {{fa-icon "exclamation-triangle"}} The account has the status "{{this.person.status}}" and may not be logged
+          into.
+        </h5>
+        For more information, contact the Personnel Manager: {{mail-to (config "PersonnelEmail")}}
+      </div>
+    {{else if this.person.needsBpguid}}
+      <div class="h4 col-12 text-danger">
+        Account does not have a Burner Profile ID on file. Signups and ticketing are disabled.
+      </div>
+    {{/if}}
+
   </div>
+
 
   {{#if this.person.message}}
     <ChBox @title="Important Account Message" @type="warning">
       {{nl2br this.person.message}}
-      <div class="mt-2 text-muted">Message added {{shift-format this.person.message_updated_at}}</div>
+      <div class="mt-2 text-muted">Posted {{shift-format this.person.message_updated_at}}</div>
     </ChBox>
   {{/if}}
 
-  <hr class="mt-1 mr-n2 ml-n2">
-
-  <div class="row d-lg-none mb-2">
+  <div class="row d-lg-none mb-2 max-width-900">
     {{!
       The drop down menu only appear on mobile/small screen devices
       When adding new areas, be sure to add the link to person-sidebar.hbs
@@ -65,7 +110,7 @@
       <div class="btn-group btn-block">
         <button type="button" class="btn btn-info dropdown-toggle" data-toggle="dropdown" aria-haspopup="true"
                 aria-expanded="false">
-          Account Section
+          Account Management Pages
         </button>
         <div class="dropdown-menu w-100">
           <LinkTo @route="person.index" @model={{this.person.id}} class="dropdown-item">Account Info</LinkTo>
@@ -86,6 +131,41 @@
           {{/if}}
           {{#if (has-role "admin")}}
             <LinkTo @route="person.password" @model={{this.person.id}} class="dropdown-item">Change Password</LinkTo>
+          {{/if}}
+          {{#if (has-role "admin" "vc" "intake")}}
+            <div class="dropdown-header">Vol Coords</div>
+            {{#if (has-role "intake")}}
+              <LinkTo @route="person.unified-flagging" class="dropdown-item">Unified Flagging</LinkTo>
+            {{/if}}
+            {{#if (has-role "admin" "vc")}}
+              <LinkTo @route="person.dashboard" class="dropdown-item">Dashboard</LinkTo>
+            {{/if}}
+            {{#if (has-role "admin")}}
+              <LinkTo @route="person.external-ids" class="dropdown-item">External IDs</LinkTo>
+            {{/if}}
+          {{/if}}
+
+          {{#if  (has-role "edit-bmids" "edit-access-docs")}}
+            <div class="dropdown-header">Pre-Playa</div>
+            {{#if (has-role "edit-bmids")}}
+              <LinkTo @route="person.bmid" class="dropdown-item">BMID</LinkTo>
+            {{/if}}
+            {{#if (has-role "edit-access-docs")}}
+              <LinkTo @route="person.access-documents" class="dropdown-item">Access Documents</LinkTo>
+            {{/if}}
+          {{/if}}
+
+          {{#if (has-role "admin" "vc")}}
+            <div class="dropdown-header">Logs</div>
+            <LinkTo @route="person.photos" class="dropdown-item">Photo History</LinkTo>
+            <LinkTo @route="person.status-history" class="dropdown-item">Status History</LinkTo>
+            {{#if (has-role "admin")}}
+              <LinkTo @route="person.contact-log" class="dropdown-item">Contact Log</LinkTo>
+              <LinkTo @route="person.broadcast-log" class="dropdown-item">Broadcast Log</LinkTo>
+              <LinkTo @route="admin.action-log" @query={{hash person=person.callsign}} class="dropdown-item">
+                Action Log
+              </LinkTo>
+            {{/if}}
           {{/if}}
         </div>
       </div>

--- a/app/templates/person/external-ids.hbs
+++ b/app/templates/person/external-ids.hbs
@@ -1,0 +1,22 @@
+<h2>External Account Identifiers</h2>
+<p>
+  This page shows the identifiers used to associate this Clubhouse account with external websites
+  such as Burner Profiles, the Docedo Learning Management System, etc.
+</p>
+<ChForm @formId="person" @formFor={{this.person}} @onSubmit={{action this.saveAction}} as |f|>
+  <div class="form-row mb-2">
+    <f.input @name="bpguid" @label="Burner Profile Global UID (BPGUID)" @type="text" @size=40 @maxlength=200
+             @grid="col-auto"/>
+  </div>
+
+  <div class="form-row mb-2">
+    <f.input @name="lms_id" @label="Docebo Account ID (aka learning.burningman.org)" @type="text" @size=40 @maxlength=200 @grid="col-auto"/>
+  </div>
+
+  <div class="form-row">
+    <f.submit @label="Update"/>
+    {{#if this.person.isSaving}}
+      <LoadingIndicator/>
+    {{/if}}
+  </div>
+</ChForm>

--- a/app/templates/person/index.hbs
+++ b/app/templates/person/index.hbs
@@ -9,357 +9,49 @@
   </p>
 {{/if}}
 
-<PersonPhoto @photo={{this.photo}} @person={{this.person}} @uploadAction={{this.showUploadDialogAction}} />
-
-<ChForm @formId="person" @formFor={{this.person}} @onSubmit={{action this.savePersonAction}} as |f|>
-
-  {{! The following block is floated left on md or larger screen to ensure
-    the photo is on the right and the form flows around it.
-  }}
-  <div class="float-md-left">
-    {{! show contact information }}
-    {{#if (has-role "admin" "vc" "view-pii" "view-email")}}
-      <div class="form-row mb-2">
-        <label class="col-form-label col-form-label-fixed col-sm-12 col-lg-2">Contact</label>
-        <div class="mt-2 col-auto">
-          <span class="d-inline-block">
-            {{#if this.person.email}}
-              email {{mail-to this.person.email}}
-            {{else}}
-              <i class="text-muted">missing</i>
-            {{/if}}
-          </span>
-          {{#if (has-role "admin" "vc" "view-pii")}}
-            <span class="d-inline-block ml-lg-2">
-              phone
-              {{#if this.person.home_phone}}
-                {{phone-link this.person.home_phone}}
-              {{else}}
-                n/a
-              {{/if}}
-            </span>
-            {{#if this.person.alt_phone}}
-              <span class="d-inline-block ml-md-2">alt phone {{phone-link this.person.alt_phone}}</span>
-            {{/if}}
-          {{/if}}
-
-          <div class="mt-2">
-            <span class="d-inline-block">last seen
-              {{#if this.person.last_seen_at}}
-                {{moment-format this.person.last_seen_at "MMM DD, YYYY @ HH:mm"}}
-              {{else}}
-                <i>unknown</i>
-              {{/if}}
-              </span>
-            <span class="ml-lg-2 d-inline-block">reviewed P.I
-              {{#if this.person.reviewed_pi_at}}
-                {{moment-format this.person.reviewed_pi_at "MMM DD, YYYY @ HH:mm"}}
-              {{else}}
-                <i>unknown</i>
-              {{/if}}
-            </span>
-          </div>
-        </div>
-      </div>
-    {{/if}}
-
-    <div class="form-row mb-2">
-      <label class="col-form-label col-form-label-fixed col-sm-12 col-lg-2">Callsign</label>
-      {{#if (has-role "admin" "mentor" "vc")}}
-        <f.input @name="callsign" @type="text" @size=35 @maxlength=100 @wrapClass="col-auto"/>
-      {{else}}
-        <div class="mt-2 col-auto">
-          {{this.person.callsign}}
-        </div>
-      {{/if}}
-    </div>
-
-    <div class="form-row mb-2">
-      <label class="col-form-label col-form-label-fixed col-sm-12 col-lg-2">FKA</label>
-      {{#if (has-role "admin" "mentor" "vc")}}
-        <f.input @name="formerly_known_as" @type="text" @size=35 @maxlength=200 @wrapClass="col-auto"/>
-      {{else}}
-        <div class="mt-2 col-auto">
-          <PresentOrNot @value={{this.person.formerly_known_as}} @empty="no previous callsigns"/>
-        </div>
-      {{/if}}
-    </div>
-
-    <div class="form-row mb-2">
-      <label class="col-form-label col-form-label-fixed col-2">Callsign Approved</label>
-      {{#if (has-role "admin" "mentor" "vc")}}
-        <f.input @name="callsign_approved" @type="select" @grid="col-auto"
-                 @options={{this.callsignApprovedOptions}} />
-      {{else}}
-        <div class="mt-2 col-sm-12 col-md-auto">
-          {{if this.person.callsign_approved "Approved" "Not Approved"}}
-        </div>
-      {{/if}}
-    </div>
-
-    <div class="form-row mb-2">
-      <label class="col-form-label col-form-label-fixed col-2">Status</label>
-      {{#if (has-role "admin" "mentor" "vc")}}
-        <f.input @name="status" @type="select" @options={{this.statusOptions}} @grid="col-auto"/>
-      {{else}}
-        <div class="mt-2 col-auto">
-          {{this.person.status}}
-        </div>
-      {{/if}}
-    </div>
-
-    <div class="form-row mb-2">
-      <label class="col-form-label col-form-label-fixed col-2">Personnel</label>
-      {{#if (has-role "admin")}}
-        <div class="col-auto mt-2">
-          <f.input @name="has_note_on_file" @label="Note on file" @value=1 @type="checkbox" @inline={{true}}/>
-        </div>
-      {{else}}
-        <div class="mt-2 col-auto">
-          {{#if this.person.has_note_on_file}}
-            <b class="text-danger">Note on file</b>
-          {{else}}
-            <i class="text-muted">no note on file</i>
-          {{/if}}
-        </div>
-      {{/if}}
-    </div>
-  </div>
-
-  {{!
-   Ensure the following is not floated next to photo
-  }}
-  <div class="clearfix"></div>
-
-  <div class="form-row mb-2">
-    <label class="col-form-label col-form-label-fixed col-sm-12 col-lg-2">Name</label>
+<div class="row">
+  <div class="col-sm-12 col-lg-9">
     {{#if (has-role "admin" "mentor" "vc")}}
-      <f.input @name="first_name" @type="text" @size=20 @maxlength=25 @grid="col-sm-12 col-lg-auto"/>
-      <f.input @name="mi" @type="text" @size=2 @maxlength=10 @grid="col-sm-12 col-lg-auto"/>
-      <f.input @name="last_name" @type="text" @size=20 @maxlength=25 @grid="col-sm-12 col-lg-auto"/>
+      <Person::FullForm @person={{this.person}}
+                            @savePersonAction={{this.savePersonAction}}
+                            @callsignApprovedOptions={{this.callsignApprovedOptions}}
+                            @statusOptions={{this.statusOptions}}
+                            @onSiteOptions={{this.onSiteOptions}}
+
+                            @personRoles={{this.personRoles}}
+                            @toggleRoles={{this.toggleRoles}}
+                            @showRoles={{this.showRoles}}
+                            @editRolesAction={{this.editRolesAction}}
+
+                            @personPositions={{this.personPositions}}
+                            @togglePositions={{this.togglePositions}}
+                            @showPositions={{this.showPositions}}
+                            @editPositionsAction={{this.editPositionsAction}}
+
+                            @editNote={{this.editNote}}
+                            @confirmNoteOrMessage={{this.confirmNoteOrMessage}}
+                            @removePersonAction={{this.removePersonAction}}
+      />
     {{else}}
-      <div class="mt-2 col-sm-12 col-lg-9">
-        {{this.person.first_name}} {{this.person.mi}} {{this.person.last_name}}
-      </div>
+      <Person::SimpleForm @person={{this.person}}
+                          @savePersonAction={{this.savePersonAction}}
+                          @onSiteOptions={{this.onSiteOptions}}
+
+                          @personRoles={{this.personRoles}}
+                          @toggleRoles={{this.toggleRoles}}
+                          @showRoles={{this.showRoles}}
+
+                          @personPositions={{this.personPositions}}
+                          @togglePositions={{this.togglePositions}}
+                          @showPositions={{this.showPositions}}
+                          @editPositionsAction={{this.editPositionsAction}}
+      />
     {{/if}}
   </div>
-
-  <div class="form-row mb-2">
-    <label class="col-form-label-fixed col-2">On Site</label>
-    <div class="col-8">
-      <f.input @name="on_site" @type="radioGroup" @options={{this.onSiteOptions }} @inline={{true}} />
-    </div>
+  <div class="col-sm-12 col-lg-1">
+    <PersonPhoto @photo={{this.photo}} @person={{this.person}} @uploadAction={{this.showUploadDialogAction}} />
   </div>
-
-  <div class="form-row mb-2">
-    <label for="person_position" class="col-form-label col-form-label-fixed col-sm-12 col-lg-2">Positions</label>
-    <div class="col-md-9 col-sm-12">
-      <div class="row col-12 mt-1 mb-2">
-        <button type="button" {{action this.togglePositions}} class="btn btn-secondary btn-sm mr-2">
-          {{if this.showPositions "Hide" "Show"}} Positions
-        </button>
-        {{#if (has-role "admin" "grant-position")}}
-          <button type="button" {{action "editPositionsAction"}} class="btn btn-secondary btn-sm">Edit Positions
-          </button>
-        {{/if}}
-      </div>
-      {{#unless this.personPositions}}
-        <div class="row">
-          <div class="col-12">
-            <strong class="text-danger">Person does not hold any positions</strong>
-          </div>
-        </div>
-      {{/unless}}
-      {{#if this.showPositions}}
-        <div class="row">
-          {{#each this.personPositions as |position| }}
-            <div class="col-sm-6 col-md-4 col-xl-3">
-              {{position.title}}
-            </div>
-          {{/each}}
-        </div>
-      {{/if}}
-    </div>
-  </div>
-
-  <div class="form-row mb-2">
-    <label class="col-form-label col-form-label-fixed col-sm-12 col-lg-2">Roles</label>
-    <div class="col-md-9 col-sm-12">
-      <div class="row col-12 mt-1 mb-2">
-        <button type="button" {{action this.toggleRoles}} class="btn btn-secondary btn-sm mr-2">
-          {{if this.showRoles "Hide" "Show"}} Roles
-        </button>
-        {{#if (has-role "admin")}}
-          <button type="button" {{action this.editRolesAction}} class="btn btn-secondary btn-sm">Edit Roles</button>
-        {{/if}}
-      </div>
-      {{#unless this.personRoles}}
-        <strong class="text-danger">Person does not hold any roles</strong>
-      {{/unless}}
-      {{#if this.showRoles}}
-        <div class="row">
-          {{#each this.personRoles as |role| }}
-            <div class="col-sm-6 col-md-4 col-xl-3">
-              {{role.title}}
-            </div>
-          {{/each}}
-        </div>
-      {{/if}}
-    </div>
-  </div>
-
-  <div class="form-row mb-2">
-    <label class="col-form-label-fixed col-sm-12 col-lg-2">Years</label>
-    <div class="col-md-9 col-sm-12">
-      {{#each this.person.years as |year|}}{{year}} {{/each}} ({{this.person.years.length}})
-    </div>
-  </div>
-
-  <div class="form-row mb-2">
-    <label class="col-form-label-fixed col-sm-12 col-lg-2">Vehicles</label>
-    <div class="col-md-9 col-sm-12">
-      {{#if (has-role "admin")}}
-        <f.input @name="vehicle_blacklisted" @label="Vehicle Blacklisted" @type="checkbox" @inline={{true}} />
-      {{else if this.person.vehicle_blacklisted}}
-        <b class="text-danger">VEHICLE BLACKLISTED</b>
-      {{else}}
-        <i>No blacklisted vehicle</i>
-      {{/if}}
-    </div>
-  </div>
-
-
-  <div class="form-row mb-2">
-    <label class="col-form-label-fixed col-sm-12 col-lg-2">Certifications</label>
-    <div class="col-sm-12 col-md-9">
-      {{#if (has-role "admin" "vc")}}
-        <f.input @name="osha10" @label="OSHA-10" @type="checkbox" @inline={{true}}  />
-        <f.input @name="osha30" @label="OSHA-30" @type="checkbox" @inline={{true}}  />
-      {{else if (or this.person.osha10 this.person.osha30)}}
-        {{#if this.person.osha10}}OSHA-10{{/if}}
-        {{#if this.person.osha30}}OSHA-30{{/if}}
-      {{else}}
-        No OSHA certifications
-      {{/if}}
-    </div>
-  </div>
-
-  <div class="form-row mb-2">
-    <label class="col-form-label-fixed col-sm-12 col-lg-2">Agreements</label>
-    <div class="col-sm-12 col-md-9">
-      {{#if (has-role "admin" "vc")}}
-        <f.input @name="behavioral_agreement" @label="Burning Man's Behavioral Standards Agreement" @type="checkbox"
-                 @inline={{true}} />
-      {{else}}
-        Behavioral Standards Agreement {{if this.person.behavioral_agreement "signed" "NOT SIGNED"}}<br>
-      {{/if}}
-    </div>
-  </div>
-
-  {{#if (has-role "admin")}}
-    <div class="form-row mb-2">
-      <label class="col-form-label col-form-label-fixed col-sm-12 col-lg-2">BPGUID</label>
-      <f.input @name="bpguid" @type="text" @size=35 @maxlength=200 @grid="col-auto"/>
-    </div>
-
-    <div class="form-row mb-2">
-      <label class="col-form-label col-form-label-fixed col-sm-12 col-lg-2">LMS ID</label>
-      <f.input @name="lms_id" @type="text" @size=35 @maxlength=200 @grid="col-auto"/>
-    </div>
-  {{/if}}
-
-  <div class="form-row mb-2">
-    <label class="col-form-label-fixed col-sm-12 col-lg-2">BMID/Tickets</label>
-    <div class="col-sm-12 col-md-9">
-      {{#if  (has-role "edit-bmids" "edit-access-docs")}}
-        {{#if (has-role "edit-bmids")}}
-          <LinkTo @route="person.bmid" class="btn btn-secondary btn-sm">Edit BMID</LinkTo>
-        {{/if}}
-        {{#if (has-role "edit-access-docs")}}
-          <LinkTo @route="person.tickets" class="btn btn-secondary btn-sm">View Tickets &amp; Stuff</LinkTo>
-          <LinkTo @route="person.access-documents" class="btn btn-secondary btn-sm">Edit Access Docs</LinkTo>
-        {{/if}}
-      {{else}}
-        <div class="text-muted">No permission to edit BMID and/or access documents.</div>
-      {{/if}}
-    </div>
-  </div>
-
-  {{#if (has-role "admin" "vc" "intake")}}
-    <div class="form-row mb-2">
-      <label class="col-form-label-fixed col-sm-12 col-lg-2">VC</label>
-      <div class="col-sm-12 col-md-9">
-        {{#if (has-role "admin" "vc")}}
-          <LinkTo @route="person.dashboard" class="btn btn-secondary btn-sm">View Dashboard</LinkTo>
-          <LinkTo @route="person.photos" class="btn btn-secondary btn-sm">Photo History</LinkTo>
-        {{/if}}
-        <LinkTo @route="person.status-history" class="btn btn-secondary btn-sm">Status History</LinkTo>
-        {{#if (has-role "intake")}}
-          <LinkTo @route="person.unified-flagging" class="btn btn-secondary btn-sm">Unified Flagging</LinkTo>
-        {{/if}}
-      </div>
-    </div>
-  {{/if}}
-  {{#if (has-role "admin")}}
-    <div class="form-row mb-2">
-      <label class="col-form-label-fixed col-sm-12 col-lg-2">Logs</label>
-      <div class="col-sm-12 col-md-9 ">
-        <LinkTo @route="person.contact-log" class="btn btn-secondary btn-sm">Contact Log</LinkTo>
-        <LinkTo @route="person.broadcast-log" class="btn btn-secondary btn-sm">Broadcast Log</LinkTo>
-        <LinkTo @route="admin.action-log" @query={{hash person=person.callsign}} class="btn btn-secondary btn-sm">
-          Action
-          Log
-        </LinkTo>
-      </div>
-    </div>
-
-    <div class="form-row mb-2">
-      <label class="col-form-label-fixed col-sm-12 col-lg-2">Note</label>
-      <div class="col-sm-12 col-md-9">
-        {{#if this.person.message}}
-          <button type="button" class="btn btn-secondary btn-sm" {{action this.editNote}}>Update Note</button>
-        {{else}}
-          <button type="button" class="btn btn-secondary btn-sm" {{action this.confirmNoteOrMessage}}>Add Note
-          </button>
-        {{/if}}
-
-      </div>
-    </div>
-  {{/if}}
-
-  <div class="form-row mb-2">
-    <label class="col-form-label-fixed col-sm-12 col-lg-2">Created</label>
-    <div class="col-sm-12 col-md-9">
-      {{#if person.create_date}}
-        {{person.create_date}}
-      {{else}}
-        <i>created prior to 2010</i>
-      {{/if}}
-    </div>
-  </div>
-
-  <div class="form-row mb-2">
-    <label class="col-form-label-fixed col-sm-12 col-lg-2">Modified</label>
-    <div class="col-sm-12 col-md-9">
-      {{person.date_verified}}
-    </div>
-  </div>
-
-  <div class="form-row mb-2">
-    <label class="col-form-label-fixed d-none d-md-block col-md-2">&nbsp;</label>
-    <div class="col-sm-7 col-md-5">
-      <f.submit @label="Update" @disabled={{or this.isSaving (not f.model.isDirty)}} />
-      {{#if this.isSaving}}
-        <LoadingIndicator/>
-      {{/if}}
-    </div>
-    {{#if (has-role "admin")}}
-      <div class="col-sm-3 col-md-2 text-right">
-        <button type="button" class="btn btn-secondary btn-sm" {{action this.removePerson}}>Remove</button>
-      </div>
-    {{/if}}
-  </div>
-</ChForm>
+</div>
 
 {{#if this.editPositions}}
   <Person::PositionForm @positions={{positions}} @positionIds={{positionIds}} @onSave={{action this.savePositions}}

--- a/package-lock.json
+++ b/package-lock.json
@@ -23070,6 +23070,15 @@
         "type-check": "~0.3.2"
       }
     },
+    "libphonenumber-js": {
+      "version": "1.7.57",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.7.57.tgz",
+      "integrity": "sha512-v6DkRf1ufgGXHb6NoKbQd1YlfWqOs6jym7WjPP+YF1YtbfiWwD7M/7/XUOW+if2jNlm5av4EzeL/lYf8ClJYjg==",
+      "requires": {
+        "minimist": "^1.2.5",
+        "xml2js": "^0.4.17"
+      }
+    },
     "linkify-it": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.2.tgz",
@@ -29990,6 +29999,11 @@
         "chokidar": ">=2.0.0 <4.0.0"
       }
     },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+    },
     "saxes": {
       "version": "3.1.11",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-3.1.11.tgz",
@@ -32533,6 +32547,20 @@
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
       "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
       "dev": true
+    },
+    "xml2js": {
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
+      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      }
+    },
+    "xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
     },
     "xmlchars": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "jquery-datetimepicker": "^2.5.21",
     "jscodeshift": "^0.11.0",
     "json-formatter-js": "^2.3.4",
+    "libphonenumber-js": "^1.7.57",
     "lodash": "^4.17.20",
     "mobile-detect": "^1.4.4"
   },

--- a/tests/integration/helpers/phone-link-test.js
+++ b/tests/integration/helpers/phone-link-test.js
@@ -8,11 +8,10 @@ module('helper:phone-link', function(hooks) {
   setupRenderingTest(hooks);
 
   test('it renders a phone link', async function(assert) {
-    const phoneNumber = '1-800-BURN-ME';
-    this.set('phone', phoneNumber);
+    this.set('phone', '415-555-1212');
 
     await render(hbs`{{phone-link phone}}`);
 
-    assert.equal(this.element.innerHTML, `<a href="tel:${phoneNumber}">${phoneNumber}</a>`);
+    assert.dom('a').hasAttribute('href', 'tel:+14155551212').hasText('(415) 555-1212');
   });
 });

--- a/tests/integration/helpers/year-range-test.js
+++ b/tests/integration/helpers/year-range-test.js
@@ -1,0 +1,17 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Helper | year-range', function(hooks) {
+  setupRenderingTest(hooks);
+
+  // TODO: Replace this with your real tests.
+  test('it renders', async function(assert) {
+    this.set('years', [ 2011, 2012, 2015, 2017, 2018, 2019, 2020]);
+
+    await render(hbs`{{year-range years}}`);
+
+    assert.equal(this.element.textContent.trim(), '2011 - 2012, 2015, 2017 - 2020');
+  });
+});

--- a/tests/unit/controllers/person/external-ids-test.js
+++ b/tests/unit/controllers/person/external-ids-test.js
@@ -1,0 +1,12 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Controller | person/external-ids', function(hooks) {
+  setupTest(hooks);
+
+  // TODO: Replace this with your real tests.
+  test('it exists', function(assert) {
+    let controller = this.owner.lookup('controller:person/external-ids');
+    assert.ok(controller);
+  });
+});

--- a/tests/unit/routes/person/external-ids-test.js
+++ b/tests/unit/routes/person/external-ids-test.js
@@ -1,0 +1,11 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Route | person/external-ids', function(hooks) {
+  setupTest(hooks);
+
+  test('it exists', function(assert) {
+    let route = this.owner.lookup('route:person/external-ids');
+    assert.ok(route);
+  });
+});


### PR DESCRIPTION
- Different landing pages for Admin/Mentor/VCs (full form) versus everyone else/login management (simple form).
- Full form has existing edit fields. Simple form has a single edit field site, and the edit position modal (if user has Grant Positions role)
- Removed first and last name edit fields (already exists in Person > Personal Info, and nobody updated a name on behalf of someone else in the last two year.)
- Years worked has been collapsed into ranges, easier to spot gap years.
- Mobile clean up. Photo is shown below edit fields on mobile devices.
- LMS ID & BPGUID moved off to their own page, External Ids.
- All page navigation links moved into the sidebar under three different groups: Vol Coords, Pre-Playa & Logs.
- Don't show "You're on a staging server, blah, blah, blah" message when in a development environment
- Added note with link about annual flags/checkboxes (motorpool agreement, asset authorization, etc) on a different page.