### PR TITLE
Add an active status to Positions

### DIFF
--- a/app/components/admin/slot-form.js
+++ b/app/components/admin/slot-form.js
@@ -29,7 +29,13 @@ export default class SlotFormComponent extends Component {
   };
 
   get positionOptions() {
-    return this.args.positions.map((p) => [p.title, p.id]);
+    let activePositions = this.args.positions.filter(p => p.active).map(p => [p.title, p.id]);
+    let inactivePositions = this.args.positions.filter(p => !p.active).map(p => [p.title, p.id]);
+
+    return [
+      { groupName: 'Active', options: activePositions },
+      { groupName: 'Inactive', options: inactivePositions },
+    ];
   }
 
   get formTitle() {

--- a/app/components/boolean-icon.hbs
+++ b/app/components/boolean-icon.hbs
@@ -1,0 +1,5 @@
+{{#if @value}}
+  <span class="{{@trueClass}}">{{if @trueIcon (fa-icon @trueIcon) (fa-icon "check") }}</span>
+{{else}}
+  <span class="{{@falseClass}}">{{if @falseIcon (fa-icon @falseIcon) "-"}}</span>
+{{/if}}

--- a/app/components/person/full-form.hbs
+++ b/app/components/person/full-form.hbs
@@ -120,7 +120,7 @@ Everyone else will see person/simple-form
         <div class="row">
           {{#each @personPositions as |position| }}
             <div class="col-sm-6 col-xl-4">
-              {{position.title}}
+              {{position-label position}}
             </div>
           {{/each}}
         </div>

--- a/app/components/person/position-form.js
+++ b/app/components/person/position-form.js
@@ -1,5 +1,6 @@
 import Component from '@glimmer/component';
 import {tracked} from '@glimmer/tracking';
+import { positionLabel } from 'clubhouse/helpers/position-label'
 
 export default class PersonPositionFormComponent extends Component {
   @tracked positionForm;
@@ -16,8 +17,13 @@ export default class PersonPositionFormComponent extends Component {
       return [];
     }
 
-    return this.args.positions.map((position) => {
-      return [position.title, position.id];
+    // Include INACTVE positions if the person has it so it can be unchecked
+    let filteredPositions = this.args.positions.filter(position => {
+      return position.active || this.args.positionIds.includes(position.id)
+    });
+
+    return filteredPositions.map((position) => {
+      return [positionLabel([position]), position.id];
     });
   }
 }

--- a/app/components/person/simple-form.hbs
+++ b/app/components/person/simple-form.hbs
@@ -80,7 +80,7 @@
       <div class="row">
         {{#each @personPositions as |position| }}
           <div class="col-sm-6 col-xl-4">
-            {{position.title}}
+            {{position-label position}}
           </div>
         {{/each}}
       </div>

--- a/app/components/shift-check-in-out.js
+++ b/app/components/shift-check-in-out.js
@@ -32,7 +32,7 @@ export default class ShiftCheckInOutComponent extends Component {
     const slots = this.args.imminentSlots;
     if (slots) {
       slots.forEach((slot) => {
-        const position = this.args.positions.find((p) => slot.position_id == p.id);
+        const position = this.activePositions.find((p) => slot.position_id == p.id);
         if (position) {
           if (position.is_untrained) {
             set(slot, 'is_untrained', true);
@@ -46,7 +46,7 @@ export default class ShiftCheckInOutComponent extends Component {
       });
     }
 
-    const signins = this.args.positions.map((pos) => {
+    const signins = this.activePositions.map((pos) => {
       let title = pos.title;
       let disqualified = null;
 
@@ -85,6 +85,10 @@ export default class ShiftCheckInOutComponent extends Component {
     this.signinPositionId = this.signinPositions.firstObject.id;
   }
 
+  get activePositions() {
+    return this.args.positions.filter(position => position.active)
+  }
+
   // Has the person gone through dirt training?
 
   get isPersonDirtTrained() {
@@ -102,7 +106,7 @@ export default class ShiftCheckInOutComponent extends Component {
   }
 
   _startShift(positionId, slotId = null) {
-    const position = this.args.positions.find((p) => p.id == positionId);
+    const position = this.activePositions.find((p) => p.id == positionId);
     const person = this.args.person;
 
     const data = {

--- a/app/controllers/admin/positions.js
+++ b/app/controllers/admin/positions.js
@@ -19,13 +19,29 @@ export default class PositionController extends Controller {
     return types;
   }
 
-  @computed('positions.@each.title', 'typeFilter')
+  activeFilter = 'all';
+  activeOptions = [
+    {id: 'all', title: 'All'},
+    {id: 'active', title: 'Active'},
+    {id: 'inactive', title: 'Inactive'},
+  ];
+
+  @computed('positions.@each.title', 'typeFilter', 'activeFilter')
   get viewPositions() {
-    const typeFilter = this.typeFilter;
     let positions = this.positions;
+    const typeFilter = this.typeFilter;
+    const activeFilter = this.activeFilter;
 
     if (typeFilter != 'All') {
       positions = positions.filterBy('type', typeFilter);
+    }
+
+    if (activeFilter) {
+      if (activeFilter == 'active') {
+        positions = positions.filterBy('active', true);
+      } else if (activeFilter == 'inactive') {
+        positions = positions.filterBy('active', false);
+      }
     }
 
     return positions.sortBy('title');

--- a/app/helpers/position-label.js
+++ b/app/helpers/position-label.js
@@ -1,0 +1,8 @@
+import { helper } from '@ember/component/helper';
+
+export function positionLabel([position]) {
+  let decorator = (position.active) ? '' : ' - [INACTIVE]';
+  return `${position.title}${decorator}`;
+}
+
+export default helper(positionLabel);

--- a/app/models/position.js
+++ b/app/models/position.js
@@ -13,4 +13,5 @@ export default class PositionModel extends Model {
   @attr('number') training_position_id;
   @attr('boolean') prevent_multiple_enrollments;
   @attr('string') contact_email;
+  @attr('boolean', { defaultValue: true}) active;
 }

--- a/app/templates/admin/positions.hbs
+++ b/app/templates/admin/positions.hbs
@@ -47,17 +47,23 @@ Showing {{this.viewPositions.length}} of {{this.positions.length}} positions
       <td>{{position.type}}</td>
       <td class="text-center">{{position.min}} / {{position.max}}</td>
       <td class="text-center">
-        {{#if position.active}}
-          {{fa-icon "check"}}
-        {{else}}
-          <span class="text-danger">{{fa-icon "times"}}</span>
-        {{/if}}
+        <BooleanIcon @value={{position.active}} @falseIcon="times" @falseClass="text-danger"/>
       </td>
-      <td class="text-center">{{yesno position.new_user_eligible}}</td>
-      <td class="text-center">{{yesno position.all_rangers}}</td>
-      <td class="text-center">{{yesno position.count_hours}}</td>
-      <td class="text-center">{{yesno position.on_sl_report}}</td>
-      <td>{{if position.prevent_multiple_enrollments "Y" "-"}}</td>
+      <td class="text-center">
+        <BooleanIcon @value={{position.new_user_eligible}} @trueIcon="user"/>
+      </td>
+      <td class="text-center">
+        <BooleanIcon @value={{position.all_rangers}} @trueIcon="users"/>
+      </td>
+      <td class="text-center">
+        <BooleanIcon @value={{position.count_hours}} @trueIcon="clock"/>
+      </td>
+      <td class="text-center">
+        <BooleanIcon @value={{position.on_sl_report}} @trueIcon="list"/>
+      </td>
+      <td class="text-center">
+        <BooleanIcon @value={{position.prevent_multiple_enrollments}} @trueIcon="ban"/>
+      </td>
       <td>
         {{#if position.training_position_id}}
           {{pluck position.training_position_id positions "title" "-"}}<br>
@@ -106,8 +112,8 @@ Showing {{this.viewPositions.length}} of {{this.positions.length}} positions
           <legend>Flags</legend>
           <div class="form-row mb-2">
             <f.input @name="active" @type="checkbox" @label="Active" @inline=true/>
-            <f.input @name="all_rangers" @type="checkbox" @label="All Rangers" @inline=true/>
             <f.input @name="new_user_eligible" @type="checkbox" @label="New user eligible" @inline=true/>
+            <f.input @name="all_rangers" @type="checkbox" @label="All Rangers" @inline=true/>
             <f.input @name="count_hours" @type="checkbox" @label="Hours count towards appreciations" @inline=true/>
             <f.input @name="on_sl_report" @type="checkbox" @label="On Shift Lead report" @inline=true/>
             <f.input @name="prevent_multiple_enrollments" @type="checkbox"

--- a/app/templates/admin/positions.hbs
+++ b/app/templates/admin/positions.hbs
@@ -20,6 +20,7 @@ Showing {{this.viewPositions.length}} of {{this.positions.length}} positions
     <th>Short Title</th>
     <th>Type</th>
     <th>Min / Max</th>
+    <th class="text-center">Active</th>
     <th class="text-center">New User Eligible</th>
     <th class="text-center">All Rangers</th>
     <th class="text-center">Count Hrs</th>
@@ -40,6 +41,13 @@ Showing {{this.viewPositions.length}} of {{this.positions.length}} positions
       </td>
       <td>{{position.type}}</td>
       <td class="text-center">{{position.min}} / {{position.max}}</td>
+      <td class="text-center">
+        {{#if position.active}}
+          {{fa-icon "check"}}
+        {{else}}
+          <span class="text-danger">{{fa-icon "times"}}</span>
+        {{/if}}
+      </td>
       <td class="text-center">{{yesno position.new_user_eligible}}</td>
       <td class="text-center">{{yesno position.all_rangers}}</td>
       <td class="text-center">{{yesno position.count_hours}}</td>
@@ -92,6 +100,7 @@ Showing {{this.viewPositions.length}} of {{this.positions.length}} positions
         <fieldset>
           <legend>Flags</legend>
           <div class="form-row mb-2">
+            <f.input @name="active" @type="checkbox" @label="Active" @inline=true/>
             <f.input @name="all_rangers" @type="checkbox" @label="All Rangers" @inline=true/>
             <f.input @name="new_user_eligible" @type="checkbox" @label="New user eligible" @inline=true/>
             <f.input @name="count_hours" @type="checkbox" @label="Hours count towards appreciations" @inline=true/>

--- a/app/templates/admin/positions.hbs
+++ b/app/templates/admin/positions.hbs
@@ -6,6 +6,11 @@
     <ChForm::Select @name="typeFilter" @value={{typeFilter}} @options={{typeOptions}} @onChange={{action
             (mut typeFilter)}} @controlClass="form-control"/>
   </div>
+  <label class="col-form-label">Active Filter</label>
+  <div class="col-auto">
+    <ChForm::Select @name="activeFilter" @value={{this.activeFilter}} @options={{this.activeOptions}}
+                    @onChange={{action (mut activeFilter)}} @controlClass="form-control"/>
+  </div>
   <div class="col-auto">
     <button type="button" class="btn btn-primary" {{on "click"  this.newAction}}>New Position</button>
   </div>


### PR DESCRIPTION
> :warning: **Requires burningmantech/ranger-clubhouse-api#663**



## Update Admin -> Positions

### What Changed?
- Add "Active" Column
- Add "Active" checkbox to form
- Reorder "flags" in form to match order in the table
- Add `BooleanIcon` component to display icons based on the boolean value
- Use new component to display icons for all boolean columns in the table
- Add an "Active Filter" to the table

### How to test and validate?
- Visit `/admin/positions`
- Verify there is an `Active` column
- Create and edit Positions with different combinations of flags.
- Validate that when a flag, other than 'active',  is set it displays a unique icon, otherwise it display a dash.  
- Validate that when the 'active' flag is set it displays a check, other wise it displays a red 'X'


## Update Person Manage Page

### What Changed?
- If a Ranger is assigned to an inactive position, that position will be labeled **[INACTIVE]** in the "Show Positions" view
- The "Edit Positions" view filters out inactive positions unless the current Ranger is assigned to an inactive position. In that case it will be labeled **[INACTIVE]** allowing it be removed from the current Ranger.

### How to test and validate?
- First set some Positions as inactive as described above.
- Visit the Person Manage Page for any Ranger, i.e. `/person/3998`
- Validate that the the inactive positions do not appear in the edit form
- Note a position that the Ranger currently holds and mark that position as inactive in the Position view
- Go back to the Person Manage Page and validate that that position:
  - is displayed on the "Show Position" and "Edit Position" with an **[INACTIVE]** label.
  - is able to be unchecked from the form and disappears once the form is submitted.


## Update `<ShiftCheckInOut>` 

### What Changed?
- The select box only displays active positions

### How to test and validate?
- Visit the Shift Manage view for a Ranger
- Validate that the list of Positions only includes active Positions. 


## Update `<Admin::SlotForm>` 

### What Changed?
- Separate the active and inactive positions into separate groups in the Position Select. 

### How to test and validate?
- Visit Admin -> Slots
- Validate that the Position select separate the positions into Active and Inactive groups.
