### PR TITLE
Update Reports to use position-label helper

### DIFF
--- a/app/controllers/reports/people-by-position.js
+++ b/app/controllers/reports/people-by-position.js
@@ -35,6 +35,7 @@ export default class PeopleByPositionController extends Controller {
       ViewPosition.create({
         id: position.id,
         title: position.title,
+        active: position.active,
         type: position.type,
         allRangers: position.all_rangers,
         allPeople: position.new_user_eligible,

--- a/app/controllers/reports/special-teams.js
+++ b/app/controllers/reports/special-teams.js
@@ -1,6 +1,7 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
+import { positionLabel } from 'clubhouse/helpers/position-label';
 
 export default class ReportsSpecialTeamsController extends Controller {
   @tracked isSubmitting = false;
@@ -13,7 +14,7 @@ export default class ReportsSpecialTeamsController extends Controller {
   @tracked people;
 
   get positionOptions() {
-    return this.positions.map((p) => [p.title, p.id]);
+    return this.positions.map((p) =>  [positionLabel([p,true]), p.id]);
   }
 
   get yearOptions() {

--- a/app/helpers/position-label.js
+++ b/app/helpers/position-label.js
@@ -3,9 +3,9 @@ import { htmlSafe } from '@ember/template';
 import _ from 'lodash';
 
 
-export function positionLabel([position]) {
-  const decorator = (position.active) ? '' :
-    '<span class="text-danger"> [inactive]</span>'
+export function positionLabel([position, muted = false]) {
+  const flag = (position.active) ? '' : ' [inactive]';
+  const decorator = (muted) ? flag : `<span class="text-danger">${flag}</span>`;
   const title = _.escape(position.title);
 
   return htmlSafe(`${title}${decorator}`);

--- a/app/helpers/position-label.js
+++ b/app/helpers/position-label.js
@@ -1,8 +1,14 @@
 import { helper } from '@ember/component/helper';
+import { htmlSafe } from '@ember/template';
+import _ from 'lodash';
+
 
 export function positionLabel([position]) {
-  let decorator = (position.active) ? '' : ' - [INACTIVE]';
-  return `${position.title}${decorator}`;
+  const decorator = (position.active) ? '' :
+    '<span class="text-danger"> [inactive]</span>'
+  const title = _.escape(position.title);
+
+  return htmlSafe(`${title}${decorator}`);
 }
 
 export default helper(positionLabel);

--- a/app/templates/reports/people-by-position.hbs
+++ b/app/templates/reports/people-by-position.hbs
@@ -38,7 +38,7 @@
 {{#each this.visiblePositions as |position|}}
   <ChAccordion as |accordion|>
     <accordion.title>
-      {{position.title}}
+      {{position-label position}}
       {{#if position.allRangers}}
         &ndash; all rangers
       {{/if}}

--- a/app/templates/reports/schedule-by-callsign.hbs
+++ b/app/templates/reports/schedule-by-callsign.hbs
@@ -14,7 +14,7 @@
 <p>
   Showing {{pluralize this.people.length "person"}}
 </p>
-<div class="max-width-700">
+<div class="max-width-900">
   {{#each this.people as |person|}}
     <ChAccordion id="person-{{person.id}}" as |accordion|>
       <accordion.title>{{person.callsign}} </accordion.title>
@@ -45,7 +45,7 @@
               <td>
                 <PresentOrNot @value={{slot.description}} @empty="-"/>
               </td>
-              <td>{{slot.position.title}}</td>
+              <td>{{position-label slot.position}}</td>
             </tr>
           {{/each}}
           </tbody>

--- a/app/templates/reports/schedule-by-position.hbs
+++ b/app/templates/reports/schedule-by-position.hbs
@@ -19,7 +19,7 @@
   {{#each this.positions as |position|}}
     <ChAccordion id="position-{{position.id}}" @isOpen={{mut (get this.showingPositions position.id)}} as |accordion|>
       <accordion.title>
-        {{position.title}} ({{pluralize position.slots.length "shift"}})
+        {{position-label position}} ({{pluralize position.slots.length "shift"}})
       </accordion.title>
       <accordion.body>
         <table class="table table-sm table-hover table-striped">

--- a/app/templates/reports/timesheet-by-callsign.hbs
+++ b/app/templates/reports/timesheet-by-callsign.hbs
@@ -52,7 +52,7 @@
               <tr>
                 <td>{{shift-format entry.on_duty}}</td>
                 <td>{{#if entry.off_duty}}{{shift-format entry.off_duty}}{{else}}<i>still on duty</i>{{/if}}</td>
-                <td>{{entry.position.title}}</td>
+                <td>{{position-label entry.position}}</td>
                 <td class="text-right">
                   {{#if entry.position.count_hours}}
                     {{hour-minute-format entry.duration}}

--- a/app/templates/reports/timesheet-by-position.hbs
+++ b/app/templates/reports/timesheet-by-position.hbs
@@ -5,7 +5,7 @@
 {{#each this.positions as |position|}}
   <div class="max-width-700">
     <ChAccordion as |accordion|>
-      <accordion.title>{{position.title}} ({{pluralize position.timesheets.length "entry"}})</accordion.title>
+      <accordion.title>{{position-label position}} ({{pluralize position.timesheets.length "entry"}})</accordion.title>
       <accordion.body>
         {{#if accordion.isOpen}}
           <p>


### PR DESCRIPTION
> :warning: This PR **requires** burningmantech/ranger-clubhouse-api/pull/726 in order to function properly.

Update the position-label helper so that it displays the [inactive] label wrapped in a span with a class of 'text-danger' by default.  It now also accepts an optional parameter `muted`, false by default, that when true does not wrap the label in a span.

Update the following reports so that they display a position active status using the position-label helper.
- People By Position
- People By Special Teams - muted set to true
- Timesheet By Position
- Timesheet by Callsign
- Schedule By Position
- Schedule By Callsign

By default, since the helper was updated, the position labels in the People Management view will also be decorated. 
