### PR TITLE
New feature - View Schedule Log

### DIFF
--- a/app/components/info-icon.hbs
+++ b/app/components/info-icon.hbs
@@ -1,0 +1,1 @@
+<i class="fas fa-question-circle info-icon"></i>

--- a/app/components/person/schedule-log.hbs
+++ b/app/components/person/schedule-log.hbs
@@ -1,0 +1,84 @@
+<p>
+  {{#if (gte @year 2019)}}
+    <a href {{action this.showLogAction}}>View Scheduling Log</a>
+    {{#if this.isLoading}}
+      <LoadingIndicator/>
+    {{/if}}
+  {{else}}
+    Sorry, the scheduling log is only available for 2019 and later.
+  {{/if}}
+</p>
+
+{{#if this.showLog}}
+  <ModalDialog @title="{{this.args.year}} Scheduling Log for {{this.args.person.callsign}}" @size="xl" as |Modal|>
+    <Modal.body>
+
+      <table class="table table-sm table-width-auto table-striped table-hover">
+        <thead>
+        <tr>
+          <th>&nbsp;</th>
+          <th>Start Time</th>
+          <th>Position</th>
+          <th>Description</th>
+          <th>Added</th>
+          <th>Added By</th>
+          <th>Removed</th>
+          <th>Removed By</th>
+        </tr>
+        </thead>
+        <tbody>
+        {{#each this.logs as |entry|}}
+          <tr>
+            <td>
+              {{#if entry.removed_at}}
+                {{fa-icon "times" color="danger"}}
+              {{else}}
+                &nbsp;
+              {{/if}}
+            </td>
+            <td>
+              {{shift-format entry.slot_begins}}
+            </td>
+            <td>{{entry.position_title}}</td>
+            <td>{{entry.slot_description}}</td>
+            {{#if entry.added_at}}
+              <td>{{shift-format entry.added_at}}</td>
+              <td>
+                {{#if (eq this.personId entry.person_added.id)}}
+                  <i>self</i>
+                {{else}}
+                  <PersonLink @person={{entry.person_added}} />
+                {{/if}}
+              </td>
+            {{else}}
+              <td>-</td>
+              <td>-</td>
+            {{/if}}
+            {{#if entry.removed_at}}
+              <td>{{shift-format entry.removed_at}}</td>
+              <td>
+                {{#if (eq this.personId entry.person_removed.id)}}
+                  <i>self</i>
+                {{else}}
+                  <PersonLink @person={{entry.person_removed}} />
+                {{/if}}
+              </td>
+            {{else}}
+              <td>-</td>
+              <td>-</td>
+            {{/if}}
+          </tr>
+        {{else}}
+        <tr>
+          <td>&nbsp;</td>
+          <td colspan="7"><b class="text-danger">No {{@year}} scheduling logs found for {{@person.callsign}}</b></td>
+        </tr>
+        {{/each}}
+        </tbody>
+      </table>
+    </Modal.body>
+    <Modal.footer>
+      <button type="button" class="btn btn-primary" {{action this.closeAction}}>Close</button>
+    </Modal.footer>
+  </ModalDialog>
+{{/if}}

--- a/app/components/person/schedule-log.js
+++ b/app/components/person/schedule-log.js
@@ -1,0 +1,32 @@
+import Component from '@glimmer/component';
+import { action }from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+import { inject as service } from '@ember/service';
+
+export default class PersonScheduleLogComponent extends Component {
+  @service ajax;
+  @service house;
+
+  @tracked showLog = false
+  @tracked isLoading = false;
+
+  constructor() {
+    super(...arguments);
+    this.personId = +this.args.person.id; // stored as  string sometime. grr.
+  }
+  @action
+  showLogAction() {
+    this.isLoading = true;
+    this.ajax.request(`person/${this.args.person.id}/schedule/log`, { data: { year: this.args.year }})
+      .then((result) => {
+        this.showLog = true;
+        this.logs = result.logs;
+      }).catch((response) => this.house.handleErrorResponse(response))
+      .finally(() => this.isLoading = false);
+  }
+
+  @action
+  closeAction() {
+    this.showLog = false;
+  }
+}

--- a/app/components/schedule-blocked.hbs
+++ b/app/components/schedule-blocked.hbs
@@ -2,7 +2,7 @@
   <ScheduleRequirements @requirements={{@requirements}} @person={{@person}} @isTraining={{@hasTrainingBlocker}} />
   {{#if @hasTrainingBlocker}}
     <p>
-      The homepage has instructions on how to resolve the issue(s) above.
+      The home page has instructions on how to resolve the issue(s) above.
     </p>
     <p>
       <YouOrCallsign @person={{@person}} @youLabel="You are" @callsignVerb="is"/>
@@ -28,7 +28,7 @@
       </button>
     {{else if @isMe}}
       <p>
-        The homepage has instructions on how to resolve the issue(s) above.
+        The home page has instructions on how to resolve the issue(s) above.
       </p>
       <BackToHome/>
     {{/if}}

--- a/app/components/schedule-manage.hbs
+++ b/app/components/schedule-manage.hbs
@@ -20,15 +20,11 @@
       </ChNotice>
     {{/if}}
 
-    <p>
-      The <i class="fas fa-question-circle info-icon"></i> icon on a shift description means additional information is
-      available. Click on the icon and/or text.
-    </p>
-
     <ScheduleTable @slots={{@signedUpSlots}} @person={{@person}} @isMe={{this.isMe}} @isAdmin={{this.isAdmin}} @year={{@year}}
                    @creditsEarned={{@creditsEarned}}
                    @scheduleSummary={{@scheduleSummary}} @leaveSlot={{this.leaveSlot}}
                    @showPeople={{this.showPeople}} />
+
     <div class="d-print-none">
       <h3 class="mt-2">{{if this.isCurrentYear "Available" "Past"}} {{@year}} Shifts</h3>
       {{#if this.availableSlots}}

--- a/app/components/schedule-table.hbs
+++ b/app/components/schedule-table.hbs
@@ -23,6 +23,7 @@
 
 <div class="m-2">
   <NoAppreciateIcon /> = the shift hours do not count towards appreciations.
+  <InfoIcon /> = More shift information available, click on the icon and/or text.
 </div>
 <div class="schedule-table schedule-itinerary">
   <div class="schedule-row schedule-header">

--- a/app/components/slot-info-link.hbs
+++ b/app/components/slot-info-link.hbs
@@ -1,5 +1,5 @@
 {{#if @info~}}
-  <a href {{on "click" this.show}}><i class="fas fa-question-circle info-icon"></i> {{@description}}</a>
+  <a href {{on "click" this.show}}><InfoIcon /> {{@description}}</a>
 {{~else~}}
   {{~@description~}}
 {{/if}}

--- a/app/services/session.js
+++ b/app/services/session.js
@@ -23,7 +23,7 @@ export default class extends SessionService {
   @tracked isMobileScreen = false;
 
   get userId() {
-    return (this.isAuthenticated && this.user) ? this.user.id : null;
+    return (this.isAuthenticated && this.user) ? +this.user.id : null;
   }
 
   constructor() {

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -132,7 +132,7 @@ $sizes: (
 main {
   flex: 1 1 0;
   min-width: 0;
-  padding: 10px;
+  padding: 10px 20px;
 }
 
 .table-fixed {
@@ -617,12 +617,27 @@ caption {
 }
 
 .person-manage-header {
-  @include make-row();
+  display:flex;
   background-color: #f4f4f4 !important;
-  margin-top: -10px;
-  margin-bottom: 10px;
-  padding-top: 10px;
+  margin: -10px -20px;  // Pull the header back so no gaps appear
+  margin-bottom: 15px;
+  padding: 10px 20px;  // Realign text with body
   border-bottom: 1px solid #e0e0e0;
+  align-items: center;
+
+}
+
+.person-manage-callsign {
+  flex: 1;
+  font-size: $h2-font-size;
+  font-weight: 500;
+}
+
+@include media-breakpoint-down(md) {
+  .person-manage-header {
+    flex-direction: column;
+    align-items: normal;
+  }
 }
 
 .max-width-700 {

--- a/app/styles/notice.scss
+++ b/app/styles/notice.scss
@@ -11,6 +11,7 @@
   font-weight: 500;
   margin-bottom: 5px;
 }
+
 .notice-success {
   border-color: #28a745;
   background-color: #c3e6cb;
@@ -28,5 +29,9 @@
   .notice-header {
     color: #9c0010;
   }
+}
+
+.notice-body {
+  margin-bottom: 5px;
 }
 

--- a/app/templates/hq.hbs
+++ b/app/templates/hq.hbs
@@ -14,12 +14,12 @@
 
 <main>
   <div class="person-manage-header">
-    <div class="homepage-title col-sm-12 col-lg-auto">
+    <div class="person-manage-callsign">
       <LinkTo @route="hq.index" @model={{this.person.id}}>{{this.person.callsign}}</LinkTo>
       &lt;{{this.person.first_name}} {{this.person.last_name}}, {{this.person.status}}&gt;
       {{#unless this.person.on_site}} <span class="text-danger">OFF SITE</span>{{/unless}}
     </div>
-    <div class="col-sm-12 col-lg-auto ml-lg-auto">
+    <div class="person-manage-switch">
       <LinkTo @route="person.index" @model={{this.person.id}}>Switch to Person Manage</LinkTo>
     </div>
   </div>

--- a/app/templates/hq/schedule.hbs
+++ b/app/templates/hq/schedule.hbs
@@ -1,3 +1,11 @@
 <h3 class="d-print-none">Schedule &amp; Sign Ups</h3>
-<h1 class="d-none d-print-block">{{year}} Schedule for {{person.callsign}}</h1>
-<ScheduleManage @person={{person}} @slots={{slots}} @creditsEarned={{creditsEarned}} @scheduleSummary={{scheduleSummary}} @signedUpSlots={{signedUpSlots}} @year={{year}} @permission={{permission}} />
+<h1 class="d-none d-print-block">{{this.year}} Schedule for {{this.person.callsign}}</h1>
+<Person::ScheduleLog @year={{this.year}} @person={{this.person}} />
+
+<ScheduleManage @person={{this.person}}
+                @slots={{slots}}
+                @year={{this.year}}
+                @creditsEarned={{this.creditsEarned}}
+                @scheduleSummary={{this.scheduleSummary}}
+                @signedUpSlots={{this.signedUpSlots}}
+                @permission={{this.permission}} />

--- a/app/templates/person.hbs
+++ b/app/templates/person.hbs
@@ -65,7 +65,7 @@
 
 <main>
   <div class="person-manage-header">
-    <div class="homepage-title col-sm-12 col-lg-auto">
+    <div class="person-manage-callsign">
       <PersonLink @person={{this.person}} />
       <span class="d-inline-block">
         &lt;{{this.person.status}}{{if this.person.vintage "/vintage"}}
@@ -75,7 +75,7 @@
         <br><i>"{{this.person.callsign_pronounce}}"</i>
       {{/if}}
     </div>
-    <div class="col-sm-12 col-lg-auto ml-lg-auto">
+    <div class="person-manage-switch">
       <LinkTo @route="hq.index" @model={{this.person.id}}>Switch to HQ Window</LinkTo>
     </div>
     {{#if (or this.person.isSuspended this.person.isResigned this.person.isDeceased this.person.isUberBonked this.person.isDismissed)}}

--- a/app/templates/person/schedule.hbs
+++ b/app/templates/person/schedule.hbs
@@ -2,6 +2,7 @@
             @subheader={{true}}
             @onChange={{action (mut this.year)}} />
 
+<Person::ScheduleLog @year={{this.year}} @person={{this.person}} />
 <ScheduleManage @person={{this.person}} @slots={{this.slots}} @signedUpSlots={{this.signedUpSlots}}
                 @scheduleSummary={{this.scheduleSummary}} @creditsEarned={{this.creditsEarned}} @year={{this.year}}
                 @permission={{this.permission}} />

--- a/tests/integration/components/person/schedule-log-test.js
+++ b/tests/integration/components/person/schedule-log-test.js
@@ -1,0 +1,15 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | person/schedule-log', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+    this.set('person', { id: 1, callsign: 'hubcap'});
+    await render(hbs`<Person::ScheduleLog @year={{2019}} @person={{this.person}} />`);
+
+    assert.dom('a').exists().hasText('View Scheduling Log');
+  });
+});


### PR DESCRIPTION
Shows the schedule sign ups and removals. Accessible by folks with Login Management.
On the {Person Manage, HQ} > Schedule pages.

- Switched person and hq headers to use flexbox layout instead of bootstrap rows & cols.
- Added a little more breathing room on the page contents (aka adjusted margins & padding).
- DRY'ed up the additional shift info icon - now <InfoIcon />.