### PR TITLE
Rework sign up blocker. UI tweaks.

### DIFF
--- a/app/components/clubhouse-messages.hbs
+++ b/app/components/clubhouse-messages.hbs
@@ -1,6 +1,6 @@
 <div class="mail-container">
   <div class="row mb-2">
-    <div class="col-md-12 col-lg-auto mt-2">
+    <div class="col-sm-12 col-lg-auto mt-2">
       {{#if @messages}}
         {{pluralize @messages.length "message"}}
         {{#if this.unreadCount}}
@@ -9,10 +9,10 @@
           (no unread)
         {{/if}}
       {{else}}
-        <b>{{if @isMe "You have" "There are"}} no messages.</b>
+        <b>There are no messages.</b>
       {{/if}}
     </div>
-    <div class="col-md-12 col-lg-auto">
+    <div class="col-sm-12 col-lg-auto">
     {{#if this.canSendMessages}}
       <button type="button" class="btn btn-primary ml-md-auto btn-responsive" {{on "click" this.newMessageAction}}>{{fa-icon "plus"}}
         New Message

--- a/app/components/dashboard-links.hbs
+++ b/app/components/dashboard-links.hbs
@@ -17,10 +17,7 @@
           <p>
             <a href={{config "RangerPoliciesUrl"}} rel="noopener noreferrer" target="_blank">Ranger Polices Folder</a>
           </p>
-          <p>
-            <a href={{config "RadioCheckoutFormUrl"}} rel="noopener noreferrer" target="_blank">Radio Checkout Form</a>
-          </p>
-        {{/unless}}
+         {{/unless}}
         </div>
       </div>
     </div>

--- a/app/components/dashboard-ranger.hbs
+++ b/app/components/dashboard-ranger.hbs
@@ -140,15 +140,6 @@
       <LinkTo @route="me.timesheet">Timesheets</LinkTo>
     </dd>
 
-    <dt>Radio Checkout Form</dt>
-    <dd>
-      Rangers must complete the Rangers Radio Checkout Form
-      before being issued a radio. Radio forms are available at Ranger HQ or
-      the form can be printed and filled out in advance. The form is located here:
-      <a href="{{config "RadioCheckoutFormUrl"}}" target="_blank" rel="noopener noreferrer">Rangers Radio Checkout
-        Form</a>
-    </dd>
-
     {{#if (config "MotorpoolPolicyEnable")}}
       <dt>Motorpool Agreement</dt>
       <dd>

--- a/app/components/modal-confirm-missing-requirements.hbs
+++ b/app/components/modal-confirm-missing-requirements.hbs
@@ -1,0 +1,12 @@
+<ModalDialog @title="Sign up requirements have not been met" as |Modal|>
+  <Modal.body>
+    <ScheduleRequirements @requirements={{this.data.requirements}} @person={{this.data.person}} />
+    <p>
+      <b class="text-danger">You have the privileges to force the sign up and your actions will be logged if you do.</b>
+    </p>
+  </Modal.body>
+  <Modal.footer>
+    <Modal.button @label="Cancel" @action={{@onClose}} @type="primary"/>
+    <Modal.button @label="Force Sign Up" @action={{@onConfirm}} @type="danger"/>
+  </Modal.footer>
+</ModalDialog>

--- a/app/components/modal-confirm-missing-requirements.js
+++ b/app/components/modal-confirm-missing-requirements.js
@@ -1,0 +1,7 @@
+import Component from '@glimmer/component';
+import { alias } from '@ember/object/computed';
+
+export default class ModalConfirmMissingRequirementsComponent extends Component {
+  @alias('args.dialog.data') data;
+
+}

--- a/app/components/modal-missing-requirements.hbs
+++ b/app/components/modal-missing-requirements.hbs
@@ -1,0 +1,10 @@
+<ModalDialog @title="Sign Up Requirements Not Met" as |Modal|>
+  <Modal.body>
+    <ScheduleRequirements @requirements={{this.data.requirements}}
+                          @person={{this.data.person}}
+                          @isTraining={{this.isTraining}} />
+  </Modal.body>
+  <Modal.footer>
+    <Modal.button @label="Close" @action={{@onClose}} @type="primary"/>
+  </Modal.footer>
+</ModalDialog>

--- a/app/components/modal-missing-requirements.js
+++ b/app/components/modal-missing-requirements.js
@@ -1,0 +1,11 @@
+import Component from '@glimmer/component';
+import { alias } from '@ember/object/computed';
+import { TRAINING } from 'clubhouse/constants/positions';
+
+export default class ModalMissingRequirementsComponent extends Component {
+  @alias('args.dialog.data') data;
+
+   get isTraining() {
+    return this.data.slot.position_id == TRAINING;
+  }
+}

--- a/app/components/modal-multiple-enrollment.hbs
+++ b/app/components/modal-multiple-enrollment.hbs
@@ -1,7 +1,8 @@
 <ModalDialog @title="Already Signed Up" as |modal|>
   <modal.body>
     <p>
-      {{this.youAreOrCallsignIs}} already enrolled in
+      <YouOrCallsign @person={{this.person}} @youLabel="You are" @callsignVerb="is"/>
+      already enrolled in
       {{pluralize this.enrolledSlots.length (if this.isAlpha "Alpha shift" (concat this.trainingType " session")) }}:
     </p>
     <p>
@@ -23,7 +24,9 @@
     </p>
     {{#if this.data.person.isRanger}}
       <p>
-        NOTE: {{this.youAreOrCallsignIs}} allowed to sign up for a single  Training session and different
+        NOTE:
+        <YouOrCallsign @person={{this.person}} @youLabel="you are" @callsignVerb="is"/>
+        allowed to sign up for a single Training session and different
         ART Training sessions.
       </p>
     {{/if}}

--- a/app/components/modal-multiple-enrollment.js
+++ b/app/components/modal-multiple-enrollment.js
@@ -7,6 +7,7 @@ export default class ModalMultipleEnrollmentComponent extends Component {
   @service session;
 
   @alias('args.dialog.data') data;
+  @alias('data.person') person;
 
   @alias('data.enrolledSlots') enrolledSlots;
 
@@ -14,14 +15,10 @@ export default class ModalMultipleEnrollmentComponent extends Component {
   @alias('data.slot.position_title') trainingType;
 
   get isMe() {
-    return this.session.userId == this.data.person.id;
+    return this.session.userId == this.person.id;
   }
 
   get isAlpha() {
     return this.slot.position_id == Position.ALPHA;
-  }
-
-  get youAreOrCallsignIs() {
-    return this.isMe ? 'You are' : `${this.data.person.callsign} is`;
   }
 }

--- a/app/components/person/timesheet-manage.hbs
+++ b/app/components/person/timesheet-manage.hbs
@@ -1,7 +1,7 @@
 <div class="border rounded p-2 mt-2 mb-2">
   <h3>Timesheet Entries</h3>
   <p>
-  <LinkTo @route="person.timesheet-log" @query={{hash year=@year}}>View {{@year}} Timesheet Log</LinkTo>
+    <LinkTo @route="person.timesheet-log" @query={{hash year=@year}}>View {{@year}} Timesheet Log</LinkTo>
   </p>
   <span class="d-inline-block">{{fa-icon "question"}} = unverified.</span>
   <span class="d-inline-block">{{fa-icon "check"}} = verified.</span>
@@ -9,7 +9,7 @@
   <span class="d-inline-block">{{fa-icon "thumbs-down" type="far"}} = requested correction rejected.</span>
   <span class="d-inline-block">{{fa-icon "thumbs-up" type="far"}} = correction approved, awaiting verify.</span>
   <span class="d-inline-block">{{fa-icon "question-circle" type="far"}} = correction needs more info.</span>
-  <span class="d-inline-block">[hh:mm] = time in brackets indicates the time does not count towards appreciations.</span>
+  <span class="d-inline-block">{{fa-icon "minus-square" color="danger" type="far"}} = hours do not count towards appreciations.</span>
 
   <table class="table table-hover table-striped table-sm table-width-auto">
     <thead>
@@ -28,7 +28,7 @@
       <tr class="{{if ts.isPendingReview "bg-warning"}}">
         <td>
           {{#if (is-empty ts.off_duty)}}
-            -
+            &nbsp;
           {{else if ts.verified}}
             {{fa-icon "check"}}
           {{else if ts.isPendingReview}}
@@ -52,11 +52,10 @@
           {{/if}}
         </td>
         <td class="text-right">
-          {{#if ts.position.count_hours}}
-            {{hour-minute-format ts.duration}}
-          {{else}}
-            [{{hour-minute-format ts.duration}}]
-          {{/if}}
+          {{#unless ts.position.count_hours}}
+            {{fa-icon "minus-square" color="danger" type="far"}}
+          {{/unless}}
+          {{hour-minute-format ts.duration}}
         </td>
         <td class="text-right">
           {{credits-format ts.credits}}
@@ -113,9 +112,9 @@
           </ChNotice>
         {{else if this.editEntry.verified}}
           <ChNotice @type="success" @icon="check" @iconSize="1x">
-              <b>Entry was verified on {{shift-format this.editEntry.verified_at}}
+            <b>Entry was verified on {{shift-format this.editEntry.verified_at}}
               by {{this.editEntry.verified_person.callsign}}.
-                Review is not needed at this time.</b>
+              Review is not needed at this time.</b>
           </ChNotice>
         {{/if}}
 
@@ -143,7 +142,9 @@
                   Edit Verification Flag &amp; Note
                 </button>
               </div>
-              <div class="mb-3 col-12"><PresentOrNot @value={{this.editEntry.notes}} /></div>
+              <div class="mb-3 col-12">
+                <PresentOrNot @value={{this.editEntry.notes}} />
+              </div>
             </div>
           {{/if}}
         </fieldset>

--- a/app/components/schedule-blocked.hbs
+++ b/app/components/schedule-blocked.hbs
@@ -1,0 +1,36 @@
+<ChNotice @type="danger" @icon="exclamation-circle">
+  <ScheduleRequirements @requirements={{@requirements}} @person={{@person}} @isTraining={{@hasTrainingBlocker}} />
+  {{#if @hasTrainingBlocker}}
+    <p>
+      The homepage has instructions on how to resolve the issue(s) above.
+    </p>
+    <p>
+      <YouOrCallsign @person={{@person}} @youLabel="You are" @callsignVerb="is"/>
+      allowed to sign up for all other shifts.
+    </p>
+    <p>
+      <b>A Training shift MUST BE ATTENDED &amp; PASSED before being allowed to work on playa.</b>
+    </p>
+    <p>
+      <button type="button" class="btn btn-primary" {{on "click" @overrideAction}}>
+        View Schedule &amp; Sign Ups
+      </button>
+    </p>
+    <BackToHome/>
+  {{else}}
+    {{#if @isAdmin}}
+      <p class="mt-2">
+        As a Clubhouse Admin, you may override the requirement(s) to gain access to the schedule.<br>
+        <b class="text-danger">ALL ACTIONS WILL BE LOGGED.</b>
+      </p>
+      <button type="button" class="btn btn-danger" {{on "click" @overrideAction}}>
+        Override Requirements
+      </button>
+    {{else if @isMe}}
+      <p>
+        The homepage has instructions on how to resolve the issue(s) above.
+      </p>
+      <BackToHome/>
+    {{/if}}
+  {{/if}}
+</ChNotice>

--- a/app/components/schedule-blocked.js
+++ b/app/components/schedule-blocked.js
@@ -1,0 +1,16 @@
+import Component from '@glimmer/component';
+import { REQUIREMENT_LABELS } from 'clubhouse/constants/signup-requirements';
+import { inject as service } from '@ember/service';
+
+export default class ScheduleBlockedComponent extends Component {
+  @service session;
+
+  constructor() {
+    super(...arguments);
+    this.requirementsList = this.args.requirements.map((r) => (REQUIREMENT_LABELS[r] || `Unknown code ${r}. Report this bug to the tech team.`));
+  }
+
+  get isMe() {
+    return this.session.userId == this.person.id;
+  }
+}

--- a/app/components/schedule-manage.hbs
+++ b/app/components/schedule-manage.hbs
@@ -1,199 +1,86 @@
-<PrintInstruction />
-{{#unless this.isCurrentYear}}
-  <ChNotice @type="warning" @icon="hand-point-right">
-    Warning: You are viewing a past schedule ({{@year}}).
-  </ChNotice>
-{{/unless}}
-{{#if (and this.noPermissionToSignUp (not this.requirementsOverride))}}
-  <ChNotice @title="Sign ups for training and/or shifts is not allowed" @type="danger" @icon="exclamation-circle">
-    {{#if (eq this.permission.photo_status "error")}}
-      <h3 class="mt-2">Oops! There was a problem communicating with our photo server.</h3>
-      <p>
-        We cannot determine if {{if this.isMe "you have" (concat @person.callsign " has")}} uploaded a photo,
-        or if it has been approved. Please check back in a few minutes to see if the problem has resolved.
-        If this problems persists, please contact {{admin-email}} for help.
-      </p>
-      <p>
-        We are sorry if this is an inconvenience for you.
-      </p>
-    {{else}}
-      {{if this.isMe "You have" (concat @person.callsign " has")}} not met all the requirements to sign up for
-      training and/or shifts. The following item(s) need to be done:
-      <ul class="mt-2">
-        {{#unless this.hasApprovedPhoto}}
-          {{#if (eq this.permission.photo_status "missing")}}
-            <li>
-              <b>Upload a photo</b>:<br>
-              Please upload a BMID photo. Note that photos can take 2-3 days to be approved.
-              A new photo may be uploaded on the
-              <LinkTo @route="me.overview">Home Page</LinkTo>
-              .
-            </li>
-          {{else if (eq this.permission.photo_status "rejected")}}
-            <li>
-              <b>Submitted photo was rejected</b><br>
-              The photo was rejected. Please upload a new photo that conforms to the guidelines.
-              A new photo may be uploaded on the
-              <LinkTo @route="me.overview">Home Page</LinkTo>
-              .
-            </li>
-          {{else}}
-            <li>
-              <b>Photo pending approval</b><br>
-              The photo has been submitted and may take up to 2 to 3 days to review. Please check back then.
-            </li>
-          {{/if}}
-        {{/unless}}
+<PrintInstruction/>
 
-        {{#if this.permission.online_training_allowed}}
-          <li><b>Complete Online Training</b><br>
-            {{#if this.permission.online_training_url}}
-              {{#if this.isMe}}
-                <OnlineTrainingLaunch @text="Click Here" @person={{@person}}
-                                      @url={{this.permission.online_training_url}} />
-                to take the Online Training Ranger course. The course will take 1 to 2 hours to complete.
-              {{else}}
-                <b>{{@person.callsign}} will need to login and complete Online Training.</b>
-              {{/if}}
-            {{else}}
-              Unfortunately, the Online Training course is still being worked on.
-              Please check back later.
-            {{/if}}
-          </li>
-        {{else if (and (not this.hasApprovedPhoto) (not this.permission.online_training_passed))}}
-          <li>
-            <b>Upload Photo &amp; Complete Part 1 of Training (online)</b><br>
-            You will need to upload a photo and have it approved before being allowed to take Part 1 of Training
-            (online).
-          </li>
-        {{/if}}
-      </ul>
-    {{/if}}
-
-    {{#if (and (not @person.callsign_approved) (not @person.isAuditor) (not @person.isNonRanger))}}
-      <p>
-        Please email {{vc-email}} if {{if this.isMe "you are" (concat @person.callsign " is")}} interested in
-        volunteering with us or if you think you have received this message in error.
-      </p>
-    {{else}}
-      {{#if this.permission.missing_bpguid}}
-        <h3 class="mt-2">Missing Burner Profile ID</h3>
-        <PersonMissingBpguid/>
-      {{/if}}
-
-    {{/if}}
-
-    {{#if this.isAdmin}}
-      <p class="mt-2">
-        As a Clubhouse Admin, you may override the requirement(s) to gain access to the schedule.
-        <b class="text-danger">ALL ACTIONS WILL BE LOGGED.</b>
-
-      </p>
-      <p>
-        <button type="button" class="btn btn-danger" {{on "click" this.setRequirementsOverride}}>
-          Click To Override
-        </button>
-      </p>
-    {{/if}}
-  </ChNotice>
-{{/if}}
-{{#if (or this.requirementsOverride (not this.noPermissionToSignUp))}}
-  {{#if this.requirementsOverride}}
-    <ChNotice @type="danger" @icon="exclamation" @title="Schedule requirements overridden">
-      <b>All actions are logged and subject to review.</b>
+<div class="max-width-1000">
+  {{#unless this.isCurrentYear}}
+    <ChNotice @type="warning">
+      Warning: You are viewing a past schedule ({{@year}}).
     </ChNotice>
-  {{/if}}
-  {{#if (and @person.isRanger this.permission.recommend_burn_weekend_shift)}}
-    <div class="border p-2 border-danger mb-2 d-print-none">
-      <h4 class="text-danger">We need help! The Burn Weekend shifts are understaffed.</h4>
-      The Burn Weekend &mdash; Friday night through Sunday night &mdash; is our busiest time.
-      We strongly urge people to sign up for a weekend shift, especially a Burn Perimeter shift, to help fill in the
-      gaps.
-      This message will stick around until you sign up for one.
-    </div>
-  {{/if}}
-  {{#if this.permission.missing_behavioral_agreement}}
-    <div class="border rounded p-2 my-2">
-      <b>Starting in 2019, Burning Man requests you sign the optional Burning Man's Behavioral Standards Agreement.</b>
-      <div class="mt-2">
-        {{#if this.isMe}}
-          <button type="button" class="btn btn-primary" {{on "click" this.showBehaviorAgreementAction}}>
-            Click here
-          </button>
-          to read about the Behavioral Standards, and be given a chance to agree.
-        {{else}}
-          {{@person.callsign}} has not signed the agreement.
-        {{/if}}
-      </div>
-    </div>
-  {{/if}}
+  {{/unless}}
 
-  <p>
-    The <i class="fas fa-info-circle info-icon"></i> icon on a shift description means additional information is
-    available. Click on the icon and/or text.
-  </p>
+  {{#if this.showScheduleBlocker}}
+    <ScheduleBlocked @requirements={{@permission.requirements}} @person={{@person}}
+                     @overrideAction={{this.overrideAction}} @canOverride={{this.canOverride}}
+                     @isMe={{this.isMe}} @isAdmin={{this.isAdmin}}
+                     @hasTrainingBlocker={{this.hasTrainingBlocker}}
+    />
+  {{else}}
+    {{#if this.requirementsOverride}}
+      <ChNotice @type="danger" @icon="exclamation" @title="Schedule requirements overridden">
+        <b>All actions are logged and subject to review.</b>
+      </ChNotice>
+    {{/if}}
 
-  <ScheduleTable @slots={{@signedUpSlots}} @person={{@person}} @year={{@year}}
-                 @creditsEarned={{@creditsEarned}}
-                 @scheduleSummary={{@scheduleSummary}} @leaveSlot={{this.leaveSlot}}
-                 @showPeople={{this.showPeople}} />
-  <div class="d-print-none">
-    <h3 class="mt-2">{{if this.isCurrentYear (concat "Available " @year " Shifts")
-                          (concat "Past " @year " Shifts")}}</h3>
-    {{#if this.availableSlots}}
-      {{#if this.inactiveSlots}}
-        <ChNotice @type="info" @title="Schedule listing has inactive shifts" @icon="hand-point-right">
-          <p>
-          Because you have the Edit Slots, Grant Positions, Trainer, VC, and/or Admin role, the shift listing
-          will contain inactive shifts.
-          </p>
-          Sign ups are disabled until the shift has been activated through the Edit Slots page.
-        </ChNotice>
-      {{/if}}
+    <p>
+      The <i class="fas fa-info-circle info-icon"></i> icon on a shift description means additional information is
+      available. Click on the icon and/or text.
+    </p>
 
-      <div class="row mb-1">
-        <div class="col-sm-5 col-md-auto mb-2">
-          <ChForm::Select @name="filterDay"
-                          @value={{this.filterDay}}
-                          @options={{this.dayOptions}}
-                          @onChange={{action (mut this.filterDay)}}
-                          @controlClass="form-control"/>
-        </div>
+    <ScheduleTable @slots={{@signedUpSlots}} @person={{@person}} @isMe={{this.isMe}} @isAdmin={{this.isAdmin}} @year={{@year}}
+                   @creditsEarned={{@creditsEarned}}
+                   @scheduleSummary={{@scheduleSummary}} @leaveSlot={{this.leaveSlot}}
+                   @showPeople={{this.showPeople}} />
+    <div class="d-print-none">
+      <h3 class="mt-2">{{if this.isCurrentYear "Available" "Past"}} {{@year}} Shifts</h3>
+      {{#if this.availableSlots}}
         {{#if this.inactiveSlots}}
+          <ChNotice @type="info" @title="Schedule listing has inactive shifts" @icon="hand-point-right">
+            <p>
+              Because you have the Edit Slots, Grant Positions, Trainer, VC, and/or Admin role, the shift listing
+              will contain inactive shifts.
+            </p>
+            Sign ups are disabled until the shift has been activated through the Edit Slots page.
+          </ChNotice>
+        {{/if}}
+
+        <div class="row mb-1">
           <div class="col-sm-5 col-md-auto mb-2">
-            <ChForm::Select @name="filterActive"
-                            @value={{this.filterActive}}
-                            @options={{this.activeOptions}}
-                            @onChange={{action (mut this.filterActive)}}
+            <ChForm::Select @name="filterDay"
+                            @value={{this.filterDay}}
+                            @options={{this.dayOptions}}
+                            @onChange={{action (mut this.filterDay)}}
                             @controlClass="form-control"/>
           </div>
-        {{/if}}
-      </div>
+          {{#if this.inactiveSlots}}
+            <div class="col-sm-5 col-md-auto mb-2">
+              <ChForm::Select @name="filterActive"
+                              @value={{this.filterActive}}
+                              @options={{this.activeOptions}}
+                              @onChange={{action (mut this.filterActive)}}
+                              @controlClass="form-control"/>
+            </div>
+          {{/if}}
+        </div>
 
-      <p>Showing {{this.viewSlots.length}} of {{this.availableSlots.length}}</p>
-      {{#each this.positions as |position|}}
-        <SchedulePositionList @position={{position}}
-                              @showPeople={{this.showPeople}}
-                              @joinSlot={{this.joinSlot}}
-                              @leaveSlot={{this.leaveSlot}}
-                              @isAdmin={{this.isAdmin}}
-                              @isCurrentYear={{this.isCurrentYear}}
-        />
+        <p>Showing {{this.viewSlots.length}} of {{this.availableSlots.length}}</p>
+        {{#each this.positions as |position|}}
+          <SchedulePositionList @position={{position}}
+                                @showPeople={{this.showPeople}}
+                                @joinSlot={{this.joinSlot}}
+                                @leaveSlot={{this.leaveSlot}}
+                                @isAdmin={{this.isAdmin}}
+                                @isCurrentYear={{this.isCurrentYear}}
+          />
+        {{else}}
+          <div class="text-danger">There are no shifts which match.</div>
+        {{/each}}
+        <div class="mt-2"><b>Note:</b>
+          <ul>
+            <li>A shift may not be added to or removed from your schedule if the shift has already started.</li>
+          </ul>
+        </div>
       {{else}}
-        <div class="text-danger">There are no shifts which match.</div>
-      {{/each}}
-      <div class="mt-2"><b>Note:</b>
-        <ul>
-          <li>A shift may not be added to or removed from your schedule if the shift has already started.</li>
-        </ul>
-      </div>
-    {{else}}
-      <p><b class="text-danger">There are no shifts available.</b></p>
-    {{/if}}
-  </div>
-
-{{/if}}
-
-{{#if this.showBehaviorAgreement}}
-  <BehavioralAgreementModal @closeAgreement={{this.closeAgreement}} @signAgreement={{this.signAgreement}} />
-{{/if}}
+        <p><b class="text-danger">There are no shifts available.</b></p>
+      {{/if}}
+    </div>
+  {{/if}}
+</div>

--- a/app/components/schedule-position-list.hbs
+++ b/app/components/schedule-position-list.hbs
@@ -2,8 +2,9 @@
   <Accordion.title>{{@position.title}} ({{@position.slots.length}})</Accordion.title>
   <Accordion.body>
     <div class="schedule-row schedule-header">
-      <div class="schedule-time">From</div>
-      <div class="schedule-time">To</div>
+      <div class="schedule-icon">&nbsp;</div>
+      <div class="schedule-time">Time</div>
+      <div class="schedule-duration">Duration</div>
       <div class="schedule-credits">Credits</div>
       <div class="schedule-description">Description</div>
       <div class="schedule-signups">Sign Ups</div>
@@ -11,15 +12,25 @@
     </div>
     {{#each @position.slots as |slot|}}
       <div class="schedule-row {{if slot.person_assigned "table-success"}}" id="slot-{{slot.id}}">
-        <div class="schedule-time">
+        <div class="schedule-icon">
           {{#if slot.person_assigned}}
             {{fa-icon "check" title="You are signed up for this shift."}}
           {{else if (not slot.slot_active)}}
-            {{fa-icon "exclamation-triangle" title="Shift is inactive and may not be signed up for"}}
+            {{fa-icon "times" title="Shift is inactive and may not be signed up for" color="danger"}}
+          {{else}}
+            &nbsp;
           {{/if}}
-          {{shift-format slot.slot_begins}}
         </div>
-        <div class="schedule-time">{{shift-format slot.slot_ends}}</div>
+        <div class="schedule-time">
+           {{shift-format slot.slot_begins slot.slot_ends}}
+        </div>
+        <div class="schedule-duration">
+          <span class="schedule-sm-label">Duration:</span>
+          {{#unless slot.position_count_hours}}
+            {{fa-icon "minus-square" color="danger" type="far"}}
+          {{/unless~}}
+          {{hour-minute-format slot.slot_duration}}
+        </div>
         <div class="schedule-credits">
           <span class="schedule-sm-label">Credits:</span> {{credits-format slot.credits}}
         </div>
@@ -40,7 +51,7 @@
             Sign Ups
           </button>
           {{#if slot.person_assigned}}
-            {{#if (or @isAdmin (not slot.has_started))}}
+            {{#if (or @isAdmin (not slot.has_started))}} {{!template-lint-disable "no-negated-condition"}}
             {{! Only allow admins to remove a sign up that has started}}
               <button type="button" {{on "click" (fn @leaveSlot slot)}} class="btn btn-light-red btn-sm"
                       title="Remove from schedule" disabled={{slot.is_submitting}}>

--- a/app/components/schedule-requirements.hbs
+++ b/app/components/schedule-requirements.hbs
@@ -1,0 +1,10 @@
+<p>
+  Before <YouOrCallsign @person={{@person}} @youLabel="you are" @callsignVerb="is" /> allowed to sign up
+  {{if @isTraining "a training shift" "any shifts"}}, the following issue(s)
+  must be fixed first:
+</p>
+<ul>
+  {{#each this.requirementsList as |req|}}
+    <li><b>{{req}}</b></li>
+  {{/each}}
+</ul>

--- a/app/components/schedule-requirements.js
+++ b/app/components/schedule-requirements.js
@@ -1,0 +1,9 @@
+import Component from '@glimmer/component';
+import { REQUIREMENT_LABELS } from "clubhouse/constants/signup-requirements";
+
+export default class ScheduleRequirementsComponent extends Component {
+  constructor() {
+    super(...arguments);
+    this.requirementsList = this.args.requirements.map((req) => REQUIREMENT_LABELS[req]);
+  }
+}

--- a/app/components/schedule-table.hbs
+++ b/app/components/schedule-table.hbs
@@ -1,55 +1,63 @@
 <div class="mb-2 d-print-none">
-  <div class="form-check form-check-inline">
-    <RadioButton @value="upcoming" @groupValue={{this.viewSchedule}} @radioId="view-upcoming"
-                 @radioClass="form-check-input"/>
-    <label for="view-upcoming" class="form-check-label">Upcoming Shifts ({{this.upcomingCount}})</label>
-  </div>
-  <div class="form-check form-check-inline">
-    <RadioButton @value="all" @groupValue={{this.viewSchedule}} @radioId="view-all" @classNames="form-check-label"
-                 @radioClass="form-check-input"/>
-    <label for="view-all" class="form-check-label">All Shifts ({{@slots.length}})</label>
+  <div class="form-row">
+    <div class="form-check form-check-inline col-auto">
+      <RadioButton @value="upcoming" @groupValue={{this.viewSchedule}} @radioId="view-upcoming"
+                   @radioClass="form-check-input"/>
+      <label for="view-upcoming" class="form-check-label">Upcoming Shifts ({{this.upcomingCount}})</label>
+    </div>
+    <div class="form-check form-check-inline col-auto">
+      <RadioButton @value="all" @groupValue={{this.viewSchedule}} @radioId="view-all" @classNames="form-check-label"
+                   @radioClass="form-check-input"/>
+      <label for="view-all" class="form-check-label">All Shifts ({{@slots.length}})</label>
+    </div>
   </div>
 </div>
 
 {{#if this.hasOverlapping}}
-  <p>
-  <div class="text-danger">
-    You are signed up for overlapping shifts, marked with a
-    {{fa-icon "exclamation-triangle"}}.
-  </div>
-  You only get credit for the time you work, and won't receive double credit for the overlapping time.
-  </p>
+  <ChNotice @icon="flag" @title="Overlapping shifts">
+    <p>
+      <YouOrCallsign @person={{@person}} @youLabel="You have" @callsignVerb="has"/>
+      overlapping shifts, marked with a
+      {{fa-icon "flag" color="danger"}}.
+      You only get credit for the time you work.
+    </p>
+  </ChNotice>
 {{/if}}
 
-[hh:mm] = time in brackets indicates the time does not count towards appreciations.
+<div class="m-2">
+  {{fa-icon "minus-square" color="danger" type="far"}} = the shift hours do not count towards appreciations.
+</div>
 <div class="schedule-table schedule-itinerary">
   <div class="schedule-row schedule-header">
-    <div class="schedule-time">From</div>
-    <div class="schedule-time">To</div>
-    <div class="schedule-duration">Time</div>
+    <div class="schedule-icon">&nbsp;</div>
+    <div class="schedule-time">Time</div>
+    <div class="schedule-duration">Duration</div>
     <div class="schedule-credits">Credits</div>
-    <div class="schedule-long-description">Position / Description</div>
+    <div class="schedule-description">Position / Description</div>
     <div class="schedule-actions d-print-none">Actions</div>
   </div>
 
   {{#each this.viewSlots as |slot| }}
     <div class="schedule-row {{if slot.is_overlapping "schedule-overlapping"}}">
-      <div class="schedule-time">
+      <div class="schedule-icon">
         {{#if slot.is_overlapping}}
-          <span class="text-danger">{{fa-icon "exclamation-triangle"}}</span>
-        {{/if}}
-        {{shift-format slot.slot_begins}}
-      </div>
-      <div class="schedule-time">{{shift-format slot.slot_ends}}</div>
-      <div class="schedule-duration"><span class="schedule-sm-label">Duration:</span>
-        {{#if slot.position_count_hours}}
-          {{hour-minute-format slot.slot_duration}}
+          {{fa-icon "flag" color="danger"}}
         {{else}}
-          [{{hour-minute-format slot.slot_duration}}]
+          &nbsp;
         {{/if}}
+      </div>
+      <div class="schedule-time">
+        {{shift-format slot.slot_begins slot.slot_ends}}
+      </div>
+      <div class="schedule-duration">
+        <span class="schedule-sm-label">Duration:</span>
+        {{#unless slot.position_count_hours}}
+          {{fa-icon "minus-square" color="danger" type="far"}}
+        {{/unless~}}
+        {{hour-minute-format slot.slot_duration}}
       </div>
       <div class="schedule-credits"><span class="schedule-sm-label">Credits:</span>{{credits-format slot.credits}}</div>
-      <div class="schedule-long-description">
+      <div class="schedule-description">
         {{slot.position_title}}<br>
         <SlotInfoLink @description={{slot.slot_description}} @info={{slot.slot_url}} />
       </div>
@@ -63,7 +71,7 @@
           {{/if}}
           Sign Ups
         </button>
-        {{#if (or (not slot.has_started) (has-role "admin"))}}
+        {{#if (or (not slot.has_started) @isAdmin)}}
         {{! Note: magic here -  by not using onclick, no event argument will be passed to leaveSlot. That tells the method to allow the page to scroll.}}
           <button type="button" {{on "click" (fn @leaveSlot slot)}} class="btn btn-light-red btn-sm"
                   title="Remove shift from schedule" disabled={{slot.is_submitting}}>
@@ -74,17 +82,23 @@
             {{/if}}
             Remove
           </button>
+          {{#if slot.slot_url}}
+
+          {{/if}}
         {{/if}}
       </div>
     </div>
   {{else}}
     <div class="schedule-row">
+      <div class="schedule-icon">
+        {{fa-icon "exclamation"}}
+      </div>
       <div>
-        {{#if slots}}
-          <b class="text-danger">No upcoming shifts were found.</b>
-          <a href {{action (mut this.viewSchedule) "all"}}>View All Shifts</a>
+        {{#if @slots}}
+          <b>No upcoming shifts were found.</b>
+          <a href {{action (mut this.viewSchedule) "all"}}>View Previous Shifts</a>
         {{else}}
-          <b>No scheduled {{@year}} shifts were found.</b>
+          <b class="text-danger">No {{@year}} shifts were found.</b>
         {{/if}}
       </div>
     </div>

--- a/app/components/wysiwyg-editor.js
+++ b/app/components/wysiwyg-editor.js
@@ -39,9 +39,9 @@ export default class WysiwygEditorComponent extends Component {
           this.editor = editor;
           editor.on('Change', () => this.args.onChange(editor.getContent()));
         },
-        plugins: 'print preview paste casechange  searchreplace autolink  visualblocks visualchars fullscreen link media mediaembed table charmap hr pagebreak nonbreaking anchor toc insertdatetime advlist lists checklist wordcount textpattern help  pageembed charmap  emoticons advtable',
+        plugins: 'print preview paste  searchreplace autolink  visualblocks visualchars fullscreen link media table charmap hr pagebreak nonbreaking anchor toc insertdatetime advlist lists wordcount textpattern help charmap emoticons',
         menubar: 'edit view insert format tools table tc help',
-        toolbar: 'undo redo | bold italic underline strikethrough | fontselect fontsizeselect formatselect | alignleft aligncenter alignright alignjustify | outdent indent |  numlist bullist checklist | forecolor backcolor casechange permanentpen formatpainter removeformat | pagebreak | charmap emoticons | fullscreen  preview save print | insertfile image media pageembed template link anchor codesample | a11ycheck ltr rtl | showcomments addcomment',
+        toolbar: 'undo redo | bold italic underline strikethrough | fontselect fontsizeselect formatselect | alignleft aligncenter alignright alignjustify | outdent indent |  numlist bullist checklist | forecolor backcolor permanentpen formatpainter removeformat | pagebreak | charmap emoticons | fullscreen  preview save print | insertfile image media template link anchor codesample | a11ycheck ltr rtl | showcomments addcomment',
         image_advtab: true,
         height: 600,
       //  image_caption: true,

--- a/app/components/you-or-callsign.hbs
+++ b/app/components/you-or-callsign.hbs
@@ -1,0 +1,5 @@
+{{#if this.isMe~}}
+  {{@youLabel}}
+{{~else~}}
+  {{@person.callsign}} {{@callsignVerb}}
+{{~/if~}}

--- a/app/components/you-or-callsign.js
+++ b/app/components/you-or-callsign.js
@@ -1,0 +1,11 @@
+import Component from '@glimmer/component';
+import { inject as service } from '@ember/service'
+
+export default class YouOrCallsignComponent extends Component {
+  @service session;
+
+  get isMe() {
+    return this.args.person.id == this.session.userId;
+  }
+}
+

--- a/app/constants/signup-requirements.js
+++ b/app/constants/signup-requirements.js
@@ -1,0 +1,21 @@
+// Personal Information has not been reviewed
+export const PI_UNREVIEWED = 'pi-unreviewed';
+// BPGUID has not been linked.
+export const BPGUID_MISSING = 'bpguid-missing';
+// Online Training has not been completed
+export const OT_MISSING = 'ot-missing';
+// Callsign is unapproved
+export const CALLSIGN_UNAPPROVED = 'callsign-unapproved';
+// Photo is missing or been rejected
+export const PHOTO_UNAPPROVED = 'photo-unapproved';
+// Person is a past prospective.
+export const PAST_PROSPECTIVE = 'past-prospective';
+
+export const REQUIREMENT_LABELS = {
+  [PI_UNREVIEWED]: 'The Personal Information needs to be reviewed first',
+  [BPGUID_MISSING]: 'The Burner Profile and Clubhouse accounts are not linked',
+  [OT_MISSING]: 'Online Training has not been completed',
+  [CALLSIGN_UNAPPROVED]: 'Callsign has not been approved',
+  [PHOTO_UNAPPROVED]: 'The BMID photo is missing or has been rejected',
+  [PAST_PROSPECTIVE]: 'The person is a Past Prospective',
+};

--- a/app/controllers/hq/site-checkin.js
+++ b/app/controllers/hq/site-checkin.js
@@ -39,14 +39,6 @@ export default class HqSiteCheckinController extends Controller {
   }
 
   @action
-  markAssetAuthorized() {
-    this.personEvent.asset_authorized = true;
-    this.personEvent.save()
-      .then(() => this.toast.success('Person successfully save.'))
-      .catch((response) => this.house.handleErrorResponse(response));
-  }
-
-  @action
   markOnSite() {
     this.person.on_site = true;
     this._savePerson(this.person,  'Person has been successfully marked as ON SITE.', () => {

--- a/app/controllers/me/radio-checkout.js
+++ b/app/controllers/me/radio-checkout.js
@@ -1,0 +1,30 @@
+import Controller from '@ember/controller';
+import {action} from '@ember/object';
+import {tracked} from '@glimmer/tracking';
+
+export default class MeRadioCheckoutController extends Controller {
+  @tracked isSubmitting;
+  @tracked hasAgreed;
+  @tracked documentHasLoaded;
+
+  @action
+  agreeAction() {
+    this.personEvent.asset_authorized = true;
+
+    this.isSubmitting = true;
+    this.personEvent.save().then(() => {
+      this.hasAgreed = true;
+      this.toast.success('Agreement has been successfully recorded.');
+    }).catch((response) => this.house.handleErrorResponse(response))
+      .finally(() => this.isSubmitting = false);
+  }
+
+  @action
+  loadedAction() {
+    this.documentHasLoaded = true;
+  }
+
+  get currentYear() {
+    return this.house.currentYear();
+  }
+}

--- a/app/helpers/shift-format.js
+++ b/app/helpers/shift-format.js
@@ -3,12 +3,11 @@ import moment from 'moment';
 
 const MONTH_DAY_TIME = 'ddd MMM DD [@] HH:mm';
 const MONTH_DAY_TIME_YEAR = 'ddd MMM DD [@] HH:mm YY';
-const DAY_TIME = 'ddd [@] HH:mm';
+//const DAY_TIME = 'ddd [@] HH:mm';
 const HOUR_MINS = 'HH:mm';
 
-export function shiftFormat([shiftDate], hash) {
+export function shiftFormat([shiftDate, toDate], hash) {
   let datetime;
-  const fromDate = hash.fromDate;
 
   if (!shiftDate) {
     return '';
@@ -19,20 +18,18 @@ export function shiftFormat([shiftDate], hash) {
     return shiftDate;
   }
 
-  if (!fromDate) {
+  if (!toDate) {
     return datetime.format(hash.year ? MONTH_DAY_TIME_YEAR : MONTH_DAY_TIME);
   }
 
-  const fromDt = moment(fromDate);
-  if (!fromDt.isValid()) {
+  const toDt = moment(toDate);
+  if (!toDt.isValid()) {
     return datetime.format(MONTH_DAY_TIME);
 
   }
-  if (datetime.day() !== fromDt.day()) {
-    return datetime.format(DAY_TIME);
-  }
 
-  return datetime.format(HOUR_MINS);
+
+  return  datetime.format(hash.year ? MONTH_DAY_TIME_YEAR : MONTH_DAY_TIME) + ' to ' + toDt.format(hash.year ? MONTH_DAY_TIME_YEAR : HOUR_MINS);
 }
 
 export default helper(shiftFormat);

--- a/app/models/timesheet.js
+++ b/app/models/timesheet.js
@@ -24,34 +24,36 @@ export default class TimesheetModel extends Model {
   @attr('', { readOnly: true}) position;
   @attr('', { readOnly: true}) slot;
 
+  isIgnoring = false; // Used the HQ window interface
+
   @computed('verified', 'notes', 'review_status')
   get isPendingReview() {
-    return (!this.verified && !isEmpty(this.notes) && this.review_status == 'pending');
+    return (!this.verified && !isEmpty(this.notes) && this.review_status === 'pending');
   }
 
   @computed('review_status')
   get isApproved() {
-    return this.review_status == 'approved';
+    return this.review_status === 'approved';
   }
 
   @computed('review_status')
   get isRejected() {
-    return this.review_status == 'rejected';
+    return this.review_status === 'rejected';
   }
 
   @computed('review_status')
   get isPending() {
-    return this.review_status == 'pending';
+    return this.review_status === 'pending';
   }
 
-  @computed('verified', 'notes', 'review_status', 'off_duty')
+  @computed('verified', 'notes', 'review_status', 'off_duty', 'isIgnoring')
   get isUnverified() {
-    return !this.verified && isEmpty(this.notes) && this.review_status == 'pending' && this.off_duty;
+    return (this.off_duty && !this.isIgnoring && !this.verified && isEmpty(this.notes) && this.review_status === 'pending');
   }
 
   @computed('review_status', 'reviewer_notes', 'status')
   get haveReviewerResponse() {
-    return this.review_status != 'pending' && !isEmpty(this.reviewer_notes);
+    return this.review_status !== 'pending' && !isEmpty(this.reviewer_notes);
   }
 
   @computed('off_duty')

--- a/app/router.js
+++ b/app/router.js
@@ -39,6 +39,7 @@ Router.map(function () {
     });
     this.route('vehicles');
     this.route('announcements');
+    this.route('radio-checkout');
   });
 
   this.route('search', function () {

--- a/app/routes/hq/shift.js
+++ b/app/routes/hq/shift.js
@@ -16,8 +16,8 @@ export default class HqShiftRoute extends Route {
     super.setupController(...arguments);
     controller.setProperties(model);
     controller.setProperties(this.modelFor('hq'));
-    controller.set('ignoreTimesheetVerification', false);
     controller.set('showCorrectionForm', false);
     controller.set('showSiteLeaveDialog', false);
+    controller.set('unverifiedTimesheets', controller.timesheets.filter((ts) => ts.isUnverified))
   }
 }

--- a/app/routes/me/radio-checkout.js
+++ b/app/routes/me/radio-checkout.js
@@ -1,0 +1,15 @@
+import Route from '@ember/routing/route';
+import MeRouteMixin from 'clubhouse/mixins/route/me';
+
+export default class MeRadioCheckoutRoute extends Route.extend(MeRouteMixin) {
+  model() {
+    return this.store.findRecord('person-event', `${this.session.userId}-${this.house.currentYear()}`, { reload: true });
+  }
+
+  setupController(controller, model) {
+    controller.set('person', this.modelFor('me'));
+    controller.set('personEvent', model);
+    controller.set('hasAgreed', model.asset_authorized);
+    controller.set('documentHasLoaded', false);
+  }
+}

--- a/app/routes/me/schedule.js
+++ b/app/routes/me/schedule.js
@@ -39,7 +39,7 @@ export default class MeScheduleRoute extends Route.extend(MeRouteMixin) {
 
     const person = this.session.user;
 
-    if (!model.permission.signup_allowed && (person.isAuditor || person.isProspective || person.isAlpha)) {
+    if ((person.isAuditor || person.isProspective || person.isAlpha) && !model.permission.all_signups_allowed) {
       this.toast.error('You need to complete one or more items in the checklist before being allowed to sign up.');
       this.transitionTo('me.overview');
     }

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -617,6 +617,10 @@ caption {
   max-width: 900px;
 }
 
+.max-width-1000 {
+  max-width: 1000px;
+}
+
 .callsign-list {
   display: flex;
   flex-wrap: wrap;

--- a/app/styles/hq.scss
+++ b/app/styles/hq.scss
@@ -1,3 +1,8 @@
 .hours-credits-header {
   font-size: 1.2rem;
 }
+
+.btn-timesheet {
+  display: inline-block;
+  width: 100px;
+}

--- a/app/styles/notice.scss
+++ b/app/styles/notice.scss
@@ -33,7 +33,7 @@
 
 .notice-danger {
   border-color: #721c24;
-  background-color: #f8d7da;
+  background-color: #fff1f2;
 
   .notice-header {
     color: #9c0010;

--- a/app/styles/schedule.scss
+++ b/app/styles/schedule.scss
@@ -19,8 +19,7 @@
 .schedule-row {
   display: flex;
   flex-wrap: wrap;
-
-  font-size: 0.9em;
+//  font-size: 0.9em;
   border-top: 1px solid #ddd;
   padding: 0 5px 10px 5px;
   width: 100%;
@@ -28,6 +27,7 @@
     display: inline-block;
     margin-top: 5px;
   }
+
 }
 
 .schedule-row:hover {
@@ -48,43 +48,38 @@
   .schedule-row > div {
     padding-right: 5px;
   }
+  .schedule-icon {
+    width: 20px;
+    text-align: center;
+  }
   .schedule-time {
-    width: 15%;
+    width: 22%;
   }
 
   .schedule-duration {
-    width: 5%;
+    width: 8%;
     text-align: right;
   }
 
   .schedule-credits {
-    width: 6%;
+    width: 8%;
     text-align: right;
   }
 
   .schedule-description {
-    width: 24%;
-  }
-
-  .schedule-signups {
-    width: 15%;
-    text-align: center;
-  }
-
-
-  @media not print {
-    .schedule-long-description {
-      width: 30%;
-    }
-    .schedule-actions {
-      width: 20%;
-    }
+    width: 25%;
+    margin-left: 10px;
   }
 
   @media print {
-    .schedule-long-description {
+    .schedule-description {
       width: 50%;
     }
+  }
+
+  .schedule-signups {
+    width: 10%;
+    text-align: center;
   }
 
   .schedule-total {
@@ -93,10 +88,14 @@
   .schedule-sm-label {
     display: none;
   }
+
+  .schedule-actions {
+    margin-left: 10px;
+  }
 }
 
 @media not print {
-  @media (max-width: map-get($grid-breakpoints, "md")) {
+  @media (max-width: map-get($grid-breakpoints, "lg")) {
     .schedule-table {
       font-size: 1rem;
     }
@@ -105,35 +104,45 @@
       display: none !important;
     }
 
+    .schedule-icon {
+      order: 2;
+     }
+
     .schedule-time {
-      width: 49%;
+      order: 1;
+      width: 90%;
     }
 
     .schedule-duration {
-      width: 49%;
+      order: 3;
+      width: 50%;
     }
 
     .schedule-credits {
-      width: 100%;
+      order: 4;
+      width: 50%;
+      text-align: right;
     }
 
     .schedule-description {
-      width: 100%;
-    }
-
-    .schedule-long-description {
+      order: 5;
       width: 100%;
     }
 
     .schedule-signups {
+      order: 6;
       width: 100%;
+      margin-top: 15px !important;
+      margin-bottom: 10px !important;
     }
 
     .schedule-total {
+      order: 7;
       width: 100%;
     }
 
     .schedule-actions {
+      order: 8;
       width: 100%;
     }
 

--- a/app/styles/timesheet.scss
+++ b/app/styles/timesheet.scss
@@ -7,7 +7,7 @@
 .timesheet-table {
   border: (2 * $table-border-width) solid $table-border-color;
   margin-bottom: 10px;
-  width: auto;
+  max-width: 850px;
 }
 
 .timesheet-header {
@@ -47,7 +47,7 @@
 }
 
 
-@media print, (min-width: 801px) {
+@media print,  (min-width: map-get($grid-breakpoints, "lg")) {
   .timesheet-time {
     width: 22%;
   }
@@ -71,7 +71,7 @@
   }
 }
 
-@media only screen and (max-width: 800px) {
+@media only screen and (max-width: map-get($grid-breakpoints, "lg")) {
   .timesheet-row button {
 //    font-size: 0.9em;
     display: inline-block;

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -70,6 +70,10 @@
                       {{#if (and (config "MotorpoolPolicyEnable") (or session.user.isRanger session.user.isAlpha))}}
                         <LinkTo @route="me.motorpool-policy" class="dropdown-item">Motorpool Policy</LinkTo>
                       {{/if}}
+                      {{#if (and (config "RadioCheckoutAgreementEnabled") (or session.user.isRanger session.user.isAlpha session.user.isNonRanger))}}
+                        <LinkTo @route="me.radio-checkout" class="dropdown-item">Radio Agreement</LinkTo>
+                      {{/if}}
+
                       {{#if this.session.user.may_request_stickers}}
                         <LinkTo @route="me.vehicles" class="dropdown-item">Vehicle Requests</LinkTo>
                       {{/if}}

--- a/app/templates/hq/shift.hbs
+++ b/app/templates/hq/shift.hbs
@@ -45,76 +45,67 @@
   <HelpPopover @slug="hq-timesheet-verification"/>
 </h3>
 
-{{#if this.unverifiedTimesheetEntry}}
-  {{#if this.ignoreTimesheetVerification}}
-    <button type="button" class="btn btn-secondary" {{action this.toggleIgnoreVerification}}>Show Verfication</button>
-  {{else}}
-    <p>Ask {{this.person.callsign}} if the following timesheet entry is correct:</p>
-    <table class="table table-width-auto">
-      <thead>
+{{#if this.unverifiedTimesheets}}
+  <p>Ask {{this.person.callsign}} if the following timesheet entries are correct:</p>
+  <table class="table table-width-auto table-striped table-hover table-sm">
+    <thead>
+    <tr>
+      <th>Position</th>
+      <th>From</th>
+      <th>To</th>
+      <th class="text-right">Duration</th>
+      <th class="text-right">Credits</th>
+      <th>Actions</th>
+    </tr>
+    </thead>
+    <tbody>
+    {{#each this.unverifiedTimesheets as |entry|}}
       <tr>
-        <th>Position</th>
-        <th>From</th>
-        <th>To</th>
-        <th class="text-right">Duration</th>
-        <th class="text-right">Credits</th>
-      </tr>
-      </thead>
-      <tbody>
-      <tr>
-        <td>
-          <AnimatedContainer>
-            {{#animated-value unverifiedTimesheetEntry.position.title use=this.fade
-                              duration=this.fadeDuration as |value|}}
-              <span>{{value}}</span>
-            {{/animated-value}}
-          </AnimatedContainer>
+        <td class="align-middle">
+          {{entry.position.title}}
         </td>
-        <td>
-          <AnimatedContainer>
-            {{#animated-value unverifiedTimesheetEntry.on_duty use=this.fade duration=this.fadeDuration as |value|}}
-              <span>{{shift-format value}}</span>
-            {{/animated-value}}
-          </AnimatedContainer>
+        <td class="align-middle">
+          {{shift-format entry.on_duty}}
         </td>
-        <td>
-          <AnimatedContainer>
-            {{#animated-value unverifiedTimesheetEntry.off_duty use=this.fade duration=this.fadeDuration as |value|}}
-              <span>{{shift-format value}}</span>
-            {{/animated-value}}
-          </AnimatedContainer>
+        <td class="align-middle">
+          {{shift-format entry.off_duty}}
         </td>
-        <td class="text-right">
-          <AnimatedContainer>
-            {{#animated-value unverifiedTimesheetEntry.duration use=this.fade duration=this.fadeDuration as |value|}}
-              <span>{{hour-minute-format value}}</span>
-            {{/animated-value}}
-          </AnimatedContainer>
+        <td class="text-right align-middle">
+          {{hour-minute-format entry.duration}}
         </td>
-        <td class="text-right">
-          <AnimatedContainer>
-            {{#animated-value unverifiedTimesheetEntry.credits use=this.fade duration=this.fadeDuration as |value|}}
-              <span>{{credits-format value}}</span>
-            {{/animated-value}}
-          </AnimatedContainer>
+        <td class="text-right align-middle">
+          {{credits-format entry.credits}}
+        </td>
+        <td class="align-middle">
+          <button type="button" class="btn btn-success btn-timesheet " {{action this.markEntryCorrect entry}}
+                  disabled={{entry.isSaving}}>
+            YES
+            {{#if entry.verified}}
+              {{fa-icon "check"}}
+            {{/if}}
+          </button>
+          <button type="button" class="btn btn-danger btn-timesheet" {{action this.markEntryIncorrect entry}}
+                  disabled={{entry.isSaving}}>
+            NO
+            {{#if entry.isPendingReview}}
+              {{fa-icon "check"}}
+            {{/if}}
+          </button>
+          <button type="button" class="btn btn-gray btn-timesheet" {{action this.ignoreEntry entry}}
+                  disabled={{or entry.isSaving entry.verified entry.isPendingReview}}>
+            IGNORE
+            {{#if entry.isIgnoring}}
+              {{fa-icon "check"}}
+            {{/if}}
+          </button>
+          {{#if entry.isSaving}}
+            <LoadingIndicator/>
+          {{/if}}
         </td>
       </tr>
-      </tbody>
-    </table>
-    <div class="mt-2">
-      <button type="button" class="btn btn-success py-2 px-4 mr-3" {{action this.markEntryCorrect}}
-              disabled={{this.isSubmitting}}>YES
-      </button>
-      <button type="button" class="btn btn-danger  py-2 px-4 p-2 mr-3" {{action this.markEntryIncorrect}}
-              disabled={{this.isSubmitting}}>NO
-      </button>
-      <button type="button" class="btn btn-gray  py-2 px-4" {{action this.toggleIgnoreVerification}}
-              disabled={{this.isSubmitting}}>IGNORE
-      </button>
-      {{#if this.isSubmitting}}
-        <LoadingIndicator/>{{/if}}
-    </div>
-  {{/if}}
+    {{/each}}
+    </tbody>
+  </table>
 {{else}}
   No timesheet entries need review at this time.
 {{/if}}
@@ -125,7 +116,7 @@
 </h3>
 <ShiftCheckInOut @positions={{this.positions}} @timesheets={{this.timesheets}} @person={{this.person}}
                  @imminentSlots={{this.imminentSlots}}
-                 @hasUnverifiedTimesheet={{and this.unverifiedTimesheets (not this.ignoreTimesheetVerification)}}
+                 @hasUnverifiedTimesheet={{this.hasUnverifiedTimesheets}}
                  @endShiftNotify={{action this.refreshTimesheetSummary}} @eventInfo={{this.eventInfo}} />
 
 
@@ -202,12 +193,10 @@
   <AssetCheckoutForm @person={{this.person}} @assets={{this.assets}} @attachments={{this.attachments}}
                      @eventInfo={{this.eventInfo}} />
 {{else}}
-  <p class="text-danger"><b>{{this.person.callsign}} is not asset authorized and may not check out equipment at this
-    time.
-    Have the person sign the Radio Checkout form, then to go Site Check In and mark the person having signed the
-    document.</b></p>
+  <h3 class="text-danger">Radio Checkout Agreement NOT SIGNED - DO NOT ISSUE RADIOS</h3>
   <p>
-    <LinkTo @route="hq.site-checkin" @model={{this.person.id}} class="btn btn-primary">Site Check In</LinkTo>
+    Direct {{this.person.callsign}} to the kiosk shack so they can login into the Clubhouse, review and sign
+    the agreement.
   </p>
 {{/if}}
 
@@ -327,7 +316,7 @@
               <td class="text-right">{{credits-format timesheetSummary.total_credits}}</td>
             </tr>
             <tr>
-              <td colspan="2">
+              <td colspan="2" class="pb-3">
                 How many credits have been earned (worked) so far that count towards reduced-price tickets and staff
                 credentials.
               </td>
@@ -337,7 +326,7 @@
               <td class="text-right">{{credits-format creditsExpected}}</td>
             </tr>
             <tr>
-              <td colspan="2">
+              <td colspan="2" class="pb-3">
                 Calculated total credits that might be received based on the credits earned so far
                 and what upcoming shifts the person is signed up for.
               </td>
@@ -347,21 +336,24 @@
               <td class="text-right">{{credits-format timesheetSummary.pre_event_credits}}</td>
             </tr>
             <tr>
-              <td colspan="2">How many credits have been earned in the pre-event period (before gate open).</td>
+              <td colspan="2" class="pb-3">How many credits have been earned in the pre-event period (before gate
+                open).
+              </td>
             </tr>
             <tr>
               <th>Earned Event Week Credits</th>
               <td class="text-right">{{credits-format timesheetSummary.event_credits}}</td>
             </tr>
             <tr>
-              <td colspan="2">Credits have been earned during the event week (gate open thru Labor Day)</td>
+              <td colspan="2" class="pb-3">Credits have been earned during the event week (gate open thru Labor Day)
+              </td>
             </tr>
             <tr>
               <th>Earned Post-Event Credits</th>
               <td class="text-right">{{credits-format timesheetSummary.post_event_credits}}</td>
             </tr>
             <tr>
-              <td colspan="2">Credits have been earned during the post-event week (after Labor Day)</td>
+              <td colspan="2" class="pb-3">Credits have been earned during the post-event week (after Labor Day)</td>
             </tr>
             </tbody>
           </table>
@@ -375,7 +367,7 @@
               <td class="text-right">{{hour-minute-format timesheetSummary.counted_duration}}</td>
             </tr>
             <tr>
-              <td colspan="2">
+              <td colspan="2" class="pb-3">
                 The total number of hours which count towards appreciations such as t-shirts, all-you-eat
                 passes, and shower pogs.
               </td>
@@ -385,7 +377,7 @@
               <td class="text-right">{{hour-minute-format this.countedDurationExpected}}</td>
             </tr>
             <tr>
-              <td colspan="2">
+              <td colspan="2" class="pb-3">
                 Calculated total hours which count towards appreciations that might be received based on
                 the hours worked so far and what upcoming shifts the person is signed up for.
               </td>
@@ -395,7 +387,7 @@
               <td class="text-right">{{hour-minute-format timesheetSummary.total_duration}}</td>
             </tr>
             <tr>
-              <td colspan="2">
+              <td colspan="2" class="pb-3">
                 The total number of hours worked so far that include appreciated and non-appreciated hours.
               </td>
             </tr>
@@ -406,28 +398,29 @@
               </td>
             </tr>
             <tr>
-              <td colspan="2">How many hours have been worked in the pre-event period (before gate open).</td>
+              <td colspan="2" class="pb-3">How many hours have been worked in the pre-event period (before gate open).
+              </td>
             </tr>
             <tr>
               <th>Event Week Hours</th>
               <td class="text-right">{{hour-minute-format timesheetSummary.event_duration}}</td>
             </tr>
             <tr>
-              <td colspan="2">Credits have been earned during the event week (gate open thru Labor Day)</td>
+              <td colspan="2" class="pb-3">The hours worked during the event week (Gate Open thru Labor Day)</td>
             </tr>
             <tr>
               <th>Post-Event Hours</th>
               <td class="text-right">{{hour-minute-format timesheetSummary.post_event_duration}}</td>
             </tr>
             <tr>
-              <td colspan="2">The hours have been earned during the post-event week (after Labor Day)</td>
+              <td colspan="2" class="pb-3">The hours have been earned during the post-event week (after Labor Day)</td>
             </tr>
             <tr>
               <th>Hours not counted towards appreciations</th>
               <td class="text-right">{{hour-minute-format timesheetSummary.other_duration}}</td>
             </tr>
             <tr>
-              <td colspan="2">
+              <td colspan="2" class="pb-3">
                 Some shifts (trainings, certain on-call positions, etc) have hours which are not counted
                 towards appreciations.
               </td>

--- a/app/templates/hq/site-checkin.hbs
+++ b/app/templates/hq/site-checkin.hbs
@@ -19,7 +19,7 @@
     <p>
       Consult with the HQ Lead or Supervisor to see if this is an error.
     </p>
-    Normally a person has to have atttend &amp; passed training before they are issued their BMID, be allowed to check out radios,
+    Normally a person has to have attend &amp; passed training before they are issued their BMID, be allowed to check out radios,
     and work a shift.
   </ChNotice>
 {{/unless}}
@@ -73,21 +73,18 @@
 {{#if this.personEvent.asset_authorized}}
     Radio checkout form has been <strong class="text-success">SIGNED</strong>.
 {{else}}
-  <div class="text-danger">Radio checkout form has NOT BEEN SIGNED.</div>
-  <button type="button" class="btn btn-primary" {{action this.markAssetAuthorized}}
-          disabled={{this.personEvent.isSaving}}>Mark Form As Signed
-  </button>
-  {{#if this.personEvent.isSaving}}
-    <LoadingIndicator/>
-  {{/if}}
+  <h4 class="text-danger">Radio Checkout Agreement NOT BEEN SIGNED - DO NOT ISSUE RADIOS.</h4>
+   Direct {{this.person.callsign}} to a kiosk and have them agree to the Radio Checkout Agreement. Only after the
+    agreement is signed may they be given a radio.
 {{/if}}
 </p>
 <p>
   {{#if this.personEvent.signed_motorpool_agreement}}
-    {{this.person.callsign}} has signed the Motorpool Policy and is authorized to drive golf carts and gators.
+   {{fa-icon "check" color="success"}} The Motorpool Policy has been signed.
   {{else}}
-    <span class="text-danger">{{this.person.callsign}} has NOT signed the Motorpool Policy. Direct the person to a
-      kiosk and have them agree to the Motorpool Policy if they would like to drive golf carts &amp; UTVs on playa for Ranger business.</span>
+    <h4 class="text-danger">Motorpool Agreement NOT SIGNED - Not authorized to drive Ranger gators, UTVs, or golf carts.</h4>
+    If {{this.person.callsign}} is comfortable driving Ranger gators, UTVs, or golf carts while on duty, direct the person to a
+      kiosk and have them agree to the Motorpool Policy.
   {{/if}}
 </p>
 

--- a/app/templates/me.hbs
+++ b/app/templates/me.hbs
@@ -26,6 +26,9 @@
       {{#if (and (config "MotorpoolPolicyEnable") (or user.isRanger user.isAlpha user.isNonRanger))}}
         <s.link @route="me.motorpool-policy" @title="Motorpool Policy" @icon="car" @iconType="s"/>
       {{/if}}
+      {{#if (and (config "RadioCheckoutAgreementEnabled") (or user.isRanger user.isAlpha user.isNonRanger))}}
+        <s.link @route="me.radio-checkout" @title="Radio Agreement" @icon="broadcast-tower" @iconType="s"/>
+      {{/if}}
       {{#if user.may_request_stickers}}
         <s.link @route="me.vehicles" @title="Vehicle Requests" @icon="truck-monster" @iconType="s"/>
       {{/if}}

--- a/app/templates/me/radio-checkout.hbs
+++ b/app/templates/me/radio-checkout.hbs
@@ -1,0 +1,32 @@
+<h1>{{this.currentYear}} Ranger Radio Checkout Agreement</h1>
+<BackToHome/>
+{{#if (config "RadioCheckoutAgreementEnabled")}}
+  {{#if this.hasAgreed}}
+    <p>
+      <b class="text-success">{{fa-icon "check"}} You have signed the Radio Checkout Agreement. Thank you.</b>
+    </p>
+  {{/if}}
+
+  <DocumentShow @tag="radio-checkout-agreement" @onLoad={{this.loadedAction}}/>
+
+  {{#if this.hasAgreed}}
+    <p class="text-success font-weight-bold">Thank you for signing the Radio Checkout Agreement.
+      You have acknowledged you have read the Radio Checkout Agreement and understand
+      the terms and conditions of using Ranger radios.
+    </p>
+  {{else if this.documentHasLoaded}}
+    <button type="submit" {{action this.agreeAction}} class="btn btn-primary" disabled={{this.isSubmitting}}>
+      Yes, I agree to the Radio Checkout Agreement.
+    </button>
+    {{#if this.isSubmitting}}
+      <LoadingIndicator/>
+    {{/if}}
+  {{/if}}
+  <div class="mt-4">
+    <BackToHome/>
+  </div>
+{{else}}
+  <p>
+    The Ranger Radio Agreement for this year is not yet available. Please check back later.
+  </p>
+{{/if}}

--- a/app/templates/me/timesheet.hbs
+++ b/app/templates/me/timesheet.hbs
@@ -1,5 +1,6 @@
-<YearSelect @title="Timesheet For {{session.user.callsign}}" @year={{this.year}} @years={{this.person.all_years}} @onChange={{action (mut this.year)}} />
-<BackToHome />
+<YearSelect @title="Timesheet For {{session.user.callsign}}" @year={{this.year}} @years={{this.person.all_years}}
+            @onChange={{action (mut this.year)}} />
+<BackToHome/>
 
 {{#if this.timesheets}}
   {{#if (and this.isCurrentYear this.timesheetInfo.correction_enabled)}}
@@ -12,21 +13,22 @@
       {{#if this.timesheetInfo.timesheet_confirmed}}
         <b>Thank you for confirming your timesheet is accurate.</b>
       {{else}}
-        <b class="text-danger">It appears you have not confirmed your timesheet as accurate.</b> Please to go the <LinkTo @route="me.timesheet-corrections">Timesheet Corrections</LinkTo> page,
-        review your timesheet entries, submit any missing timesheet entries requests, and confirm your {{year}} timesheet as accurate.
+        <b class="text-danger">It appears you have not confirmed your timesheet as accurate.</b> Please to go the
+        <LinkTo @route="me.timesheet-corrections">Timesheet Corrections</LinkTo>
+        page,
+        review your timesheet entries, submit any missing timesheet entries requests, and confirm your {{year}}
+        timesheet as accurate.
       {{/if}}
     </p>
   {{/if}}
-  <div class="row my-2">
-    <div class="col-auto">
-      [hh:mm] = time in brackets indicates the time does not count towards appreciations.
-    </div>
+  <div class="m-2">
+    {{fa-icon "minus-square" color="danger" type="far"}} = the shift hours do not count towards appreciations.
   </div>
   <div class="timesheet-table">
     <div class="timesheet-row timesheet-header">
       <div class="timesheet-time">From</div>
       <div class="timesheet-time">To</div>
-      <div class="timesheet-duration">Time</div>
+      <div class="timesheet-duration">Duration</div>
       <div class="timesheet-credits">Credits</div>
       <div class="timesheet-position">Position</div>
     </div>
@@ -42,12 +44,11 @@
             {{/if}}
           </div>
           <div class="timesheet-duration">
-            <span class="timesheet-sm-label">Time:</span>
-            {{#if ts.position.count_hours}}
-              {{hour-minute-format ts.duration}}
-            {{else}}
-              [{{hour-minute-format ts.duration}}]
-            {{/if}}
+            <span class="timesheet-sm-label">Duration:</span>
+            {{#unless ts.position.count_hours}}
+              {{fa-icon "minus-square" color="danger" type="far"}}
+            {{/unless}}
+            {{hour-minute-format ts.duration}}
           </div>
           <div class="timesheet-credits">
             <span class="timesheet-sm-label">Credits:</span>

--- a/app/templates/person/event-info.hbs
+++ b/app/templates/person/event-info.hbs
@@ -3,14 +3,12 @@
 
 <ChForm @forId="person-event" @formFor={{this.personEvent}} @onSubmit={{this.saveEvent}} as |f|>
   <dl>
-    <dt>Years Active</dt>
+    <dt>Years Worked ({{this.person.years.length}})</dt>
     <dd>
-      {{#if person.years}}
-        {{#each person.years as |y|}}
-          {{y}}
-        {{/each}} ({{person.years.length}})
+      {{#if this.person.years}}
+        {{year-range this.person.years}}
       {{else}}
-        None yet.
+        <i>Has not worked yet</i>
       {{/if}}
     </dd>
 
@@ -57,16 +55,23 @@
         Radio eligibility for this year is not yet available.
       {{/if}}
       <div class="mt-2">
-      <f.input @name="asset_authorized" @label="Assets Authorized (i.e. signed Radio Authorization form)"
-               @type="checkbox"
-               @inline={{true}}  />
+        {{#if (has-role "admin")}}
+          <f.input @name="asset_authorized" @label="Radio Checkout Agreement"  @type="checkbox"  @inline={{true}}  />
+        {{else}}
+          {{#if this.personEvent.asset_authorized}}
+            <b class="text-success"> {{fa-icon "check"}} Signed</b>
+          {{else}}
+            <b class="text-danger">{{fa-icon "times"}} NOT SIGNED</b>
+          {{/if}}
+          the Radio Checkout Agreement.
+        {{/if}}
       </div>
     </dd>
 
     <dt>{{this.year}} Driving</dt>
     <dd>
       {{#if this.person.vehicle_blacklisted}}
-        {{badge "danger" "Blacklisted"}} Vehicle is blacklisted. May not drive gators, cars, or trucks on playa for
+        <b class="text-danger">{{fa-icon "ban"}} Vehicle is blacklisted.</b> May not drive gators, cars, or trucks on playa for
         Ranger business.
       {{else}}
         {{#if (has-role "admin" "vc")}}
@@ -77,24 +82,24 @@
                    @type="checkbox" @inline={{true}} />
         {{else}}
           {{#if this.personEvent.signed_motorpool_agreement}}
-            {{badge "success" "Agreed"}}
+            <b class="text-success"> {{fa-icon "check"}} Signed</b>
           {{else}}
-            {{badge "warning" "NOT AGREED"}}
+            <b class="text-danger">{{fa-icon "times"}} NOT SIGNED</b>
           {{/if}}
-          to drive golf carts &amp; gators (UTVs) on playa for Ranger business.<br>
+          the {{this.year}} Motorpool Agreement policy.<br>
           {{#if this.personEvent.org_vehicle_insurance}}
-            {{badge "success" "Authorized" }}
+            <b class="text-success"> {{fa-icon "check"}} Authorized</b>
           {{else}}
-            {{badge "warning" "Not Authorized" }}
+            <b class="text-danger">{{fa-icon "times"}} NOT AUTHORIZED</b>
           {{/if}}
-          to drive cars and trucks (including own personal vehicle) on playa for Ranger business.
+          for the {{this.year}} event to drive Ranger vehicles (including own personal vehicle) on playa for Ranger business.
           Vehicle must have a valid Burning Man driving sticker.
         {{/if}}
       {{/if}}
     </dd>
     <dt>{{this.year}} Personal Vehicle Use</dt>
     <dd>
-      {{#if (has-role "admin" "vc")}}
+      {{#if (has-role "admin")}}
         <f.input @name="may_request_stickers" @label="Personal Vehicle Use Requests Allowed"
                  @type="checkbox" @inline={{true}} />
         <br>
@@ -102,18 +107,18 @@
         <f.input @name="signed_personal_vehicle_agreement" @label="Personal Vehicle Policy Agreement"
                  @type="checkbox" @inline={{true}} />
       {{else}}
-        {{#if this.personEvent.signed_personal_vehicle_agreement}}
-          {{badge "success" "Allowed"}}
+        {{#if this.personEvent.may_request_stickers}}
+          <b class="text-success">{{fa-icon "check"}} Allowed</b>
         {{else}}
-          {{badge "warning" "NOT ALLOWED"}}
+          <b class="text-danger">{{fa-icon "times"}} NOT ALLOWED</b>
         {{/if}}
         to submit Personal Vehicle Requests.<br>
         {{#if this.personEvent.signed_personal_vehicle_agreement}}
-          {{badge "success" "Agreed"}}
+          <b class="text-success"> {{fa-icon "check"}} Signed</b>
         {{else}}
-          {{badge "warning" "NOT AGREED"}}
+          <b class="text-danger">{{fa-icon "times"}} NOT SIGNED</b>
         {{/if}}
-        to the Personal Vehicle Agreement.
+        the {{this.year}} Personal Vehicle Agreement.
       {{/if}}
     </dd>
 
@@ -122,7 +127,13 @@
       {{#if (has-role "admin" "vc")}}
         <f.input @name="sandman_affidavit" @label="Sandman Affidavit" @type="checkbox" @inline={{true}} />
       {{else}}
-        {{this.year}} Sandman Affidavit {{if this.personEvent.sandman_affidavit "signed" "NOT SIGNED"}}
+        {{#if this.personEvent.sandman_affidavit}}
+          <b class="text-success"> {{fa-icon "check"}} Signed</b>
+        {{else}}
+          <b class="text-danger">{{fa-icon "times"}} NOT SIGNED</b>
+        {{/if}}
+
+        the {{this.year}} Sandman Affidavit
       {{/if}}
     </dd>
   </dl>

--- a/app/templates/person/personal-info.hbs
+++ b/app/templates/person/personal-info.hbs
@@ -1,11 +1,12 @@
-<h3>Update Personal Information</h3>
+<h3>Personal Information for {{this.person.callsign}}</h3>
 <p>
-Last reviewed by {{this.person.callsign}} on
-{{#if this.person.reviewed_pi_at}}
-  {{moment-format this.person.reviewed_pi_at "MMM DD, YYYY @ HH:mm"}}
-{{else}}
-  <i>unknown</i>
-{{/if}}
+  {{this.person.callsign}}
+  {{#if this.person.reviewed_pi_at}}
+    last reviewed their information on
+    {{moment-format this.person.reviewed_pi_at "MMM DD, YYYY @ HH:mm"}}
+  {{else}}
+    has not reviewed their Personal Information.
+  {{/if}}
 </p>
 
 {{#if this.canEditPersonalInfo}}
@@ -20,14 +21,14 @@ Last reviewed by {{this.person.callsign}} on
         <f.input @name="last_name" @type="text" @label="Last Name" @maxlength=25 @grid="col-sm-4 col-md-auto"/>
       </div>
       <div class="form-row">
-        <f.input @name="email" @label="Email" @type="text" @inputmode="email" @size=25 @maxlength=50 @grid="col-sm-12 col-md-auto"
+        <f.input @name="email" @label="Email" @type="text" @inputmode="email" @size=25 @maxlength=50
+                 @grid="col-sm-12 col-lg-auto"
                  @noSpaces={{true}} />
-      </div>
-      <div class="form-row">
-        <f.input @name="home_phone" @type="text" @inputmode="tel" @label="Primary Phone" @grid="col-sm-4 col-md-auto"
+        <f.input @name="home_phone" @type="text" @inputmode="tel" @label="Primary Phone" @grid="col-sm-4 col-lg-auto"
                  @maxlength=25/>
-          <f.input @name="alt_phone" @type="text" @inputmode="tel" @label="Alternative Phone" @grid="col-sm-4 col-md-auto"
-                  @maxlength=25/>
+          <f.input @name="alt_phone" @type="text" @inputmode="tel" @label="Alternative Phone"
+                   @grid="col-sm-4 col-lg-auto"
+                   @maxlength={{25}}/>
       </div>
 
       <div class="form-row">
@@ -36,14 +37,15 @@ Last reviewed by {{this.person.callsign}} on
       </div>
 
       <div class="form-row">
-        <f.input @name="callsign_pronounce" @type="text" @label="Callsign Pronounciation" @size=32 @maxlength=32 @grid="col-sm-12 col-md-auto"/>
+        <f.input @name="callsign_pronounce" @type="text" @label="Callsign Pronounciation" @size=32 @maxlength=32
+                 @grid="col-sm-12 col-md-auto"/>
       </div>
 
       <div class="form-row">
         <f.input @name="languages" @label="Languages Spoken"
                  @hint="List the English names of languages you are comfortable speaking separated by a comma. Ex: english, french, japanese"/>
       </div>
-      <div class="form-row col-auto">
+      <div class="form-row">
         <f.input @name="camp_location" @type="textarea" @label="Camp Name & Location" @cols=50 @rows=4 @maxlength=200
                  @hint={{concat (if f.model.camp_location f.model.camp_location.length "0") " of 200 characters"}} />
       </div>

--- a/app/utils/slot-signup.js
+++ b/app/utils/slot-signup.js
@@ -7,7 +7,7 @@ export function slotSignup(controller, slot, person, callback = null, force = fa
     data: {slot_id: slot.id, force: (force ? 1 : 0)}
   }).then((result) => {
     set(slot, 'is_submitting', false);
-    if (result.status == 'success') {
+    if (result.status === 'success') {
       const toast = controller.toast;
       const isMe = controller.session.userId == person.id;
       const name = isMe ? "You are" : person.callsign + " is";
@@ -29,7 +29,7 @@ export function slotSignup(controller, slot, person, callback = null, force = fa
 
       if (forcedReasons.length > 0) {
         let sentence;
-        if (forcedReasons.length == 1) {
+        if (forcedReasons.length === 1) {
           sentence = forcedReasons[0];
         } else {
           sentence = forcedReasons.slice(0, forcedReasons.length - 1).join(', ') + ", and " + forcedReasons.slice(-1)
@@ -92,6 +92,18 @@ function handleSignupError(controller, result, slot, person, callback) {
         );
 
         return;
+
+      case 'missing-requirements':
+        modal.open(
+          'modal-confirm-missing-requirements', {
+            requirements: result.requirements,
+            person
+          },
+          () => {
+            slotSignup(controller, slot, person, callback, true);
+          }
+        );
+      return;
     }
   }
 
@@ -119,8 +131,17 @@ function handleSignupError(controller, result, slot, person, callback) {
     case 'multiple-enrollment':
       modal.open(
         'modal-multiple-enrollment', {
-          title: 'Multiple Enrollments Not Allowed',
           enrolledSlots: result.slots,
+          person,
+          slot
+        });
+      break;
+
+
+    case 'missing-requirements':
+      modal.open(
+        'modal-missing-requirements', {
+          requirements: result.requirements,
           person,
           slot
         });

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -24,8 +24,6 @@ export default function () {
       MealInfoAvailable: false,
       MealDates: 'Pre Event is Tue 8/8 (dinner) - Sun 8/27; During Event is Mon 8/28 - Mon 9/4; Post Event is Tue 9/5 - Sat 9/9 (lunch)',
 
-      RadioCheckoutFormUrl: 'https://drive.google.com/open?id=1p4EerIDN6ZRxcWkI7tDFGuMf6SgL1LTQ',
-
       SiteNotice: 'Copyright 2008-2018 Black Rock City, LLC. All information contained within this website is strictly confidential.',
 
       SiteTitle: 'Black Rock Rangers Secret Clubhouse',
@@ -178,15 +176,10 @@ export default function () {
 
     return {
       permission: {
-        signup_allowed: true,
-        callsign_approved: true,
-        photo_status: true,
-        // is the online training link allowed to be shown (if link is enabled)
-        online_training_allowed: true,
-        // was online training taken/passed?
-        online_training_passed: true,
-        // online training page link - if enabled
-        online_training_url: 'https://learning-foo.example.com',
+        all_signups_allowed: true,
+        training_signups_allowed: true,
+        requirements: [],
+        recommend_burn_weekend_shift: false
       }
     };
 

--- a/tests/integration/components/modal-confirm-missing-requirements-test.js
+++ b/tests/integration/components/modal-confirm-missing-requirements-test.js
@@ -1,0 +1,20 @@
+import {module, test} from 'qunit';
+import {setupRenderingTest} from 'ember-qunit';
+import {render} from '@ember/test-helpers';
+import {hbs} from 'ember-cli-htmlbars';
+import {OT_MISSING} from 'clubhouse/constants/signup-requirements';
+
+module('Integration | Component | modal-confirm-missing-requirements', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function (assert) {
+    this.set('dialog', {data: {
+      person: { id: 1, callsign: 'hubcap' },
+      requirements: [OT_MISSING]
+    }});
+    this.set('nullAction', () => { })
+
+    await render(hbs`<ModalConfirmMissingRequirements @dialog={{this.dialog}}  @onClose={{this.nullAction}} @onConfirm={{this.nullAction}} />`);
+    assert.dom('div.modal').exists();
+  });
+});

--- a/tests/integration/components/modal-missing-requirements-test.js
+++ b/tests/integration/components/modal-missing-requirements-test.js
@@ -1,0 +1,20 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import {OT_MISSING} from 'clubhouse/constants/signup-requirements';
+
+module('Integration | Component | modal-missing-requirements', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+    this.set('dialog', {data: {
+        person: { id: 1, callsign: 'hubcap' },
+        requirements: [OT_MISSING],
+        slot:  { id: 1, begins: '2020-01-01 10:00:00', position_id: 1 }
+      }});
+    this.set('nullAction', () => {});
+    await render(hbs`<ModalMissingRequirements @dialog={{this.dialog}}  @onClose={{this.nullAction}}  />`);
+    assert.dom('div.modal').exists();
+  });
+});

--- a/tests/integration/components/schedule-blocked-test.js
+++ b/tests/integration/components/schedule-blocked-test.js
@@ -1,0 +1,25 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { OT_MISSING } from 'clubhouse/constants/signup-requirements';
+
+module('Integration | Component | schedule-blocked', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+
+    this.set('person', { id: 1, callsign: 'hubcap'});
+    this.set('requirements', [ OT_MISSING ]);
+    this.set('overrideAction', () => { });
+
+    await render(hbs`<ScheduleBlocked @person={{this.person}}
+                                    @requirements={{this.requirements}}
+                                    @overrideAction={{this.overrideAction}}
+                                    @isAdmin={{false}}
+                                    @isMe={{true}}
+                        />`);
+
+    assert.dom('div.notice-box').exists();
+  });
+});

--- a/tests/integration/components/schedule-requirements-test.js
+++ b/tests/integration/components/schedule-requirements-test.js
@@ -1,0 +1,18 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { MISSING_BPGUID} from 'clubhouse/constants/dashboard-steps';
+
+module('Integration | Component | schedule-requirements', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+    this.set('requirements', [ MISSING_BPGUID]);
+    this.set('person', { id: 1, callsign: 'hubcap'});
+
+    await render(hbs`<ScheduleRequirements @requirements={{this.requirements}} @person={{this.person}}/>`);
+    assert.dom('ul').exists();
+    assert.dom('li').exists();
+  });
+});

--- a/tests/integration/components/you-or-callsign-test.js
+++ b/tests/integration/components/you-or-callsign-test.js
@@ -1,0 +1,27 @@
+import {module, test} from 'qunit';
+import {setupRenderingTest} from 'ember-qunit';
+import {render} from '@ember/test-helpers';
+import {hbs} from 'ember-cli-htmlbars';
+import Service from '@ember/service';
+
+module('Integration | Component | you-or-callsign', function (hooks) {
+  setupRenderingTest(hooks);
+
+
+  test('it renders', async function (assert) {
+    this.owner.register('service:session', class MockService extends Service {
+      get userId() {
+        return 99;
+      }
+    });
+    this.set('person', {id: 99, callsign: 'hubcap'})
+    await render(hbs`<YouOrCallsign @person={{this.person}} @youLabel="you are" @callsignVerb="is" />`);
+
+    assert.equal(this.element.textContent.trim(), 'you are');
+
+    this.set('person', {id: 88, callsign: 'bucket'})
+    await render(hbs`<YouOrCallsign @person={{this.person}} @youLabel="you are" @callsignVerb="is" />`);
+
+    assert.equal(this.element.textContent.trim(), 'bucket is');
+  });
+});

--- a/tests/unit/controllers/me/radio-checkout-test.js
+++ b/tests/unit/controllers/me/radio-checkout-test.js
@@ -1,0 +1,12 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Controller | me/radio-checkout', function(hooks) {
+  setupTest(hooks);
+
+  // TODO: Replace this with your real tests.
+  test('it exists', function(assert) {
+    let controller = this.owner.lookup('controller:me/radio-checkout');
+    assert.ok(controller);
+  });
+});

--- a/tests/unit/routes/me/radio-checkout-test.js
+++ b/tests/unit/routes/me/radio-checkout-test.js
@@ -1,0 +1,11 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Route | me/radio-checkout', function(hooks) {
+  setupTest(hooks);
+
+  test('it exists', function(assert) {
+    let route = this.owner.lookup('route:me/radio-checkout');
+    assert.ok(route);
+  });
+});


### PR DESCRIPTION
- Handle two different sign up blockers - all sign ups (excluding training), and training sign ups.
- New radio checkout agreement page: /me/radio-cheeckout
- Removed radio checkout form url from home page.
- Added duration column to available sign ups table
- Collapsed 'from' and 'to' time columns on available sign up tables into a single 'Time' column which
  has the start datetime and end time. (e.g. Sun Aug 25 @ 10:00 to 13:00). Allows table row size to be
  reduced and helps increase readability.
- Added icon column to schedule table for better alignment.