### PR TITLE
Downgraded ember-changeset to 3.8.2 and locked validated-changeset to  0.8.2.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12326,24 +12326,24 @@
       }
     },
     "ember-changeset": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/ember-changeset/-/ember-changeset-3.9.0.tgz",
-      "integrity": "sha512-ptHJW5e8BBGE3kysF+sMWes8oIwx9NzZZcq26jKS/O8ESo52CMg8YxsLfG3I/kqQVCMyjPTsxi265OBT1qwBpA==",
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/ember-changeset/-/ember-changeset-3.8.2.tgz",
+      "integrity": "sha512-fdL/FETakNswsthOApkv7QuNYrt+VKj66ksMqyv+H24Z6KVc2nbk/55V9Kwp4jOkkFw4KxMr865Ko8ccctdWcw==",
       "dev": true,
       "requires": {
         "@glimmer/tracking": "^1.0.1",
         "ember-auto-import": "^1.5.2",
         "ember-cli-babel": "^7.19.0",
-        "validated-changeset": "~0.9.0"
+        "validated-changeset": "~0.8.2"
       }
     },
     "ember-changeset-validations": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/ember-changeset-validations/-/ember-changeset-validations-3.9.0.tgz",
-      "integrity": "sha512-e+4AbArZGiWgncF37ZIxfeiMzrMWAVlHJGgLVsxHKK47weWK6tWISIxw2X40x+QYKr8oe5X/zPEUvFqmyvFjYA==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/ember-changeset-validations/-/ember-changeset-validations-3.8.1.tgz",
+      "integrity": "sha512-vWVAvhJGv9aEPcjUAthHA0zQ/mydSWIflzGEqyf3tfzVNZzNjukY2ZDxShR0tTUtrnS+W7UCbUoUtL6FY9wnQw==",
       "dev": true,
       "requires": {
-        "ember-changeset": "^3.9.0",
+        "ember-changeset": "^3.8.2",
         "ember-cli-babel": "^7.8.0",
         "ember-cli-htmlbars": "^4.0.5",
         "ember-get-config": "^0.2.4",
@@ -24753,29 +24753,34 @@
       "dependencies": {
         "ansi-align": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
           "requires": {
             "string-width": "^2.0.0"
           }
         },
         "ansi-regex": {
           "version": "3.0.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
         },
         "ansi-styles": {
           "version": "3.2.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "requires": {
             "color-convert": "^1.9.0"
           }
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
         },
         "boxen": {
           "version": "1.3.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
           "requires": {
             "ansi-align": "^2.0.0",
             "camelcase": "^4.0.0",
@@ -24788,7 +24793,8 @@
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -24796,19 +24802,23 @@
         },
         "builtins": {
           "version": "1.0.3",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og="
         },
         "camelcase": {
           "version": "4.1.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
         },
         "capture-stack-trace": {
           "version": "1.0.1",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw=="
         },
         "chalk": {
           "version": "2.4.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "requires": {
             "ansi-styles": "^3.2.1",
             "escape-string-regexp": "^1.0.5",
@@ -24817,15 +24827,18 @@
         },
         "ci-info": {
           "version": "1.6.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A=="
         },
         "cli-boxes": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM="
         },
         "cliui": {
           "version": "4.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
           "requires": {
             "string-width": "^2.1.1",
             "strip-ansi": "^4.0.0",
@@ -24834,26 +24847,31 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
         },
         "color-convert": {
           "version": "1.9.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
           "requires": {
             "color-name": "1.1.3"
           }
         },
         "color-name": {
           "version": "1.1.3",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
         "configstore": {
           "version": "3.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
           "requires": {
             "dot-prop": "^4.1.0",
             "graceful-fs": "^4.1.2",
@@ -24865,14 +24883,16 @@
         },
         "create-error-class": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
           "requires": {
             "capture-stack-trace": "^1.0.0"
           }
         },
         "cross-spawn": {
           "version": "5.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
           "requires": {
             "lru-cache": "^4.0.1",
             "shebang-command": "^1.2.0",
@@ -24881,45 +24901,54 @@
         },
         "crypto-random-string": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4="
         },
         "decamelize": {
           "version": "1.2.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
         },
         "deep-extend": {
           "version": "0.6.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
         },
         "dot-prop": {
           "version": "4.2.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
           "requires": {
             "is-obj": "^1.0.0"
           }
         },
         "dotenv": {
           "version": "5.0.1",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-4As8uPrjfwb7VXC+WnLCbXK7y+Ueb2B3zgNCePYfhxS1PYeaO1YTeplffTEcbfLhvFNGLAz90VvJs9yomG7bow=="
         },
         "duplexer3": {
           "version": "0.1.4",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
         },
         "end-of-stream": {
           "version": "1.4.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
           "requires": {
             "once": "^1.4.0"
           }
         },
         "escape-string-regexp": {
           "version": "1.0.5",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
         },
         "execa": {
           "version": "0.7.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
           "requires": {
             "cross-spawn": "^5.0.1",
             "get-stream": "^3.0.0",
@@ -24932,26 +24961,31 @@
         },
         "find-up": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "requires": {
             "locate-path": "^2.0.0"
           }
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
         },
         "get-caller-file": {
           "version": "1.0.3",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
         },
         "get-stream": {
           "version": "3.0.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
         },
         "glob": {
           "version": "7.1.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -24963,14 +24997,16 @@
         },
         "global-dirs": {
           "version": "0.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
           "requires": {
             "ini": "^1.3.4"
           }
         },
         "got": {
           "version": "6.7.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
           "requires": {
             "create-error-class": "^3.0.0",
             "duplexer3": "^0.1.4",
@@ -24987,27 +25023,33 @@
         },
         "graceful-fs": {
           "version": "4.2.3",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
         },
         "has-flag": {
           "version": "3.0.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
         },
         "hosted-git-info": {
           "version": "2.8.5",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg=="
         },
         "import-lazy": {
           "version": "2.1.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM="
         },
         "imurmurhash": {
           "version": "0.1.4",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
         },
         "inflight": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "requires": {
             "once": "^1.3.0",
             "wrappy": "1"
@@ -25015,30 +25057,36 @@
         },
         "inherits": {
           "version": "2.0.4",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
         },
         "ini": {
           "version": "1.3.5",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
         },
         "invert-kv": {
           "version": "2.0.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA=="
         },
         "is-ci": {
           "version": "1.2.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
           "requires": {
             "ci-info": "^1.5.0"
           }
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
         },
         "is-installed-globally": {
           "version": "0.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
           "requires": {
             "global-dirs": "^0.1.0",
             "is-path-inside": "^1.0.0"
@@ -25046,52 +25094,62 @@
         },
         "is-npm": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ="
         },
         "is-obj": {
           "version": "1.0.1",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
         },
         "is-path-inside": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
           "requires": {
             "path-is-inside": "^1.0.1"
           }
         },
         "is-redirect": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ="
         },
         "is-retry-allowed": {
           "version": "1.2.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg=="
         },
         "is-stream": {
           "version": "1.1.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
         },
         "isexe": {
           "version": "2.0.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
         },
         "latest-version": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
           "requires": {
             "package-json": "^4.0.0"
           }
         },
         "lcid": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
           "requires": {
             "invert-kv": "^2.0.0"
           }
         },
         "libnpx": {
           "version": "10.2.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-ujaYToga1SAX5r7FU5ShMFi88CWpY75meNZtr6RtEyv4l2ZK3+Wgvxq2IqlwWBiDZOqhumdeiocPS1aKrCMe3A==",
           "requires": {
             "dotenv": "^5.0.1",
             "npm-package-arg": "^6.0.0",
@@ -25105,7 +25163,8 @@
         },
         "locate-path": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
           "requires": {
             "p-locate": "^2.0.0",
             "path-exists": "^3.0.0"
@@ -25113,11 +25172,13 @@
         },
         "lowercase-keys": {
           "version": "1.0.1",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
         },
         "lru-cache": {
           "version": "4.1.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
           "requires": {
             "pseudomap": "^1.0.2",
             "yallist": "^2.1.2"
@@ -25125,21 +25186,24 @@
         },
         "make-dir": {
           "version": "1.3.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
           "requires": {
             "pify": "^3.0.0"
           }
         },
         "map-age-cleaner": {
           "version": "0.1.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
           "requires": {
             "p-defer": "^1.0.0"
           }
         },
         "mem": {
           "version": "4.3.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
           "requires": {
             "map-age-cleaner": "^0.1.1",
             "mimic-fn": "^2.0.0",
@@ -25148,26 +25212,31 @@
         },
         "mimic-fn": {
           "version": "2.1.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
         },
         "minimatch": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "1.2.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         },
         "nice-try": {
           "version": "1.0.5",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
         },
         "npm": {
           "version": "5.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-pt5ClxEmY/dLpb60SmGQQBKi3nB6Ljx1FXmpoCUdAULlGqGVn2uCyXxPCWFbcuHGthT7qGiaGa1wOfs/UjGYMw==",
           "requires": {
             "JSONStream": "~1.3.1",
             "abbrev": "~1.1.0",
@@ -25269,7 +25338,8 @@
           "dependencies": {
             "JSONStream": {
               "version": "1.3.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
               "requires": {
                 "jsonparse": "^1.2.0",
                 "through": ">=2.2.7 <3"
@@ -25277,45 +25347,55 @@
               "dependencies": {
                 "jsonparse": {
                   "version": "1.3.1",
-                  "bundled": true
+                  "resolved": false,
+                  "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
                 },
                 "through": {
                   "version": "2.3.8",
-                  "bundled": true
+                  "resolved": false,
+                  "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
                 }
               }
             },
             "abbrev": {
               "version": "1.1.0",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8="
             },
             "ansi-regex": {
               "version": "3.0.0",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
             },
             "ansicolors": {
               "version": "0.3.2",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk="
             },
             "ansistyles": {
               "version": "0.1.3",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-XeYEFb2gcbs3EnhUyGT0GyMlRTk="
             },
             "aproba": {
               "version": "1.1.2",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha512-ZpYajIfO0j2cOFTO955KUMIKNmj6zhX8kVztMAxFsDaMwz+9Z9SV0uou2pC9HJqcfpffOsjnbrDMvkNy+9RXPw=="
             },
             "archy": {
               "version": "1.0.0",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA="
             },
             "bluebird": {
               "version": "3.5.0",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw="
             },
             "cacache": {
               "version": "9.2.9",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-ghg1j5OyTJ6qsrqU++dN23QiTDxb5AZCFGsF3oB+v9v/gY+F4X8L/0gdQMEjd+8Ot3D29M2etX5PKozHRn2JQw==",
               "requires": {
                 "bluebird": "^3.5.0",
                 "chownr": "^1.0.1",
@@ -25334,7 +25414,8 @@
               "dependencies": {
                 "lru-cache": {
                   "version": "4.1.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
                   "requires": {
                     "pseudomap": "^1.0.2",
                     "yallist": "^2.1.2"
@@ -25342,31 +25423,37 @@
                   "dependencies": {
                     "pseudomap": {
                       "version": "1.0.2",
-                      "bundled": true
+                      "resolved": false,
+                      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
                     },
                     "yallist": {
                       "version": "2.1.2",
-                      "bundled": true
+                      "resolved": false,
+                      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
                     }
                   }
                 },
                 "y18n": {
                   "version": "3.2.1",
-                  "bundled": true
+                  "resolved": false,
+                  "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
                 }
               }
             },
             "call-limit": {
               "version": "1.1.0",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-b9YbA/PaQqLNDsK2DwK9DnGZH+o="
             },
             "chownr": {
               "version": "1.0.1",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE="
             },
             "cmd-shim": {
               "version": "2.0.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-b8vamUg6j9FdfTChlspp1oii79s=",
               "requires": {
                 "graceful-fs": "^4.1.2",
                 "mkdirp": "~0.5.0"
@@ -25374,7 +25461,8 @@
             },
             "columnify": {
               "version": "1.5.4",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
               "requires": {
                 "strip-ansi": "^3.0.0",
                 "wcwidth": "^1.0.0"
@@ -25382,34 +25470,39 @@
               "dependencies": {
                 "strip-ansi": {
                   "version": "3.0.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                   "requires": {
                     "ansi-regex": "^2.0.0"
                   },
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.1.1",
-                      "bundled": true
+                      "resolved": false,
+                      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
                     }
                   }
                 },
                 "wcwidth": {
                   "version": "1.0.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
                   "requires": {
                     "defaults": "^1.0.3"
                   },
                   "dependencies": {
                     "defaults": {
                       "version": "1.0.3",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
                       "requires": {
                         "clone": "^1.0.2"
                       },
                       "dependencies": {
                         "clone": {
                           "version": "1.0.2",
-                          "bundled": true
+                          "resolved": false,
+                          "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk="
                         }
                       }
                     }
@@ -25419,7 +25512,8 @@
             },
             "config-chain": {
               "version": "1.1.11",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-q6CXR9++TD5w52am5BWG4YWfxvI=",
               "requires": {
                 "ini": "^1.3.4",
                 "proto-list": "~1.2.1"
@@ -25427,21 +25521,25 @@
               "dependencies": {
                 "proto-list": {
                   "version": "1.2.4",
-                  "bundled": true
+                  "resolved": false,
+                  "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk="
                 }
               }
             },
             "debuglog": {
               "version": "1.0.1",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI="
             },
             "detect-indent": {
               "version": "5.0.0",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50="
             },
             "dezalgo": {
               "version": "1.0.3",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
               "requires": {
                 "asap": "^2.0.0",
                 "wrappy": "1"
@@ -25449,17 +25547,20 @@
               "dependencies": {
                 "asap": {
                   "version": "2.0.5",
-                  "bundled": true
+                  "resolved": false,
+                  "integrity": "sha1-UidltQw1EEkOUtfc/ghe+bqWlY8="
                 }
               }
             },
             "editor": {
               "version": "1.0.0",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-YMf4e9YrzGqJT6jM1q+3gjok90I="
             },
             "fs-vacuum": {
               "version": "1.2.10",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-t2Kb7AekAxolSP35n17PHMizHjY=",
               "requires": {
                 "graceful-fs": "^4.1.2",
                 "path-is-inside": "^1.0.1",
@@ -25468,7 +25569,8 @@
             },
             "fs-write-stream-atomic": {
               "version": "1.0.10",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
               "requires": {
                 "graceful-fs": "^4.1.2",
                 "iferr": "^0.1.5",
@@ -25478,7 +25580,8 @@
             },
             "fstream": {
               "version": "1.0.11",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
               "requires": {
                 "graceful-fs": "^4.1.2",
                 "inherits": "~2.0.0",
@@ -25488,7 +25591,8 @@
             },
             "fstream-npm": {
               "version": "1.2.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-iBHpm/LmD1qw0TlHMAqVd9rwdU6M+EHRUnPkXpRi5G/Hf0FIFH+oZFryodAU2MFNfGRh/CzhUFlMKV3pdeOTDw==",
               "requires": {
                 "fstream-ignore": "^1.0.0",
                 "inherits": "2"
@@ -25496,7 +25600,8 @@
               "dependencies": {
                 "fstream-ignore": {
                   "version": "1.0.5",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
                   "requires": {
                     "fstream": "^1.0.0",
                     "inherits": "2",
@@ -25505,14 +25610,16 @@
                   "dependencies": {
                     "minimatch": {
                       "version": "3.0.4",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
                       "requires": {
                         "brace-expansion": "^1.1.7"
                       },
                       "dependencies": {
                         "brace-expansion": {
                           "version": "1.1.8",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
                           "requires": {
                             "balanced-match": "^1.0.0",
                             "concat-map": "0.0.1"
@@ -25520,11 +25627,13 @@
                           "dependencies": {
                             "balanced-match": {
                               "version": "1.0.0",
-                              "bundled": true
+                              "resolved": false,
+                              "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
                             },
                             "concat-map": {
                               "version": "0.0.1",
-                              "bundled": true
+                              "resolved": false,
+                              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
                             }
                           }
                         }
@@ -25536,7 +25645,8 @@
             },
             "glob": {
               "version": "7.1.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
               "requires": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -25548,18 +25658,21 @@
               "dependencies": {
                 "fs.realpath": {
                   "version": "1.0.0",
-                  "bundled": true
+                  "resolved": false,
+                  "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
                 },
                 "minimatch": {
                   "version": "3.0.4",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
                   "requires": {
                     "brace-expansion": "^1.1.7"
                   },
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.8",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
                       "requires": {
                         "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
@@ -25567,11 +25680,13 @@
                       "dependencies": {
                         "balanced-match": {
                           "version": "1.0.0",
-                          "bundled": true
+                          "resolved": false,
+                          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
                         },
                         "concat-map": {
                           "version": "0.0.1",
-                          "bundled": true
+                          "resolved": false,
+                          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
                         }
                       }
                     }
@@ -25579,33 +25694,40 @@
                 },
                 "path-is-absolute": {
                   "version": "1.0.1",
-                  "bundled": true
+                  "resolved": false,
+                  "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
                 }
               }
             },
             "graceful-fs": {
               "version": "4.1.11",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
             },
             "has-unicode": {
               "version": "2.0.1",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
             },
             "hosted-git-info": {
               "version": "2.5.0",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg=="
             },
             "iferr": {
               "version": "0.1.5",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE="
             },
             "imurmurhash": {
               "version": "0.1.4",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
             },
             "inflight": {
               "version": "1.0.6",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
               "requires": {
                 "once": "^1.3.0",
                 "wrappy": "1"
@@ -25613,15 +25735,18 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
             },
             "ini": {
               "version": "1.3.4",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4="
             },
             "init-package-json": {
               "version": "1.10.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-zYc6FneWvvuZYSsodioLY5P9j2o=",
               "requires": {
                 "glob": "^7.1.1",
                 "npm-package-arg": "^4.0.0 || ^5.0.0",
@@ -25635,7 +25760,8 @@
               "dependencies": {
                 "promzard": {
                   "version": "0.3.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=",
                   "requires": {
                     "read": "1"
                   }
@@ -25644,19 +25770,23 @@
             },
             "lazy-property": {
               "version": "1.0.0",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-hN3Es3Bnm6i9TNz6TAa0PVcREUc="
             },
             "lockfile": {
               "version": "1.0.3",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-Jjj8OaAzHpysGgS3F5mTHJxQ33k="
             },
             "lodash._baseindexof": {
               "version": "3.1.0",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw="
             },
             "lodash._baseuniq": {
               "version": "4.6.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-DrtE5FaBSveQXGIS+iybLVG4Qeg=",
               "requires": {
                 "lodash._createset": "~4.0.0",
                 "lodash._root": "~3.0.0"
@@ -25664,56 +25794,68 @@
               "dependencies": {
                 "lodash._createset": {
                   "version": "4.0.3",
-                  "bundled": true
+                  "resolved": false,
+                  "integrity": "sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY="
                 },
                 "lodash._root": {
                   "version": "3.0.1",
-                  "bundled": true
+                  "resolved": false,
+                  "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI="
                 }
               }
             },
             "lodash._bindcallback": {
               "version": "3.0.1",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4="
             },
             "lodash._cacheindexof": {
               "version": "3.0.2",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI="
             },
             "lodash._createcache": {
               "version": "3.1.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=",
               "requires": {
                 "lodash._getnative": "^3.0.0"
               }
             },
             "lodash._getnative": {
               "version": "3.9.1",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
             },
             "lodash.clonedeep": {
               "version": "4.5.0",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
             },
             "lodash.restparam": {
               "version": "3.6.1",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU="
             },
             "lodash.union": {
               "version": "4.6.0",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg="
             },
             "lodash.uniq": {
               "version": "4.5.0",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
             },
             "lodash.without": {
               "version": "4.4.0",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-PNRXSgC2e643OpS3SHcmQFB7eqw="
             },
             "lru-cache": {
               "version": "4.1.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
               "requires": {
                 "pseudomap": "^1.0.2",
                 "yallist": "^2.1.2"
@@ -25721,17 +25863,20 @@
               "dependencies": {
                 "pseudomap": {
                   "version": "1.0.2",
-                  "bundled": true
+                  "resolved": false,
+                  "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
                 },
                 "yallist": {
                   "version": "2.1.2",
-                  "bundled": true
+                  "resolved": false,
+                  "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
                 }
               }
             },
             "mississippi": {
               "version": "1.3.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-0gFYPrEjJ+PFwWQqQEqcrPlONPU=",
               "requires": {
                 "concat-stream": "^1.5.0",
                 "duplexify": "^3.4.2",
@@ -25747,7 +25892,8 @@
               "dependencies": {
                 "concat-stream": {
                   "version": "1.6.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
                   "requires": {
                     "inherits": "^2.0.3",
                     "readable-stream": "^2.2.2",
@@ -25756,13 +25902,15 @@
                   "dependencies": {
                     "typedarray": {
                       "version": "0.0.6",
-                      "bundled": true
+                      "resolved": false,
+                      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
                     }
                   }
                 },
                 "duplexify": {
                   "version": "3.5.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-GqdzAC4VeEV+nZ1KULDMquvL1gQ=",
                   "requires": {
                     "end-of-stream": "1.0.0",
                     "inherits": "^2.0.1",
@@ -25772,14 +25920,16 @@
                   "dependencies": {
                     "end-of-stream": {
                       "version": "1.0.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-1FlucCc0qT5A6a+GQxnqvZn/Lw4=",
                       "requires": {
                         "once": "~1.3.0"
                       },
                       "dependencies": {
                         "once": {
                           "version": "1.3.3",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
                           "requires": {
                             "wrappy": "1"
                           }
@@ -25788,20 +25938,23 @@
                     },
                     "stream-shift": {
                       "version": "1.0.0",
-                      "bundled": true
+                      "resolved": false,
+                      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
                     }
                   }
                 },
                 "end-of-stream": {
                   "version": "1.4.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
                   "requires": {
                     "once": "^1.4.0"
                   }
                 },
                 "flush-write-stream": {
                   "version": "1.0.2",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-yBuQ2HRnZvGmCaRoCZRsRd2K5Bc=",
                   "requires": {
                     "inherits": "^2.0.1",
                     "readable-stream": "^2.0.4"
@@ -25809,7 +25962,8 @@
                 },
                 "from2": {
                   "version": "2.3.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
                   "requires": {
                     "inherits": "^2.0.1",
                     "readable-stream": "^2.0.0"
@@ -25817,7 +25971,8 @@
                 },
                 "parallel-transform": {
                   "version": "1.1.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
                   "requires": {
                     "cyclist": "~0.2.2",
                     "inherits": "^2.0.3",
@@ -25826,13 +25981,15 @@
                   "dependencies": {
                     "cyclist": {
                       "version": "0.2.2",
-                      "bundled": true
+                      "resolved": false,
+                      "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA="
                     }
                   }
                 },
                 "pump": {
                   "version": "1.0.2",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-Oz7mUS+U8OV1U4wXmV+fFpkKXVE=",
                   "requires": {
                     "end-of-stream": "^1.1.0",
                     "once": "^1.3.1"
@@ -25840,7 +25997,8 @@
                 },
                 "pumpify": {
                   "version": "1.3.5",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-G2ccYZlAq8rqwK0OOjwWS+dgmTs=",
                   "requires": {
                     "duplexify": "^3.1.2",
                     "inherits": "^2.0.1",
@@ -25849,7 +26007,8 @@
                 },
                 "stream-each": {
                   "version": "1.2.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-HpXUdXP1gNgU3A/4zQ9m8c5TyZE=",
                   "requires": {
                     "end-of-stream": "^1.1.0",
                     "stream-shift": "^1.0.0"
@@ -25857,13 +26016,15 @@
                   "dependencies": {
                     "stream-shift": {
                       "version": "1.0.0",
-                      "bundled": true
+                      "resolved": false,
+                      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
                     }
                   }
                 },
                 "through2": {
                   "version": "2.0.3",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
                   "requires": {
                     "readable-stream": "^2.1.5",
                     "xtend": "~4.0.1"
@@ -25871,7 +26032,8 @@
                   "dependencies": {
                     "xtend": {
                       "version": "4.0.1",
-                      "bundled": true
+                      "resolved": false,
+                      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
                     }
                   }
                 }
@@ -25879,20 +26041,23 @@
             },
             "mkdirp": {
               "version": "0.5.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
               "requires": {
                 "minimist": "0.0.8"
               },
               "dependencies": {
                 "minimist": {
                   "version": "0.0.8",
-                  "bundled": true
+                  "resolved": false,
+                  "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
                 }
               }
             },
             "move-concurrently": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
               "requires": {
                 "aproba": "^1.1.1",
                 "copy-concurrently": "^1.0.0",
@@ -25904,7 +26069,8 @@
               "dependencies": {
                 "copy-concurrently": {
                   "version": "1.0.3",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-Rft4ZiSaHKiJqlcI5svSc+dbslA=",
                   "requires": {
                     "aproba": "^1.1.1",
                     "fs-write-stream-atomic": "^1.0.8",
@@ -25916,7 +26082,8 @@
                 },
                 "run-queue": {
                   "version": "1.0.3",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
                   "requires": {
                     "aproba": "^1.1.1"
                   }
@@ -25925,7 +26092,8 @@
             },
             "node-gyp": {
               "version": "3.6.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-m/vlRWIoYoSDjnUOrAUpWFP6HGA=",
               "requires": {
                 "fstream": "^1.0.0",
                 "glob": "^7.0.3",
@@ -25944,14 +26112,16 @@
               "dependencies": {
                 "minimatch": {
                   "version": "3.0.4",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
                   "requires": {
                     "brace-expansion": "^1.1.7"
                   },
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.8",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
                       "requires": {
                         "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
@@ -25959,11 +26129,13 @@
                       "dependencies": {
                         "balanced-match": {
                           "version": "1.0.0",
-                          "bundled": true
+                          "resolved": false,
+                          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
                         },
                         "concat-map": {
                           "version": "0.0.1",
-                          "bundled": true
+                          "resolved": false,
+                          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
                         }
                       }
                     }
@@ -25971,7 +26143,8 @@
                 },
                 "nopt": {
                   "version": "3.0.6",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
                   "requires": {
                     "abbrev": "1"
                   }
@@ -25980,7 +26153,8 @@
             },
             "nopt": {
               "version": "4.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
               "requires": {
                 "abbrev": "1",
                 "osenv": "^0.1.4"
@@ -25988,7 +26162,8 @@
             },
             "normalize-package-data": {
               "version": "2.4.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
               "requires": {
                 "hosted-git-info": "^2.1.4",
                 "is-builtin-module": "^1.0.0",
@@ -25998,14 +26173,16 @@
               "dependencies": {
                 "is-builtin-module": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
                   "requires": {
                     "builtin-modules": "^1.0.0"
                   },
                   "dependencies": {
                     "builtin-modules": {
                       "version": "1.1.1",
-                      "bundled": true
+                      "resolved": false,
+                      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
                     }
                   }
                 }
@@ -26013,18 +26190,21 @@
             },
             "npm-cache-filename": {
               "version": "1.0.2",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-3tMGxbC/yHCp6fr4I7xfKD4FrhE="
             },
             "npm-install-checks": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-1K7N/VGlPjcjt7L5Oy7ijjB7wNc=",
               "requires": {
                 "semver": "^2.3.0 || 3.x || 4 || 5"
               }
             },
             "npm-package-arg": {
               "version": "5.1.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-wJBsrf0qpypPT7A0LART18hCdyhpCMxeTtcb0X4IZO2jsP6Om7EHN1d9KSKiqD+KVH030RVNpWS9thk+pb7wzA==",
               "requires": {
                 "hosted-git-info": "^2.4.2",
                 "osenv": "^0.1.4",
@@ -26034,7 +26214,8 @@
             },
             "npm-registry-client": {
               "version": "8.4.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-PVNfqq0lyRdFnE//nDmn3CC9uqTsr8Bya9KPLIevlXMfkP0m4RpCVyFFk0W1Gfx436kKwyhLA6J+lV+rgR81gQ==",
               "requires": {
                 "concat-stream": "^1.5.2",
                 "graceful-fs": "^4.1.6",
@@ -26051,7 +26232,8 @@
               "dependencies": {
                 "concat-stream": {
                   "version": "1.6.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
                   "requires": {
                     "inherits": "^2.0.3",
                     "readable-stream": "^2.2.2",
@@ -26060,7 +26242,8 @@
                   "dependencies": {
                     "typedarray": {
                       "version": "0.0.6",
-                      "bundled": true
+                      "resolved": false,
+                      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
                     }
                   }
                 }
@@ -26068,11 +26251,13 @@
             },
             "npm-user-validate": {
               "version": "1.0.0",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-jOyg9c6gTU6TUZ73LQVXp1Ei6VE="
             },
             "npmlog": {
               "version": "4.1.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
               "requires": {
                 "are-we-there-yet": "~1.1.2",
                 "console-control-strings": "~1.1.0",
@@ -26082,7 +26267,8 @@
               "dependencies": {
                 "are-we-there-yet": {
                   "version": "1.1.4",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
                   "requires": {
                     "delegates": "^1.0.0",
                     "readable-stream": "^2.0.6"
@@ -26090,17 +26276,20 @@
                   "dependencies": {
                     "delegates": {
                       "version": "1.0.0",
-                      "bundled": true
+                      "resolved": false,
+                      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
                     }
                   }
                 },
                 "console-control-strings": {
                   "version": "1.1.0",
-                  "bundled": true
+                  "resolved": false,
+                  "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
                 },
                 "gauge": {
                   "version": "2.7.4",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
                   "requires": {
                     "aproba": "^1.0.3",
                     "console-control-strings": "^1.0.0",
@@ -26114,15 +26303,18 @@
                   "dependencies": {
                     "object-assign": {
                       "version": "4.1.1",
-                      "bundled": true
+                      "resolved": false,
+                      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
                     },
                     "signal-exit": {
                       "version": "3.0.2",
-                      "bundled": true
+                      "resolved": false,
+                      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
                     },
                     "string-width": {
                       "version": "1.0.2",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                       "requires": {
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",
@@ -26131,18 +26323,21 @@
                       "dependencies": {
                         "code-point-at": {
                           "version": "1.1.0",
-                          "bundled": true
+                          "resolved": false,
+                          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
                         },
                         "is-fullwidth-code-point": {
                           "version": "1.0.0",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                           "requires": {
                             "number-is-nan": "^1.0.0"
                           },
                           "dependencies": {
                             "number-is-nan": {
                               "version": "1.0.1",
-                              "bundled": true
+                              "resolved": false,
+                              "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
                             }
                           }
                         }
@@ -26150,20 +26345,23 @@
                     },
                     "strip-ansi": {
                       "version": "3.0.1",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                       "requires": {
                         "ansi-regex": "^2.0.0"
                       },
                       "dependencies": {
                         "ansi-regex": {
                           "version": "2.1.1",
-                          "bundled": true
+                          "resolved": false,
+                          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
                         }
                       }
                     },
                     "wide-align": {
                       "version": "1.1.2",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
                       "requires": {
                         "string-width": "^1.0.2"
                       }
@@ -26172,24 +26370,28 @@
                 },
                 "set-blocking": {
                   "version": "2.0.0",
-                  "bundled": true
+                  "resolved": false,
+                  "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
                 }
               }
             },
             "once": {
               "version": "1.4.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
               "requires": {
                 "wrappy": "1"
               }
             },
             "opener": {
               "version": "1.4.3",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-XG2ixdflgx6P+jlklQ+NZnSskLg="
             },
             "osenv": {
               "version": "0.1.4",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
               "requires": {
                 "os-homedir": "^1.0.0",
                 "os-tmpdir": "^1.0.0"
@@ -26197,17 +26399,20 @@
               "dependencies": {
                 "os-homedir": {
                   "version": "1.0.2",
-                  "bundled": true
+                  "resolved": false,
+                  "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
                 },
                 "os-tmpdir": {
                   "version": "1.0.2",
-                  "bundled": true
+                  "resolved": false,
+                  "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
                 }
               }
             },
             "pacote": {
               "version": "2.7.38",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-XxHUyHQB7QCVBxoXeVu0yKxT+2PvJucsc0+1E+6f95lMUxEAYERgSAc71ckYXrYr35Ew3xFU/LrhdIK21GQFFA==",
               "requires": {
                 "bluebird": "^3.5.0",
                 "cacache": "^9.2.9",
@@ -26234,7 +26439,8 @@
               "dependencies": {
                 "make-fetch-happen": {
                   "version": "2.4.13",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-73CsTlMRSLdGr7VvOE8iYl/ejOSIxyfRYg7jZhepGGEqIlgdq6FLe2DEAI5bo813Jdg5fS/Ku62SRQ/UpT6NJA==",
                   "requires": {
                     "agentkeepalive": "^3.3.0",
                     "cacache": "^9.2.9",
@@ -26251,21 +26457,24 @@
                   "dependencies": {
                     "agentkeepalive": {
                       "version": "3.3.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha512-9yhcpXti2ZQE7bxuCsjjWNIZoQOd9sZ1ZBovHG0YeCRohFv73SLvcm73PC9T3olM4GyozaQb+4MGdQpcD8m7NQ==",
                       "requires": {
                         "humanize-ms": "^1.2.1"
                       },
                       "dependencies": {
                         "humanize-ms": {
                           "version": "1.2.1",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
                           "requires": {
                             "ms": "^2.0.0"
                           },
                           "dependencies": {
                             "ms": {
                               "version": "2.0.0",
-                              "bundled": true
+                              "resolved": false,
+                              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
                             }
                           }
                         }
@@ -26273,11 +26482,13 @@
                     },
                     "http-cache-semantics": {
                       "version": "3.7.3",
-                      "bundled": true
+                      "resolved": false,
+                      "integrity": "sha1-LzXFMuzSnx5UE7mvgztySjxvf3I="
                     },
                     "http-proxy-agent": {
                       "version": "2.0.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-RkgqLwUjpNYIJVFwn0acs+SoX/Q=",
                       "requires": {
                         "agent-base": "4",
                         "debug": "2"
@@ -26285,21 +26496,24 @@
                       "dependencies": {
                         "agent-base": {
                           "version": "4.1.0",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-IOF0Ac1Js8B2v1akvGxbQ2/6jVU=",
                           "requires": {
                             "es6-promisify": "^5.0.0"
                           },
                           "dependencies": {
                             "es6-promisify": {
                               "version": "5.0.0",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
                               "requires": {
                                 "es6-promise": "^4.0.3"
                               },
                               "dependencies": {
                                 "es6-promise": {
                                   "version": "4.1.1",
-                                  "bundled": true
+                                  "resolved": false,
+                                  "integrity": "sha512-OaU1hHjgJf+b0NzsxCg7NdIYERD6Hy/PEmFLTjw+b65scuisG3Kt4QoTvJ66BBkPZ581gr0kpoVzKnxniM8nng=="
                                 }
                               }
                             }
@@ -26307,14 +26521,16 @@
                         },
                         "debug": {
                           "version": "2.6.8",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
                           "requires": {
                             "ms": "2.0.0"
                           },
                           "dependencies": {
                             "ms": {
                               "version": "2.0.0",
-                              "bundled": true
+                              "resolved": false,
+                              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
                             }
                           }
                         }
@@ -26322,7 +26538,8 @@
                     },
                     "https-proxy-agent": {
                       "version": "2.0.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-/6pLb69YasNAwYoUBDHna31/KUQ=",
                       "requires": {
                         "agent-base": "^4.1.0",
                         "debug": "^2.4.1"
@@ -26330,21 +26547,24 @@
                       "dependencies": {
                         "agent-base": {
                           "version": "4.1.0",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-IOF0Ac1Js8B2v1akvGxbQ2/6jVU=",
                           "requires": {
                             "es6-promisify": "^5.0.0"
                           },
                           "dependencies": {
                             "es6-promisify": {
                               "version": "5.0.0",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
                               "requires": {
                                 "es6-promise": "^4.0.3"
                               },
                               "dependencies": {
                                 "es6-promise": {
                                   "version": "4.1.1",
-                                  "bundled": true
+                                  "resolved": false,
+                                  "integrity": "sha512-OaU1hHjgJf+b0NzsxCg7NdIYERD6Hy/PEmFLTjw+b65scuisG3Kt4QoTvJ66BBkPZ581gr0kpoVzKnxniM8nng=="
                                 }
                               }
                             }
@@ -26352,14 +26572,16 @@
                         },
                         "debug": {
                           "version": "2.6.8",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
                           "requires": {
                             "ms": "2.0.0"
                           },
                           "dependencies": {
                             "ms": {
                               "version": "2.0.0",
-                              "bundled": true
+                              "resolved": false,
+                              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
                             }
                           }
                         }
@@ -26367,7 +26589,8 @@
                     },
                     "node-fetch-npm": {
                       "version": "2.0.1",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha512-W3onhopST5tqpX0/MGSL47pDQLLKobNR83AvkiOWQKaw54h+uYUfzeLAxCiyhWlUOiuI+GIb4O9ojLaAFlhCCA==",
                       "requires": {
                         "encoding": "^0.1.11",
                         "json-parse-helpfulerror": "^1.0.3",
@@ -26376,27 +26599,31 @@
                       "dependencies": {
                         "encoding": {
                           "version": "0.1.12",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
                           "requires": {
                             "iconv-lite": "~0.4.13"
                           },
                           "dependencies": {
                             "iconv-lite": {
                               "version": "0.4.18",
-                              "bundled": true
+                              "resolved": false,
+                              "integrity": "sha512-sr1ZQph3UwHTR0XftSbK85OvBbxe/abLGzEnPENCQwmHf7sck8Oyu4ob3LgBxWWxRoM+QszeUyl7jbqapu2TqA=="
                             }
                           }
                         },
                         "json-parse-helpfulerror": {
                           "version": "1.0.3",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-E/FM4C7tTpgSl7ZOueO5MuLdE9w=",
                           "requires": {
                             "jju": "^1.1.0"
                           },
                           "dependencies": {
                             "jju": {
                               "version": "1.3.0",
-                              "bundled": true
+                              "resolved": false,
+                              "integrity": "sha1-2t2e8BkkvHKLA/L3l5vb1i96Kqo="
                             }
                           }
                         }
@@ -26404,7 +26631,8 @@
                     },
                     "socks-proxy-agent": {
                       "version": "3.0.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha512-YJcT+SNNBgFoK/NpO20PChz0VnBOhkjG3X10BwlrYujd0NZlSsH1jbxSQ1S0njt3sOvzwQ2PvGqqUIvP4rNk/w==",
                       "requires": {
                         "agent-base": "^4.0.1",
                         "socks": "^1.1.10"
@@ -26412,21 +26640,24 @@
                       "dependencies": {
                         "agent-base": {
                           "version": "4.1.0",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-IOF0Ac1Js8B2v1akvGxbQ2/6jVU=",
                           "requires": {
                             "es6-promisify": "^5.0.0"
                           },
                           "dependencies": {
                             "es6-promisify": {
                               "version": "5.0.0",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
                               "requires": {
                                 "es6-promise": "^4.0.3"
                               },
                               "dependencies": {
                                 "es6-promise": {
                                   "version": "4.1.1",
-                                  "bundled": true
+                                  "resolved": false,
+                                  "integrity": "sha512-OaU1hHjgJf+b0NzsxCg7NdIYERD6Hy/PEmFLTjw+b65scuisG3Kt4QoTvJ66BBkPZ581gr0kpoVzKnxniM8nng=="
                                 }
                               }
                             }
@@ -26434,7 +26665,8 @@
                         },
                         "socks": {
                           "version": "1.1.10",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-W4t/x8jzQcU+0FbpKbe/Tei6e1o=",
                           "requires": {
                             "ip": "^1.1.4",
                             "smart-buffer": "^1.0.13"
@@ -26442,11 +26674,13 @@
                           "dependencies": {
                             "ip": {
                               "version": "1.1.5",
-                              "bundled": true
+                              "resolved": false,
+                              "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
                             },
                             "smart-buffer": {
                               "version": "1.1.15",
-                              "bundled": true
+                              "resolved": false,
+                              "integrity": "sha1-fxFLW2X6s+KjWqd1uxLw0cZJvxY="
                             }
                           }
                         }
@@ -26456,14 +26690,16 @@
                 },
                 "minimatch": {
                   "version": "3.0.4",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
                   "requires": {
                     "brace-expansion": "^1.1.7"
                   },
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.8",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
                       "requires": {
                         "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
@@ -26471,11 +26707,13 @@
                       "dependencies": {
                         "balanced-match": {
                           "version": "1.0.0",
-                          "bundled": true
+                          "resolved": false,
+                          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
                         },
                         "concat-map": {
                           "version": "0.0.1",
-                          "bundled": true
+                          "resolved": false,
+                          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
                         }
                       }
                     }
@@ -26483,7 +26721,8 @@
                 },
                 "npm-pick-manifest": {
                   "version": "1.0.4",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-MKxNdeyOZysPRTTbHtW0M5Fw38Jo/3ARsoGw5qjCfS+XGjvNB/Gb4qtAZUFmKPM2mVum+eX559eHvKywU856BQ==",
                   "requires": {
                     "npm-package-arg": "^5.1.2",
                     "semver": "^5.3.0"
@@ -26491,7 +26730,8 @@
                 },
                 "promise-retry": {
                   "version": "1.1.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=",
                   "requires": {
                     "err-code": "^1.0.0",
                     "retry": "^0.10.0"
@@ -26499,26 +26739,30 @@
                   "dependencies": {
                     "err-code": {
                       "version": "1.1.2",
-                      "bundled": true
+                      "resolved": false,
+                      "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA="
                     }
                   }
                 },
                 "protoduck": {
                   "version": "4.0.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-/kh02MeRM2bP2erRJFOiLNNlf44=",
                   "requires": {
                     "genfun": "^4.0.1"
                   },
                   "dependencies": {
                     "genfun": {
                       "version": "4.0.1",
-                      "bundled": true
+                      "resolved": false,
+                      "integrity": "sha1-7RAEHy5KfxsKOEZtF6XD4n3x38E="
                     }
                   }
                 },
                 "tar-fs": {
                   "version": "1.15.3",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-7M+TXpQUk9gVECjmNuUc5MPKfyA=",
                   "requires": {
                     "chownr": "^1.0.1",
                     "mkdirp": "^0.5.1",
@@ -26528,7 +26772,8 @@
                   "dependencies": {
                     "pump": {
                       "version": "1.0.2",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-Oz7mUS+U8OV1U4wXmV+fFpkKXVE=",
                       "requires": {
                         "end-of-stream": "^1.1.0",
                         "once": "^1.3.1"
@@ -26536,7 +26781,8 @@
                       "dependencies": {
                         "end-of-stream": {
                           "version": "1.4.0",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
                           "requires": {
                             "once": "^1.4.0"
                           }
@@ -26547,7 +26793,8 @@
                 },
                 "tar-stream": {
                   "version": "1.5.4",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-NlSc8E7RrumyowwBQyUiONr5QBY=",
                   "requires": {
                     "bl": "^1.0.0",
                     "end-of-stream": "^1.0.0",
@@ -26557,21 +26804,24 @@
                   "dependencies": {
                     "bl": {
                       "version": "1.2.1",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
                       "requires": {
                         "readable-stream": "^2.0.5"
                       }
                     },
                     "end-of-stream": {
                       "version": "1.4.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
                       "requires": {
                         "once": "^1.4.0"
                       }
                     },
                     "xtend": {
                       "version": "4.0.1",
-                      "bundled": true
+                      "resolved": false,
+                      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
                     }
                   }
                 }
@@ -26579,35 +26829,41 @@
             },
             "path-is-inside": {
               "version": "1.0.2",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
             },
             "promise-inflight": {
               "version": "1.0.1",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM="
             },
             "read": {
               "version": "1.0.7",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
               "requires": {
                 "mute-stream": "~0.0.4"
               },
               "dependencies": {
                 "mute-stream": {
                   "version": "0.0.7",
-                  "bundled": true
+                  "resolved": false,
+                  "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
                 }
               }
             },
             "read-cmd-shim": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-LV0Vd4ajfAVdIgd8MsU/gynpHHs=",
               "requires": {
                 "graceful-fs": "^4.1.2"
               }
             },
             "read-installed": {
               "version": "4.0.3",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-/5uLZ/GH0eTCm5/rMfayI6zRkGc=",
               "requires": {
                 "debuglog": "^1.0.1",
                 "graceful-fs": "^4.1.2",
@@ -26620,13 +26876,15 @@
               "dependencies": {
                 "util-extend": {
                   "version": "1.0.3",
-                  "bundled": true
+                  "resolved": false,
+                  "integrity": "sha1-p8IW0mdUUWljeztu3GypEZ4v+T8="
                 }
               }
             },
             "read-package-json": {
               "version": "2.0.9",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-vuV8p921IgyelL4UOKv3FsRuRZSaRn30HanLAOKargsr8TbBEq+I3MgloSRXYuKhNdYP1wlEGilMWAIayA2RFg==",
               "requires": {
                 "glob": "^7.1.1",
                 "graceful-fs": "^4.1.2",
@@ -26636,14 +26894,16 @@
               "dependencies": {
                 "json-parse-helpfulerror": {
                   "version": "1.0.3",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-E/FM4C7tTpgSl7ZOueO5MuLdE9w=",
                   "requires": {
                     "jju": "^1.1.0"
                   },
                   "dependencies": {
                     "jju": {
                       "version": "1.3.0",
-                      "bundled": true
+                      "resolved": false,
+                      "integrity": "sha1-2t2e8BkkvHKLA/L3l5vb1i96Kqo="
                     }
                   }
                 }
@@ -26651,7 +26911,8 @@
             },
             "read-package-tree": {
               "version": "5.1.6",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-FCX1aT3GWyY658wzDICef4p+n0dB+ENRct8E/Qyvppj6xVpOYerBHfUu7OP5Rt1/393Tdglguf5ju5DEX4wZNg==",
               "requires": {
                 "debuglog": "^1.0.1",
                 "dezalgo": "^1.0.0",
@@ -26662,7 +26923,8 @@
             },
             "readable-stream": {
               "version": "2.3.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-WgTfBeT1f+Pw3Gj90R3FyXx+b00=",
               "requires": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -26675,32 +26937,38 @@
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
-                  "bundled": true
+                  "resolved": false,
+                  "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
                 },
                 "isarray": {
                   "version": "1.0.0",
-                  "bundled": true
+                  "resolved": false,
+                  "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
                 },
                 "process-nextick-args": {
                   "version": "1.0.7",
-                  "bundled": true
+                  "resolved": false,
+                  "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
                 },
                 "string_decoder": {
                   "version": "1.0.3",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
                   "requires": {
                     "safe-buffer": "~5.1.0"
                   }
                 },
                 "util-deprecate": {
                   "version": "1.0.2",
-                  "bundled": true
+                  "resolved": false,
+                  "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
                 }
               }
             },
             "readdir-scoped-modules": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-n6+jfShr5dksuuve4DDcm19AZ0c=",
               "requires": {
                 "debuglog": "^1.0.1",
                 "dezalgo": "^1.0.0",
@@ -26710,7 +26978,8 @@
             },
             "request": {
               "version": "2.81.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
               "requires": {
                 "aws-sign2": "~0.6.0",
                 "aws4": "^1.2.1",
@@ -26738,40 +27007,48 @@
               "dependencies": {
                 "aws-sign2": {
                   "version": "0.6.0",
-                  "bundled": true
+                  "resolved": false,
+                  "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
                 },
                 "aws4": {
                   "version": "1.6.0",
-                  "bundled": true
+                  "resolved": false,
+                  "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
                 },
                 "caseless": {
                   "version": "0.12.0",
-                  "bundled": true
+                  "resolved": false,
+                  "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
                 },
                 "combined-stream": {
                   "version": "1.0.5",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
                   "requires": {
                     "delayed-stream": "~1.0.0"
                   },
                   "dependencies": {
                     "delayed-stream": {
                       "version": "1.0.0",
-                      "bundled": true
+                      "resolved": false,
+                      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
                     }
                   }
                 },
                 "extend": {
                   "version": "3.0.1",
-                  "bundled": true
+                  "resolved": false,
+                  "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
                 },
                 "forever-agent": {
                   "version": "0.6.1",
-                  "bundled": true
+                  "resolved": false,
+                  "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
                 },
                 "form-data": {
                   "version": "2.1.4",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
                   "requires": {
                     "asynckit": "^0.4.0",
                     "combined-stream": "^1.0.5",
@@ -26780,13 +27057,15 @@
                   "dependencies": {
                     "asynckit": {
                       "version": "0.4.0",
-                      "bundled": true
+                      "resolved": false,
+                      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
                     }
                   }
                 },
                 "har-validator": {
                   "version": "4.2.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
                   "requires": {
                     "ajv": "^4.9.1",
                     "har-schema": "^1.0.5"
@@ -26794,7 +27073,8 @@
                   "dependencies": {
                     "ajv": {
                       "version": "4.11.8",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
                       "requires": {
                         "co": "^4.6.0",
                         "json-stable-stringify": "^1.0.1"
@@ -26802,18 +27082,21 @@
                       "dependencies": {
                         "co": {
                           "version": "4.6.0",
-                          "bundled": true
+                          "resolved": false,
+                          "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
                         },
                         "json-stable-stringify": {
                           "version": "1.0.1",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
                           "requires": {
                             "jsonify": "~0.0.0"
                           },
                           "dependencies": {
                             "jsonify": {
                               "version": "0.0.0",
-                              "bundled": true
+                              "resolved": false,
+                              "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
                             }
                           }
                         }
@@ -26821,13 +27104,15 @@
                     },
                     "har-schema": {
                       "version": "1.0.5",
-                      "bundled": true
+                      "resolved": false,
+                      "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4="
                     }
                   }
                 },
                 "hawk": {
                   "version": "3.1.3",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
                   "requires": {
                     "boom": "2.x.x",
                     "cryptiles": "2.x.x",
@@ -26837,25 +27122,29 @@
                   "dependencies": {
                     "boom": {
                       "version": "2.10.1",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
                       "requires": {
                         "hoek": "2.x.x"
                       }
                     },
                     "cryptiles": {
                       "version": "2.0.5",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
                       "requires": {
                         "boom": "2.x.x"
                       }
                     },
                     "hoek": {
                       "version": "2.16.3",
-                      "bundled": true
+                      "resolved": false,
+                      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
                     },
                     "sntp": {
                       "version": "1.0.9",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
                       "requires": {
                         "hoek": "2.x.x"
                       }
@@ -26864,7 +27153,8 @@
                 },
                 "http-signature": {
                   "version": "1.1.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
                   "requires": {
                     "assert-plus": "^0.2.0",
                     "jsprim": "^1.2.2",
@@ -26873,11 +27163,13 @@
                   "dependencies": {
                     "assert-plus": {
                       "version": "0.2.0",
-                      "bundled": true
+                      "resolved": false,
+                      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
                     },
                     "jsprim": {
                       "version": "1.4.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
                       "requires": {
                         "assert-plus": "1.0.0",
                         "extsprintf": "1.0.2",
@@ -26887,19 +27179,23 @@
                       "dependencies": {
                         "assert-plus": {
                           "version": "1.0.0",
-                          "bundled": true
+                          "resolved": false,
+                          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
                         },
                         "extsprintf": {
                           "version": "1.0.2",
-                          "bundled": true
+                          "resolved": false,
+                          "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA="
                         },
                         "json-schema": {
                           "version": "0.2.3",
-                          "bundled": true
+                          "resolved": false,
+                          "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
                         },
                         "verror": {
                           "version": "1.3.6",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
                           "requires": {
                             "extsprintf": "1.0.2"
                           }
@@ -26908,7 +27204,8 @@
                     },
                     "sshpk": {
                       "version": "1.13.1",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
                       "requires": {
                         "asn1": "~0.2.3",
                         "assert-plus": "^1.0.0",
@@ -26922,15 +27219,18 @@
                       "dependencies": {
                         "asn1": {
                           "version": "0.2.3",
-                          "bundled": true
+                          "resolved": false,
+                          "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
                         },
                         "assert-plus": {
                           "version": "1.0.0",
-                          "bundled": true
+                          "resolved": false,
+                          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
                         },
                         "bcrypt-pbkdf": {
                           "version": "1.0.1",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
                           "optional": true,
                           "requires": {
                             "tweetnacl": "^0.14.3"
@@ -26938,14 +27238,16 @@
                         },
                         "dashdash": {
                           "version": "1.14.1",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
                           "requires": {
                             "assert-plus": "^1.0.0"
                           }
                         },
                         "ecc-jsbn": {
                           "version": "0.1.1",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
                           "optional": true,
                           "requires": {
                             "jsbn": "~0.1.0"
@@ -26953,19 +27255,22 @@
                         },
                         "getpass": {
                           "version": "0.1.7",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
                           "requires": {
                             "assert-plus": "^1.0.0"
                           }
                         },
                         "jsbn": {
                           "version": "0.1.1",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
                           "optional": true
                         },
                         "tweetnacl": {
                           "version": "0.14.5",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
                           "optional": true
                         }
                       }
@@ -26974,61 +27279,73 @@
                 },
                 "is-typedarray": {
                   "version": "1.0.0",
-                  "bundled": true
+                  "resolved": false,
+                  "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
                 },
                 "isstream": {
                   "version": "0.1.2",
-                  "bundled": true
+                  "resolved": false,
+                  "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
                 },
                 "json-stringify-safe": {
                   "version": "5.0.1",
-                  "bundled": true
+                  "resolved": false,
+                  "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
                 },
                 "mime-types": {
                   "version": "2.1.15",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
                   "requires": {
                     "mime-db": "~1.27.0"
                   },
                   "dependencies": {
                     "mime-db": {
                       "version": "1.27.0",
-                      "bundled": true
+                      "resolved": false,
+                      "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE="
                     }
                   }
                 },
                 "oauth-sign": {
                   "version": "0.8.2",
-                  "bundled": true
+                  "resolved": false,
+                  "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
                 },
                 "performance-now": {
                   "version": "0.2.0",
-                  "bundled": true
+                  "resolved": false,
+                  "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
                 },
                 "qs": {
                   "version": "6.4.0",
-                  "bundled": true
+                  "resolved": false,
+                  "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM="
                 },
                 "stringstream": {
                   "version": "0.0.5",
-                  "bundled": true
+                  "resolved": false,
+                  "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
                 },
                 "tough-cookie": {
                   "version": "2.3.2",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
                   "requires": {
                     "punycode": "^1.4.1"
                   },
                   "dependencies": {
                     "punycode": {
                       "version": "1.4.1",
-                      "bundled": true
+                      "resolved": false,
+                      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
                     }
                   }
                 },
                 "tunnel-agent": {
                   "version": "0.6.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
                   "requires": {
                     "safe-buffer": "^5.0.1"
                   }
@@ -27037,26 +27354,31 @@
             },
             "retry": {
               "version": "0.10.1",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q="
             },
             "rimraf": {
               "version": "2.6.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
               "requires": {
                 "glob": "^7.0.5"
               }
             },
             "safe-buffer": {
               "version": "5.1.1",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
             },
             "semver": {
               "version": "5.3.0",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
             },
             "sha": {
               "version": "2.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-YDCCL70smCOUn49y7WQR7lzyWq4=",
               "requires": {
                 "graceful-fs": "^4.1.2",
                 "readable-stream": "^2.0.2"
@@ -27064,15 +27386,18 @@
             },
             "slide": {
               "version": "1.1.6",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
             },
             "sorted-object": {
               "version": "2.0.1",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-fWMfS9OnmKJK8d/8+/6DM3pd9fw="
             },
             "sorted-union-stream": {
               "version": "2.1.3",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-x3lMfgd4gAUv9xqNSi27Sppjisc=",
               "requires": {
                 "from2": "^1.3.0",
                 "stream-iterate": "^1.1.0"
@@ -27080,7 +27405,8 @@
               "dependencies": {
                 "from2": {
                   "version": "1.3.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-iEE7qqX5pZfP3pIh2GmGzTwGHf0=",
                   "requires": {
                     "inherits": "~2.0.1",
                     "readable-stream": "~1.1.10"
@@ -27088,7 +27414,8 @@
                   "dependencies": {
                     "readable-stream": {
                       "version": "1.1.14",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
                       "requires": {
                         "core-util-is": "~1.0.0",
                         "inherits": "~2.0.1",
@@ -27098,15 +27425,18 @@
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.2",
-                          "bundled": true
+                          "resolved": false,
+                          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
                         },
                         "isarray": {
                           "version": "0.0.1",
-                          "bundled": true
+                          "resolved": false,
+                          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "bundled": true
+                          "resolved": false,
+                          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
                         }
                       }
                     }
@@ -27114,7 +27444,8 @@
                 },
                 "stream-iterate": {
                   "version": "1.2.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-K9fHcpbBcCpGSIuK1B95hl7s1OE=",
                   "requires": {
                     "readable-stream": "^2.1.5",
                     "stream-shift": "^1.0.0"
@@ -27122,7 +27453,8 @@
                   "dependencies": {
                     "stream-shift": {
                       "version": "1.0.0",
-                      "bundled": true
+                      "resolved": false,
+                      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
                     }
                   }
                 }
@@ -27130,27 +27462,31 @@
             },
             "ssri": {
               "version": "4.1.6",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-WUbCdgSAMQjTFZRWvSPpauryvREEA+Krn19rx67UlJEJx/M192ZHxMmJXjZ4tkdFm+Sb0SXGlENeQVlA5wY7kA==",
               "requires": {
                 "safe-buffer": "^5.1.0"
               }
             },
             "strip-ansi": {
               "version": "4.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "requires": {
                 "ansi-regex": "^3.0.0"
               },
               "dependencies": {
                 "ansi-regex": {
                   "version": "3.0.0",
-                  "bundled": true
+                  "resolved": false,
+                  "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
                 }
               }
             },
             "tar": {
               "version": "2.2.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
               "requires": {
                 "block-stream": "*",
                 "fstream": "^1.0.2",
@@ -27159,7 +27495,8 @@
               "dependencies": {
                 "block-stream": {
                   "version": "0.0.9",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
                   "requires": {
                     "inherits": "~2.0.0"
                   }
@@ -27168,26 +27505,31 @@
             },
             "text-table": {
               "version": "0.2.0",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
             },
             "uid-number": {
               "version": "0.0.6",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE="
             },
             "umask": {
               "version": "1.1.0",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0="
             },
             "unique-filename": {
               "version": "1.1.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-0F8v5AMlYIcfMOk8vnNe6iAVFPM=",
               "requires": {
                 "unique-slug": "^2.0.0"
               },
               "dependencies": {
                 "unique-slug": {
                   "version": "2.0.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
                   "requires": {
                     "imurmurhash": "^0.1.4"
                   }
@@ -27196,11 +27538,13 @@
             },
             "unpipe": {
               "version": "1.0.0",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
             },
             "update-notifier": {
               "version": "2.2.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-G1g3z5DAc22IYncytmHBOPht5y8=",
               "requires": {
                 "boxen": "^1.0.0",
                 "chalk": "^1.0.0",
@@ -27214,7 +27558,8 @@
               "dependencies": {
                 "boxen": {
                   "version": "1.1.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-sbad1SIwXoB6md7ud329blFnsQI=",
                   "requires": {
                     "ansi-align": "^2.0.0",
                     "camelcase": "^4.0.0",
@@ -27227,22 +27572,26 @@
                   "dependencies": {
                     "ansi-align": {
                       "version": "2.0.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
                       "requires": {
                         "string-width": "^2.0.0"
                       }
                     },
                     "camelcase": {
                       "version": "4.1.0",
-                      "bundled": true
+                      "resolved": false,
+                      "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
                     },
                     "cli-boxes": {
                       "version": "1.0.0",
-                      "bundled": true
+                      "resolved": false,
+                      "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM="
                     },
                     "string-width": {
                       "version": "2.1.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-AwZkVh/BRslCPsfZeP4kV0N/5tA=",
                       "requires": {
                         "is-fullwidth-code-point": "^2.0.0",
                         "strip-ansi": "^4.0.0"
@@ -27250,11 +27599,13 @@
                       "dependencies": {
                         "is-fullwidth-code-point": {
                           "version": "2.0.0",
-                          "bundled": true
+                          "resolved": false,
+                          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
                         },
                         "strip-ansi": {
                           "version": "4.0.0",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                           "requires": {
                             "ansi-regex": "^3.0.0"
                           }
@@ -27263,14 +27614,16 @@
                     },
                     "term-size": {
                       "version": "0.1.1",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-hzYLljlsq1dgljcUzaDQy+7K2co=",
                       "requires": {
                         "execa": "^0.4.0"
                       },
                       "dependencies": {
                         "execa": {
                           "version": "0.4.0",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-TrZGejaglfq7KXD/nV4/t7zm68M=",
                           "requires": {
                             "cross-spawn-async": "^2.1.1",
                             "is-stream": "^1.1.0",
@@ -27282,7 +27635,8 @@
                           "dependencies": {
                             "cross-spawn-async": {
                               "version": "2.2.5",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-hF/wwINKPe2dFg2sptOQkGuyiMw=",
                               "requires": {
                                 "lru-cache": "^4.0.0",
                                 "which": "^1.2.8"
@@ -27290,26 +27644,31 @@
                             },
                             "is-stream": {
                               "version": "1.1.0",
-                              "bundled": true
+                              "resolved": false,
+                              "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
                             },
                             "npm-run-path": {
                               "version": "1.0.0",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-9cMr9ZX+ga6Sfa7FLoL4sACsPI8=",
                               "requires": {
                                 "path-key": "^1.0.0"
                               }
                             },
                             "object-assign": {
                               "version": "4.1.1",
-                              "bundled": true
+                              "resolved": false,
+                              "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
                             },
                             "path-key": {
                               "version": "1.0.0",
-                              "bundled": true
+                              "resolved": false,
+                              "integrity": "sha1-XVPVeAGWRsDWiADbThRua9wqx68="
                             },
                             "strip-eof": {
                               "version": "1.0.0",
-                              "bundled": true
+                              "resolved": false,
+                              "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
                             }
                           }
                         }
@@ -27317,14 +27676,16 @@
                     },
                     "widest-line": {
                       "version": "1.0.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-DAnIXCqUaD0Nfq+O4JfVZL8OEFw=",
                       "requires": {
                         "string-width": "^1.0.1"
                       },
                       "dependencies": {
                         "string-width": {
                           "version": "1.0.2",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                           "requires": {
                             "code-point-at": "^1.0.0",
                             "is-fullwidth-code-point": "^1.0.0",
@@ -27333,31 +27694,36 @@
                           "dependencies": {
                             "code-point-at": {
                               "version": "1.1.0",
-                              "bundled": true
+                              "resolved": false,
+                              "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
                             },
                             "is-fullwidth-code-point": {
                               "version": "1.0.0",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                               "requires": {
                                 "number-is-nan": "^1.0.0"
                               },
                               "dependencies": {
                                 "number-is-nan": {
                                   "version": "1.0.1",
-                                  "bundled": true
+                                  "resolved": false,
+                                  "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
                                 }
                               }
                             },
                             "strip-ansi": {
                               "version": "3.0.1",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                               "requires": {
                                 "ansi-regex": "^2.0.0"
                               },
                               "dependencies": {
                                 "ansi-regex": {
                                   "version": "2.1.1",
-                                  "bundled": true
+                                  "resolved": false,
+                                  "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
                                 }
                               }
                             }
@@ -27369,7 +27735,8 @@
                 },
                 "chalk": {
                   "version": "1.1.3",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                   "requires": {
                     "ansi-styles": "^2.2.1",
                     "escape-string-regexp": "^1.0.2",
@@ -27380,47 +27747,55 @@
                   "dependencies": {
                     "ansi-styles": {
                       "version": "2.2.1",
-                      "bundled": true
+                      "resolved": false,
+                      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
                     },
                     "escape-string-regexp": {
                       "version": "1.0.5",
-                      "bundled": true
+                      "resolved": false,
+                      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
                     },
                     "has-ansi": {
                       "version": "2.0.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
                       "requires": {
                         "ansi-regex": "^2.0.0"
                       },
                       "dependencies": {
                         "ansi-regex": {
                           "version": "2.1.1",
-                          "bundled": true
+                          "resolved": false,
+                          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
                         }
                       }
                     },
                     "strip-ansi": {
                       "version": "3.0.1",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                       "requires": {
                         "ansi-regex": "^2.0.0"
                       },
                       "dependencies": {
                         "ansi-regex": {
                           "version": "2.1.1",
-                          "bundled": true
+                          "resolved": false,
+                          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
                         }
                       }
                     },
                     "supports-color": {
                       "version": "2.0.0",
-                      "bundled": true
+                      "resolved": false,
+                      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
                     }
                   }
                 },
                 "configstore": {
                   "version": "3.1.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-Rd+QcHPibfoc9LLVL1tgVF6qEdE=",
                   "requires": {
                     "dot-prop": "^4.1.0",
                     "graceful-fs": "^4.1.2",
@@ -27432,40 +27807,46 @@
                   "dependencies": {
                     "dot-prop": {
                       "version": "4.1.1",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-qEk/C3te7sglJbXHWH+n3nyoWcE=",
                       "requires": {
                         "is-obj": "^1.0.0"
                       },
                       "dependencies": {
                         "is-obj": {
                           "version": "1.0.1",
-                          "bundled": true
+                          "resolved": false,
+                          "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
                         }
                       }
                     },
                     "make-dir": {
                       "version": "1.0.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-l6ARdR6R3YfPre9Ygy67BJNt6Xg=",
                       "requires": {
                         "pify": "^2.3.0"
                       },
                       "dependencies": {
                         "pify": {
                           "version": "2.3.0",
-                          "bundled": true
+                          "resolved": false,
+                          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
                         }
                       }
                     },
                     "unique-string": {
                       "version": "1.0.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
                       "requires": {
                         "crypto-random-string": "^1.0.0"
                       },
                       "dependencies": {
                         "crypto-random-string": {
                           "version": "1.0.0",
-                          "bundled": true
+                          "resolved": false,
+                          "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4="
                         }
                       }
                     }
@@ -27473,22 +27854,26 @@
                 },
                 "import-lazy": {
                   "version": "2.1.0",
-                  "bundled": true
+                  "resolved": false,
+                  "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM="
                 },
                 "is-npm": {
                   "version": "1.0.0",
-                  "bundled": true
+                  "resolved": false,
+                  "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ="
                 },
                 "latest-version": {
                   "version": "3.1.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
                   "requires": {
                     "package-json": "^4.0.0"
                   },
                   "dependencies": {
                     "package-json": {
                       "version": "4.0.1",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
                       "requires": {
                         "got": "^6.7.1",
                         "registry-auth-token": "^3.0.1",
@@ -27498,7 +27883,8 @@
                       "dependencies": {
                         "got": {
                           "version": "6.7.1",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
                           "requires": {
                             "create-error-class": "^3.0.0",
                             "duplexer3": "^0.1.4",
@@ -27515,59 +27901,71 @@
                           "dependencies": {
                             "create-error-class": {
                               "version": "3.0.2",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
                               "requires": {
                                 "capture-stack-trace": "^1.0.0"
                               },
                               "dependencies": {
                                 "capture-stack-trace": {
                                   "version": "1.0.0",
-                                  "bundled": true
+                                  "resolved": false,
+                                  "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0="
                                 }
                               }
                             },
                             "duplexer3": {
                               "version": "0.1.4",
-                              "bundled": true
+                              "resolved": false,
+                              "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
                             },
                             "get-stream": {
                               "version": "3.0.0",
-                              "bundled": true
+                              "resolved": false,
+                              "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
                             },
                             "is-redirect": {
                               "version": "1.0.0",
-                              "bundled": true
+                              "resolved": false,
+                              "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ="
                             },
                             "is-retry-allowed": {
                               "version": "1.1.0",
-                              "bundled": true
+                              "resolved": false,
+                              "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ="
                             },
                             "is-stream": {
                               "version": "1.1.0",
-                              "bundled": true
+                              "resolved": false,
+                              "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
                             },
                             "lowercase-keys": {
                               "version": "1.0.0",
-                              "bundled": true
+                              "resolved": false,
+                              "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY="
                             },
                             "timed-out": {
                               "version": "4.0.1",
-                              "bundled": true
+                              "resolved": false,
+                              "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
                             },
                             "unzip-response": {
                               "version": "2.0.1",
-                              "bundled": true
+                              "resolved": false,
+                              "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c="
                             },
                             "url-parse-lax": {
                               "version": "1.0.0",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
                               "requires": {
                                 "prepend-http": "^1.0.1"
                               },
                               "dependencies": {
                                 "prepend-http": {
                                   "version": "1.0.4",
-                                  "bundled": true
+                                  "resolved": false,
+                                  "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
                                 }
                               }
                             }
@@ -27575,7 +27973,8 @@
                         },
                         "registry-auth-token": {
                           "version": "3.3.1",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-+w0yie4Nmtosu1KvXf5mywcNMAY=",
                           "requires": {
                             "rc": "^1.1.6",
                             "safe-buffer": "^5.0.1"
@@ -27583,7 +27982,8 @@
                           "dependencies": {
                             "rc": {
                               "version": "1.2.1",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
                               "requires": {
                                 "deep-extend": "~0.4.0",
                                 "ini": "~1.3.0",
@@ -27593,15 +27993,18 @@
                               "dependencies": {
                                 "deep-extend": {
                                   "version": "0.4.2",
-                                  "bundled": true
+                                  "resolved": false,
+                                  "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
                                 },
                                 "minimist": {
                                   "version": "1.2.0",
-                                  "bundled": true
+                                  "resolved": false,
+                                  "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
                                 },
                                 "strip-json-comments": {
                                   "version": "2.0.1",
-                                  "bundled": true
+                                  "resolved": false,
+                                  "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
                                 }
                               }
                             }
@@ -27609,14 +28012,16 @@
                         },
                         "registry-url": {
                           "version": "3.1.0",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
                           "requires": {
                             "rc": "^1.0.1"
                           },
                           "dependencies": {
                             "rc": {
                               "version": "1.2.1",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
                               "requires": {
                                 "deep-extend": "~0.4.0",
                                 "ini": "~1.3.0",
@@ -27626,15 +28031,18 @@
                               "dependencies": {
                                 "deep-extend": {
                                   "version": "0.4.2",
-                                  "bundled": true
+                                  "resolved": false,
+                                  "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
                                 },
                                 "minimist": {
                                   "version": "1.2.0",
-                                  "bundled": true
+                                  "resolved": false,
+                                  "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
                                 },
                                 "strip-json-comments": {
                                   "version": "2.0.1",
-                                  "bundled": true
+                                  "resolved": false,
+                                  "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
                                 }
                               }
                             }
@@ -27646,24 +28054,28 @@
                 },
                 "semver-diff": {
                   "version": "2.1.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
                   "requires": {
                     "semver": "^5.0.3"
                   }
                 },
                 "xdg-basedir": {
                   "version": "3.0.0",
-                  "bundled": true
+                  "resolved": false,
+                  "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ="
                 }
               }
             },
             "uuid": {
               "version": "3.1.0",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
             },
             "validate-npm-package-license": {
               "version": "3.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
               "requires": {
                 "spdx-correct": "~1.0.0",
                 "spdx-expression-parse": "~1.0.0"
@@ -27671,52 +28083,60 @@
               "dependencies": {
                 "spdx-correct": {
                   "version": "1.0.2",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
                   "requires": {
                     "spdx-license-ids": "^1.0.2"
                   },
                   "dependencies": {
                     "spdx-license-ids": {
                       "version": "1.2.2",
-                      "bundled": true
+                      "resolved": false,
+                      "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc="
                     }
                   }
                 },
                 "spdx-expression-parse": {
                   "version": "1.0.4",
-                  "bundled": true
+                  "resolved": false,
+                  "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw="
                 }
               }
             },
             "validate-npm-package-name": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
               "requires": {
                 "builtins": "^1.0.3"
               },
               "dependencies": {
                 "builtins": {
                   "version": "1.0.3",
-                  "bundled": true
+                  "resolved": false,
+                  "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og="
                 }
               }
             },
             "which": {
               "version": "1.2.14",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
               "requires": {
                 "isexe": "^2.0.0"
               },
               "dependencies": {
                 "isexe": {
                   "version": "2.0.0",
-                  "bundled": true
+                  "resolved": false,
+                  "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
                 }
               }
             },
             "worker-farm": {
               "version": "1.3.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-QzMRK7SbF6oFC4eJXKayys9A5f8=",
               "requires": {
                 "errno": ">=0.1.1 <0.2.0-0",
                 "xtend": ">=4.0.0 <4.1.0-0"
@@ -27724,30 +28144,35 @@
               "dependencies": {
                 "errno": {
                   "version": "0.1.4",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
                   "requires": {
                     "prr": "~0.0.0"
                   },
                   "dependencies": {
                     "prr": {
                       "version": "0.0.0",
-                      "bundled": true
+                      "resolved": false,
+                      "integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo="
                     }
                   }
                 },
                 "xtend": {
                   "version": "4.0.1",
-                  "bundled": true
+                  "resolved": false,
+                  "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
                 }
               }
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
             },
             "write-file-atomic": {
               "version": "2.1.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-0TZ20a+xcIl4u0+Mj5xDH2yOWdmQiXlKf9Hm+TgDXjTMsEYb+gDrmb8e8UNAzMCitX8NBqG4Z/FUQIyzv/R1JQ==",
               "requires": {
                 "graceful-fs": "^4.1.11",
                 "imurmurhash": "^0.1.4",
@@ -27758,7 +28183,8 @@
         },
         "npm-package-arg": {
           "version": "6.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-qBpssaL3IOZWi5vEKUKW0cO7kzLeT+EQO9W8RsLOZf76KF9E/K9+wH0C7t06HXPpaH8WH5xF1MExLuCwbTqRUg==",
           "requires": {
             "hosted-git-info": "^2.7.1",
             "osenv": "^0.1.5",
@@ -27768,29 +28194,34 @@
         },
         "npm-run-path": {
           "version": "2.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
           "requires": {
             "path-key": "^2.0.0"
           }
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
         },
         "once": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "requires": {
             "wrappy": "1"
           }
         },
         "os-homedir": {
           "version": "1.0.2",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
         },
         "os-locale": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
           "requires": {
             "execa": "^1.0.0",
             "lcid": "^2.0.0",
@@ -27799,7 +28230,8 @@
           "dependencies": {
             "cross-spawn": {
               "version": "6.0.5",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
               "requires": {
                 "nice-try": "^1.0.4",
                 "path-key": "^2.0.1",
@@ -27810,7 +28242,8 @@
             },
             "execa": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
               "requires": {
                 "cross-spawn": "^6.0.0",
                 "get-stream": "^4.0.0",
@@ -27823,7 +28256,8 @@
             },
             "get-stream": {
               "version": "4.1.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
               "requires": {
                 "pump": "^3.0.0"
               }
@@ -27832,11 +28266,13 @@
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
         },
         "osenv": {
           "version": "0.1.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "requires": {
             "os-homedir": "^1.0.0",
             "os-tmpdir": "^1.0.0"
@@ -27844,37 +28280,44 @@
         },
         "p-defer": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww="
         },
         "p-finally": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
         },
         "p-is-promise": {
           "version": "2.1.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg=="
         },
         "p-limit": {
           "version": "1.3.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
           "requires": {
             "p-try": "^1.0.0"
           }
         },
         "p-locate": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
           "requires": {
             "p-limit": "^1.1.0"
           }
         },
         "p-try": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
         },
         "package-json": {
           "version": "4.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
           "requires": {
             "got": "^6.7.1",
             "registry-auth-token": "^3.0.1",
@@ -27884,35 +28327,43 @@
         },
         "path-exists": {
           "version": "3.0.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
         },
         "path-is-inside": {
           "version": "1.0.2",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
         },
         "path-key": {
           "version": "2.0.1",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
         },
         "pify": {
           "version": "3.0.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
         },
         "prepend-http": {
           "version": "1.0.4",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
         },
         "pseudomap": {
           "version": "1.0.2",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
         },
         "pump": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
           "requires": {
             "end-of-stream": "^1.1.0",
             "once": "^1.3.1"
@@ -27920,7 +28371,8 @@
         },
         "rc": {
           "version": "1.2.8",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
           "requires": {
             "deep-extend": "^0.6.0",
             "ini": "~1.3.0",
@@ -27930,7 +28382,8 @@
         },
         "registry-auth-token": {
           "version": "3.4.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-4LM6Fw8eBQdwMYcES4yTnn2TqIasbXuwDx3um+QRs7S55aMKCBKBxvPXl2RiUjHwuJLTyYfxSpmfSAjQpcuP+A==",
           "requires": {
             "rc": "^1.1.6",
             "safe-buffer": "^5.0.1"
@@ -27938,63 +28391,75 @@
         },
         "registry-url": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
           "requires": {
             "rc": "^1.0.1"
           }
         },
         "require-directory": {
           "version": "2.1.1",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
         },
         "require-main-filename": {
           "version": "1.0.1",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
         },
         "rimraf": {
           "version": "2.7.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
           "requires": {
             "glob": "^7.1.3"
           }
         },
         "safe-buffer": {
           "version": "5.2.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
         },
         "semver": {
           "version": "5.7.1",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
         },
         "semver-diff": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
           "requires": {
             "semver": "^5.0.3"
           }
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
         },
         "shebang-command": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
           "requires": {
             "shebang-regex": "^1.0.0"
           }
         },
         "shebang-regex": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
         },
         "string-width": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "requires": {
             "is-fullwidth-code-point": "^2.0.0",
             "strip-ansi": "^4.0.0"
@@ -28002,51 +28467,60 @@
         },
         "strip-ansi": {
           "version": "4.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "requires": {
             "ansi-regex": "^3.0.0"
           }
         },
         "strip-eof": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
         },
         "supports-color": {
           "version": "5.5.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "requires": {
             "has-flag": "^3.0.0"
           }
         },
         "term-size": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
           "requires": {
             "execa": "^0.7.0"
           }
         },
         "timed-out": {
           "version": "4.0.1",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
         },
         "unique-string": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
           "requires": {
             "crypto-random-string": "^1.0.0"
           }
         },
         "unzip-response": {
           "version": "2.0.1",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c="
         },
         "update-notifier": {
           "version": "2.5.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
           "requires": {
             "boxen": "^1.2.1",
             "chalk": "^2.0.1",
@@ -28062,39 +28536,45 @@
         },
         "url-parse-lax": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
           "requires": {
             "prepend-http": "^1.0.1"
           }
         },
         "validate-npm-package-name": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
           "requires": {
             "builtins": "^1.0.3"
           }
         },
         "which": {
           "version": "1.3.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
           "requires": {
             "isexe": "^2.0.0"
           }
         },
         "which-module": {
           "version": "2.0.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
         },
         "widest-line": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
           "requires": {
             "string-width": "^2.1.1"
           }
         },
         "wrap-ansi": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
           "requires": {
             "string-width": "^1.0.1",
             "strip-ansi": "^3.0.1"
@@ -28102,18 +28582,21 @@
           "dependencies": {
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
             },
             "is-fullwidth-code-point": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
             },
             "string-width": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -28122,7 +28605,8 @@
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -28131,11 +28615,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
         "write-file-atomic": {
           "version": "2.4.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
           "requires": {
             "graceful-fs": "^4.1.11",
             "imurmurhash": "^0.1.4",
@@ -28144,19 +28630,23 @@
         },
         "xdg-basedir": {
           "version": "3.0.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ="
         },
         "y18n": {
           "version": "4.0.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
         },
         "yallist": {
           "version": "2.1.2",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
         },
         "yargs": {
           "version": "11.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-PRU7gJrJaXv3q3yQZ/+/X6KBswZiaQ+zOmdprZcouPYtQgvNU35i+68M4b1ZHLZtYFT5QObFLV+ZkmJYcwKdiw==",
           "requires": {
             "cliui": "^4.0.0",
             "decamelize": "^1.1.1",
@@ -28174,13 +28664,15 @@
           "dependencies": {
             "y18n": {
               "version": "3.2.1",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
             }
           }
         },
         "yargs-parser": {
           "version": "9.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
           "requires": {
             "camelcase": "^4.1.0"
           }
@@ -32080,10 +32572,9 @@
       }
     },
     "validated-changeset": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/validated-changeset/-/validated-changeset-0.9.0.tgz",
-      "integrity": "sha512-wglCCOjenijB9YXwhAJ953QIu/1dsKF5b4uCLG101EOWV47P/lHB5ASBr1wr3BVGaOp/4beinzYCCepSN+EJBg==",
-      "dev": true
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/validated-changeset/-/validated-changeset-0.8.2.tgz",
+      "integrity": "sha512-XEWjzRK53AM1mNwYFYnMG83HtJR5VjUQX9i7p7sIZsaeVa7tg9AfMjwXu7PtL7Fs9M3mwdUcngV6shgGnFNPvw=="
     },
     "vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "json-formatter-js": "^2.3.4",
     "libphonenumber-js": "^1.7.57",
     "lodash": "^4.17.20",
-    "mobile-detect": "^1.4.4"
+    "mobile-detect": "^1.4.4",
+    "validated-changeset": "0.8.2"
   },
   "devDependencies": {
     "@ember/edition-utils": "^1.2.0",
@@ -45,8 +46,8 @@
     "ember-ajax": "^5.0.0",
     "ember-animated": "^0.10.1",
     "ember-auto-import": "^1.6.0",
-    "ember-changeset": "^3.9.0",
-    "ember-changeset-validations": "^3.9.0",
+    "ember-changeset": "3.8.2",
+    "ember-changeset-validations": "3.8.1",
     "ember-cli": "~3.21.2",
     "ember-cli-app-version": "^3.2.0",
     "ember-cli-babel": "^7.22.1",


### PR DESCRIPTION
validated-changeset introduced an exception propagation bug. The original server exception
is lost and as a result the http status and response payload is no longer accessible.
A github issue has been filed.