### PR TITLE
Convert admin/{slots,credits} to glimmer style. Minor fix ups.

### DIFF
--- a/app/components/ch-accordion-body.hbs
+++ b/app/components/ch-accordion-body.hbs
@@ -1,3 +1,3 @@
-<div class="accordion-body collapse" {{did-insert @onInsert}}>
+<div class="accordion-body collapse {{if @isInitOpen "show"}}" {{did-insert @onInsert}}>
   {{yield}}
 </div>

--- a/app/components/ch-accordion.hbs
+++ b/app/components/ch-accordion.hbs
@@ -2,5 +2,5 @@
   {{yield (hash isOpen=this.isOpen
                   closeAction=this.onClickAction
                   title=(component "ch-accordion-title" isOpen=this.isOpen onClick=this.onClickAction)
-                  body=(component "ch-accordion-body" isOpen=this.isOpen onInsert=this.onInsertAction))}}
+                  body=(component "ch-accordion-body" isOpen=this.isOpen onInsert=this.onInsertAction isInitOpen=@isInitOpen))}}
 </div>

--- a/app/components/schedule-manage.js
+++ b/app/components/schedule-manage.js
@@ -45,9 +45,9 @@ export default class ScheduleManageComponent extends Component {
     this._sortAndMarkSignups();
 
     signedUpSlots.forEach((signedUp) => {
-      const slot = slots.find((slot) => signedUp.id == slot.id);
+      const slot = slots.find((slot) => signedUp.id === slot.id);
       if (slot) {
-        slot.set('person_assigned', true);
+        slot.person_assigned = true;
       }
     });
 
@@ -177,7 +177,7 @@ export default class ScheduleManageComponent extends Component {
       // Record the original row position on the page
 
       this.args.signedUpSlots.pushObject(slot);
-      slot.set('person_assigned', true);
+      slot.person_assigned = true;
       this.permission = {...this.permission, recommend_burn_weekend_shift: result.recommend_burn_weekend_shift};
       this._sortAndMarkSignups();
       this._retrieveScheduleSummary();
@@ -214,7 +214,6 @@ export default class ScheduleManageComponent extends Component {
         this.ajax.request(`person/${this.args.person.id}/schedule/${slot.id}`, {
           method: 'DELETE',
         }).then((result) => {
-          set(slot, 'is_submitting', false);
           const signedUp = this.args.signedUpSlots.find((s) => s.id == slot.id);
 
           if (row) {
@@ -231,15 +230,13 @@ export default class ScheduleManageComponent extends Component {
             this._sortAndMarkSignups();
           }
 
-          slot.set('person_assigned', false);
-          slot.set('slot_signed_up', result.signed_up);
+          slot.person_assigned = false;
+          slot.slot_signed_up = result.signed_up;
           set(this.permission, 'recommend_burn_weekend_shift', result.recommend_burn_weekend_shift);
           this._retrieveScheduleSummary();
           this.toast.success('The shift has been removed from the schedule.');
-        }).catch((response) => {
-          set(slot, 'is_submitting', false);
-          this.house.handleErrorResponse(response);
-        });
+        }).catch((response) => this.house.handleErrorResponse(response))
+          .finally(() => set(slot, 'is_submitting', false));
       }
     );
   }

--- a/app/components/schedule-position-list.hbs
+++ b/app/components/schedule-position-list.hbs
@@ -1,88 +1,93 @@
 <ChAccordion as |Accordion|>
-  <Accordion.title>{{@position.title}} ({{@position.slots.length}})</Accordion.title>
+  <Accordion.title>
+    {{@position.title}} ({{@position.slots.length}})
+    {{#if this.signupCount}} <span class="text-success">[{{pluralize this.signupCount "signup"}}]</span>{{/if}}
+  </Accordion.title>
   <Accordion.body>
-    <div class="schedule-row schedule-header">
-      <div class="schedule-icon">&nbsp;</div>
-      <div class="schedule-time">Time</div>
-      <div class="schedule-duration">Duration</div>
-      <div class="schedule-credits">Credits</div>
-      <div class="schedule-signup-description">Description</div>
-      <div class="schedule-signups">Sign Ups</div>
-      <div class="schedule-actions">Actions</div>
-    </div>
-    {{#each @position.slots as |slot|}}
-      <div class="schedule-row {{if slot.person_assigned "table-success"}}" id="slot-{{slot.id}}">
-        <div class="schedule-icon">
-          {{#if slot.person_assigned}}
-            {{fa-icon "check" title="You are signed up for this shift."}}
-          {{else if (not slot.slot_active)}}
-            {{fa-icon "times" title="Shift is inactive and may not be signed up for" color="danger"}}
-          {{else}}
-            &nbsp;
-          {{/if}}
-        </div>
-        <div class="schedule-time">
-           {{shift-format slot.slot_begins slot.slot_ends}}
-        </div>
-        <div class="schedule-duration">
-          <span class="schedule-sm-label">Duration:</span>
-          {{#unless slot.position_count_hours}}
-            <NoAppreciateIcon />
-          {{/unless~}}
-          {{hour-minute-format slot.slot_duration}}
-        </div>
-        <div class="schedule-credits">
-          <span class="schedule-sm-label">Credits:</span> {{credits-format slot.credits}}
-        </div>
-        <div class="schedule-signup-description">
-          <span class="schedule-sm-label">{{@position.title}}</span>
-          <SlotInfoLink @description={{slot.slot_description}} @info={{slot.slot_url}} />
-        </div>
-        <div class="schedule-signups">{{slot-full-indicator slot.slot_signed_up slot.slot_max}}</div>
-        <div class="schedule-actions">
-          <button type="button" {{on "click" (fn @showPeople slot)}} class="btn btn-secondary btn-sm"
-                  title="View people signed up"
-                  disabled={{slot.is_retrieving_people}}>
-            {{#if slot.is_retrieving_people}}
-              {{fa-icon "spinner" spin="true"}}
+    {{#if Accordion.isOpen}}
+      <div class="schedule-row schedule-header">
+        <div class="schedule-icon">&nbsp;</div>
+        <div class="schedule-time">Time</div>
+        <div class="schedule-duration">Duration</div>
+        <div class="schedule-credits">Credits</div>
+        <div class="schedule-signup-description">Description</div>
+        <div class="schedule-signups">Sign Ups</div>
+        <div class="schedule-actions">Actions</div>
+      </div>
+      {{#each @position.slots as |slot|}}
+        <div class="schedule-row {{if slot.person_assigned "table-success"}}" id="slot-{{slot.id}}">
+          <div class="schedule-icon">
+            {{#if slot.person_assigned}}
+              {{fa-icon "check" title="You are signed up for this shift."}}
+            {{else if (not slot.slot_active)}}
+              {{fa-icon "times" title="Shift is inactive and may not be signed up for" color="danger"}}
             {{else}}
-              {{fa-icon "users" type="fas"}}
+              &nbsp;
             {{/if}}
-            Sign Ups
-          </button>
-          {{#if slot.person_assigned}}
-            {{#if (or @isAdmin (not slot.has_started))}} {{!template-lint-disable "no-negated-condition"}}
-            {{! Only allow admins to remove a sign up that has started}}
-              <button type="button" {{on "click" (fn @leaveSlot slot)}} class="btn btn-light-red btn-sm"
-                      title="Remove from schedule" disabled={{slot.is_submitting}}>
-                {{#if slot.is_submitting}}
-                  {{fa-icon "spinner" spin=true}}
-                {{else}}
-                  {{fa-icon "trash-alt" type="fas"}}
-                {{/if}}
-                Remove
-              </button>
-            {{/if}}
-          {{else if @isCurrentYear}}
-          {{! Only show action buttons for the current year}}
-            {{#if slot.slot_active}}
-              {{#if (or @isAdmin (and (not slot.isFull) (not slot.has_started)))}}
-                <button type="button" {{on "click" (fn @joinSlot slot)}} class="btn btn-primary btn-sm"
-                        title="Sign up for the shift" disabled={{slot.is_submitting}}>
+          </div>
+          <div class="schedule-time">
+            {{shift-format slot.slot_begins slot.slot_ends}}
+          </div>
+          <div class="schedule-duration">
+            <span class="schedule-sm-label">Duration:</span>
+            {{#unless slot.position_count_hours}}
+              <NoAppreciateIcon/>
+            {{/unless~}}
+            {{hour-minute-format slot.slot_duration}}
+          </div>
+          <div class="schedule-credits">
+            <span class="schedule-sm-label">Credits:</span> {{credits-format slot.credits}}
+          </div>
+          <div class="schedule-signup-description">
+            <span class="schedule-sm-label">{{@position.title}}</span>
+            <SlotInfoLink @description={{slot.slot_description}} @info={{slot.slot_url}} />
+          </div>
+          <div class="schedule-signups">{{slot-full-indicator slot.slot_signed_up slot.slot_max}}</div>
+          <div class="schedule-actions">
+            <button type="button" {{on "click" (fn @showPeople slot)}} class="btn btn-secondary btn-sm"
+                    title="View people signed up"
+                    disabled={{slot.is_retrieving_people}}>
+              {{#if slot.is_retrieving_people}}
+                {{fa-icon "spinner" spin="true"}}
+              {{else}}
+                {{fa-icon "users" type="fas"}}
+              {{/if}}
+              Sign Ups
+            </button>
+            {{#if slot.person_assigned}}
+              {{#if (or @isAdmin (not slot.has_started))}} {{!template-lint-disable "no-negated-condition"}}
+              {{! Only allow admins to remove a sign up that has started}}
+                <button type="button" {{on "click" (fn @leaveSlot slot)}} class="btn btn-light-red btn-sm"
+                        title="Remove from schedule" disabled={{slot.is_submitting}}>
                   {{#if slot.is_submitting}}
                     {{fa-icon "spinner" spin=true}}
                   {{else}}
-                    {{fa-icon "user-plus" type="fas"}}
+                    {{fa-icon "trash-alt" type="fas"}}
                   {{/if}}
-                  Add
+                  Remove
                 </button>
               {{/if}}
-            {{else}}
-              <small class="text-danger">inactive</small>
+            {{else if @isCurrentYear}}
+            {{! Only show action buttons for the current year}}
+              {{#if slot.slot_active}}
+                {{#if (or @isAdmin (and (not slot.isFull) (not slot.has_started)))}}
+                  <button type="button" {{on "click" (fn @joinSlot slot)}} class="btn btn-primary btn-sm"
+                          title="Sign up for the shift" disabled={{slot.is_submitting}}>
+                    {{#if slot.is_submitting}}
+                      {{fa-icon "spinner" spin=true}}
+                    {{else}}
+                      {{fa-icon "user-plus" type="fas"}}
+                    {{/if}}
+                    Add
+                  </button>
+                {{/if}}
+              {{else}}
+                <small class="text-danger">inactive</small>
+              {{/if}}
             {{/if}}
-          {{/if}}
+          </div>
         </div>
-      </div>
-    {{/each}}
+      {{/each}}
+    {{/if}}
   </Accordion.body>
 </ChAccordion>

--- a/app/components/schedule-position-list.js
+++ b/app/components/schedule-position-list.js
@@ -1,0 +1,7 @@
+import Component from '@glimmer/component';
+
+export default class SchedulePositionListComponent extends Component {
+  get signupCount() {
+    return this.args.position.slots.reduce((signups, s) => ((s.person_assigned ? 1 : 0) + signups), 0);
+  }
+}

--- a/app/models/position-credit.js
+++ b/app/models/position-credit.js
@@ -1,4 +1,5 @@
 import Model, { attr } from '@ember-data/model';
+import { tracked } from '@glimmer/tracking';
 import moment from 'moment';
 
 export default class PositionCreditModel extends Model {
@@ -9,6 +10,8 @@ export default class PositionCreditModel extends Model {
   @attr('number') credits_per_hour;
 
   @attr('', { readOnly: true}) position;
+
+  @tracked selected;  // used to duplicate credits in admin/credits
 
   get positionTitle() {
     return this.position ? this.position.title : `Position #${this.position_id}`;

--- a/app/models/schedule.js
+++ b/app/models/schedule.js
@@ -1,5 +1,6 @@
 import Model, { attr } from '@ember-data/model';
 import moment from 'moment';
+import { tracked } from '@glimmer/tracking';
 
 export default class ScheduleModel extends Model {
   // the position row id
@@ -49,6 +50,8 @@ export default class ScheduleModel extends Model {
 
   // contact email
   @attr('string', { readOnly: true }) contact_email;
+
+  @tracked person_assigned;
 
   get isFull() {
     return (this.slot_signed_up >= this.slot_max);

--- a/app/models/slot.js
+++ b/app/models/slot.js
@@ -1,5 +1,6 @@
 import Model, {attr} from '@ember-data/model';
 import moment from 'moment';
+import {tracked} from '@glimmer/tracking';
 
 export default class SlotModel extends Model {
   @attr('shiftdate') begins;
@@ -20,6 +21,7 @@ export default class SlotModel extends Model {
   @attr('', {readOnly: true}) position;
   @attr('', {readOnly: true}) trainer_slot;
 
+  @tracked selected; // Used to administer slots
 
   get slotDay() {
     const begins = this.begins;

--- a/app/routes/admin/credits.js
+++ b/app/routes/admin/credits.js
@@ -26,7 +26,9 @@ export default class AdminCreditsRoute extends Route {
     controller.set('entry', null);
     controller.set('positionFilter', 'all');
     controller.set('dayFilter', 'all');
-    controller.setProperties(model)
+    controller.setProperties(model);
+    controller.set('positionsOpened', {});
+    controller._buildDisplay();
   }
 
   resetController(controller, isExiting) {

--- a/app/routes/admin/slots.js
+++ b/app/routes/admin/slots.js
@@ -27,5 +27,7 @@ export default class AdminSlotsRoute extends Route {
     controller.setProperties(model)
     controller.set('dayFilter', 'all');
     controller.set('activeFilter', 'all');
+    controller.set('positionsOpened', {});
+    controller._buildDisplay();
   }
 }

--- a/app/templates/admin/credits.hbs
+++ b/app/templates/admin/credits.hbs
@@ -3,14 +3,16 @@
 <div class="form-row my-3 no-gutters">
   <label class="col-form-label">Day Filter</label>
   <div class="col-auto">
-    <ChForm::Select @name="dayFilter" @value={{this.dayFilter}} @options={{this.dayOptions}} @onChange={{action
-            (mut this.dayFilter)}}  @controlClass="form-control"/>
+    <ChForm::Select @name="dayFilter" @value={{this.dayFilter}} @options={{this.dayOptions}}
+                    @onChange={{this.changeDayFilter}}  @controlClass="form-control"/>
   </div>
   <label class="col-form-label">Actions</label>
   <div class="col-auto">
     <button type="button" {{on "click" this.newCredit}} class="btn btn-primary">New Position Credit</button>
     {{#if this.credits.length}}
-      <button type="button" {{on "click" (fn this.startCopy 0)}} class="btn btn-secondary">Copy Credits</button>
+      <button type="button" {{on "click" (fn this.startCopy 0)}} class="btn btn-secondary">
+        Copy Credits
+      </button>
     {{/if}}
   </div>
 </div>
@@ -29,48 +31,54 @@
   To copy credits from a previous year, select that year from the list above.
 {{/if}}
 
-{{#each this.creditGroups as |group|}}
-  <ChAccordion as |accordion|>
+{{#each this.positionCredits as |position|}}
+  <ChAccordion @isInitOpen={{get this.positionsOpened position.position_id}}
+               @onClick={{action this.positionClicked position}} as |accordion|>
     <accordion.title>
-      {{group.title}} ({{group.credits.length}})
+      {{position.title}} ({{position.credits.length}})
+      {{#if position.isNonExistent}}
+        <b class="text-danger">POSITION DOES NOT EXIST</b>
+      {{/if}}
     </accordion.title>
     <accordion.body>
-      <p>
-      <button type="button" {{on "click" (fn this.startCopy group.position_id)}} class="btn btn-secondary btn-sm">
-        Bulk Copy
-      </button>
+      {{#if accordion.isOpen}}
+        <p>
+        <button type="button" {{on "click" (fn this.startCopy position.position_id)}} class="btn btn-secondary btn-sm">
+          Bulk Copy
+        </button>
       </p>
-      <table class="table table-sm table-hover table-striped">
-        <thead>
-        <tr>
-          <th class="w-5">ID</th>
-          <th class="w-15">From</th>
-          <th class="w-15">To</th>
-          <th class="w-10 text-right">Credits</th>
-          <th class="w-35">Description</th>
-          <th class="w-20">Actions</th>
-        </tr>
-        </thead>
-        <tbody>
-        {{#each group.credits as |credit|}}
-          <tr id="credit-{{credit.id}}">
-            <td class="w-5">{{credit.id}}</td>
-            <td class="w-15">{{shift-format credit.start_time}}</td>
-            <td class="w-15">{{shift-format credit.end_time}}</td>
-            <td class="w-10 text-right">{{credits-format credit.credits_per_hour}}</td>
-            <td class="w-35">{{credit.description}}</td>
-            <td class="w-20">
-              <button type="button" {{on "click" (fn this.deleteCredit credit)}} class="btn btn-danger btn-sm">
-                {{fa-icon "trash-alt" type="fas"}} Delete
-              </button>
-              <button type="button" {{on "click" (fn this.editCredit credit)}} class="btn btn-primary btn-sm">
-                {{fa-icon "edit"}} Edit
-              </button>
-            </td>
+        <table class="table table-sm table-hover table-striped">
+          <thead>
+          <tr>
+            <th class="w-5">ID</th>
+            <th class="w-15">From</th>
+            <th class="w-15">To</th>
+            <th class="w-10 text-right">Credits</th>
+            <th class="w-35">Description</th>
+            <th class="w-20">Actions</th>
           </tr>
-        {{/each}}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+          {{#each position.credits as |credit|}}
+            <tr id="credit-{{credit.id}}">
+              <td class="w-5">{{credit.id}}</td>
+              <td class="w-15">{{shift-format credit.start_time}}</td>
+              <td class="w-15">{{shift-format credit.end_time}}</td>
+              <td class="w-10 text-right">{{credits-format credit.credits_per_hour}}</td>
+              <td class="w-35">{{credit.description}}</td>
+              <td class="w-20">
+                <button type="button" {{on "click" (fn this.deleteCredit credit)}} class="btn btn-danger btn-sm">
+                  {{fa-icon "trash-alt" type="fas"}} Delete
+                </button>
+                <button type="button" {{on "click" (fn this.editCredit credit)}} class="btn btn-primary btn-sm">
+                  {{fa-icon "edit"}} Edit
+                </button>
+              </td>
+            </tr>
+          {{/each}}
+          </tbody>
+        </table>
+      {{/if}}
     </accordion.body>
   </ChAccordion>
 {{/each}}
@@ -80,29 +88,30 @@
     <ChForm @formId="credit-form" @formFor={{this.credit}} @validator={{this.creditValidations}}
             @onSubmit={{this.saveCredit}} @onCancel={{this.cancelCredit}} as |f|>
       <Modal.body>
-        <div class="form-row">
-          {{#if this.credit.isNew}}
-            <f.input @name="position_id" @label="Position" @type="select" @options={{this.positionOptions}}
-                     @multiple=true @size=15 @grid="col-4" @hint="Select multiple positions to create in bulk"/>
-          {{else}}
-            <f.input @name="position_id" @label="Position" @type="select" @options={{this.positionOptions}}
-                     @grid="col-4"/>
-          {{/if}}
-
+        <div class="row">
+          <div class="col-5">
+            {{#if this.credit.isNew}}
+              <f.input @name="position_id" @label="Position" @type="select" @options={{this.positionOptions}}
+                       @multiple=true @size={{15}} @hint="Select multiple positions to create in bulk"/>
+            {{else}}
+              <f.input @name="position_id" @label="Position" @type="select" @options={{this.positionOptions}} />
+            {{/if}}
+          </div>
           <div class="col-7">
             <div class="form-row">
-              <f.input @name="start_time" @label="Begining Time" @type="datetime" @maxlength=25 @grid="col-auto"/>
-              <f.input @name="end_time" @label="Ending Time" @type="datetime" @maxlength=20 @grid="col-auto"/>
-              <f.input @name="credits_per_hour" @label="Credits Per Hour" @type="text" @maxlength=20
-                       @grid="col-auto"/>
-              <f.input @name="description" @label="Description" @size=25 @maxlength=25 @grid="col-md-auto"/>
+              <f.input @name="start_time" @label="Beginning Time" @type="datetime" @maxlength={{25}}
+                       @gridClass="col-auto"/>
+              <f.input @name="end_time" @label="Ending Time" @type="datetime" @maxlength={{20}} @gridClass="col-auto"/>
+              <f.input @name="credits_per_hour" @label="Credits Per Hour" @type="text" @maxlength={{20}}
+                       @gridClass="col-auto"/>
+              <f.input @name="description" @label="Description" @size={{25}} @maxlength={{25}} @gridClass="col-auto"/>
             </div>
           </div>
         </div>
       </Modal.body>
       <Modal.footer @noAlign=true>
-        <f.submit @label={{if this.credit.isNew "Create" "Update"}} @disabled={{or this.credit.isSaving
-                                                                                   this.isCreditSubmitting}} />
+        <f.submit @label={{if this.credit.isNew "Create" "Update"}}
+                  @disabled={{or this.credit.isSaving this.isCreditSubmitting}} />
         <f.cancel @disabled={{or this.credit.isSaving this.isCreditSubmitting}} />
         {{#if (or this.credit.isSaving this.isCreditSubmitting)}}
           <LoadingIndicator/>
@@ -122,71 +131,83 @@
         <fieldset>
           <legend>Add/Subtract Time to New Credits</legend>
           <div class="form-row">
-            <f.input @name="deltaDays" @label="Days" @type="number" @maxlength=5 @grid="col-sm"/>
-            <f.input @name="deltaHours" @label="Hours" @type="number" @maxlength=5 @grid="col-sm"/>
-            <f.input @name="deltaMinutes" @label="Minutes" @type="number" @maxlength=5 @grid="col-sm"/>
+            <f.input @name="deltaDays" @label="Days" @type="number" @maxlength={{5}} @size={{5}} @gridClass="col-auto"/>
+            <f.input @name="deltaHours" @label="Hours" @type="number" @maxlength={{5}} @size={{5}}
+                     @gridClass="col-auto"/>
+            <f.input @name="deltaMinutes" @label="Minutes" @type="number" @maxlength={{5}} @size={{5}}
+                     @gridClass="col-auto"/>
             <f.input @name="newPositionId" @label="Position" @type="select" @options={{this.positionOptionsForCopy}}
-                     @grid="col-md-auto"/>
+                     @gridClass="col-auto"/>
           </div>
           <p>
             Labor Day of {{this.year}} is {{this.selectedYearLaborDay}}.
             Labor Day of {{this.presentYear}} is {{this.presentYearLaborDay}}, {{this.laborDayDiff}} days later.
           </p>
+          {{#if this.badCredits}}
+            <p>
+              <b class="text-danger">
+                {{this.badCredits.length}} credit(s) have been filtered because the credits point to non-existent
+                positions.
+              </b>
+            </p>
+          {{/if}}
         </fieldset>
-        <f.submit @label={{concat "Copy " this.copySelectedCreditCount " selected credits"}}
-                  @disabled={{this.isCopying}} />
-        <f.cancel @disabled={{this.isCopying}} />
-        {{#if this.isCopying}}
-          <LoadingIndicator/>
-        {{/if}}
+        <div class="mb-2">
+          <f.submit @label={{concat "Copy " this.copySelectedCreditCount " selected credits"}}
+                    @disabled={{this.isCopying}} />
+          <f.cancel @disabled={{this.isCopying}} />
+          {{#if this.isCopying}}
+            <LoadingIndicator/>
+          {{/if}}
+        </div>
         {{#each this.copySourcePositions as |position|}}
-          <table class="table table-sm table-box table-hover mt-1">
-            <caption>
-              {{position.selectedCredits.length}} <strong>{{position.title}}</strong> credits to copy
-              <button type="button" {{action this.copyToggleExpanded position}}>
-                {{#if position.expanded}}collapse{{else}}expand{{/if}}
-              </button>
-              <button type="button" {{action this.copyPositionSelectAll position}}>
+          <ChAccordion as |Accordion|>
+            <Accordion.title>
+              [{{position.selectedCredits.length}}] <b>{{position.title}}</b> credits to copy
+              <button type="button" {{on "click" (fn this.copyPositionSelectAll position)}}>
                 {{#if position.allSelected}}deselect{{else}}select{{/if}} all
               </button>
-            </caption>
-            <thead>
-            <tr>
-              <th>Copy</th>
-              <th>Start time</th>
-              <th>End time</th>
-              <th class="text-right">Credits</th>
-              <th>Description</th>
-            </tr>
-            </thead>
-            <tbody>
-            {{#if position.expanded}}
-              {{#each position.credits as |credit|}}
-                <tr>
-                  {{#let (concat "copy-credit-" credit.source.id) as |checkid|}}
-                    <td><Input @type="checkbox" @checked={{credit.selected}} @id={{checkid}} /></td>
-                    <td>
-                      <label for={{checkid}}>
-                        {{shift-format credit.source.start_time}} &rarr;
-                        <br>{{credit.start_time}}
-                      </label>
-                    </td>
-                    <td>
-                      <label for={{checkid}}>
-                        {{shift-format credit.source.end_time}} &rarr;
-                        <br>{{credit.end_time}}
-                      </label>
-                    </td>
-                    <td class="text-right">
-                      <label for={{checkid}}>{{credits-format credit.source.credits_per_hour}}</label>
-                    </td>
-                    <td><label for={{checkid}}>{{credit.source.description}}</label></td>
-                  {{/let}}
-                </tr>
-              {{/each}}
-            {{/if}}
-            </tbody>
-          </table>
+            </Accordion.title>
+            <Accordion.body>
+              {{#if Accordion.isOpen}}
+                <table class="table table-sm table-box table-hover">
+                  <thead>
+                  <tr>
+                    <th>Copy</th>
+                    <th>Start time</th>
+                    <th>End time</th>
+                    <th class="text-right">Credits</th>
+                    <th>Description</th>
+                  </tr>
+                  </thead>
+                  <tbody>
+                  {{#each position.credits as |credit|}}
+                    <tr>
+                      <td><Input @type="checkbox" @checked={{credit.selected}} @id={{credit.checkboxId}} /></td>
+                      <td>
+                        <label for={{credit.checkboxId}}>
+                          {{shift-format credit.source.start_time}} &rarr;
+                          <br>{{credit.start_time}}
+                        </label>
+                      </td>
+                      <td>
+                        <label for={{credit.checkboxId}}>
+                          {{shift-format credit.source.end_time}} &rarr;
+                          <br>{{credit.end_time}}
+                        </label>
+                      </td>
+                      <td class="text-right">
+                        <label for={{credit.checkboxId}}>{{credits-format credit.source.credits_per_hour}}</label>
+                      </td>
+                      <td><label for={{credit.checkboxId}}>{{credit.source.description}}</label></td>
+                    </tr>
+                  {{/each}}
+                  </tbody>
+                </table>
+              {{/if}}
+            </Accordion.body>
+          </ChAccordion>
+
         {{/each}}
       </Modal.body>
     </ChForm>

--- a/app/templates/admin/slots.hbs
+++ b/app/templates/admin/slots.hbs
@@ -5,13 +5,13 @@
   <label class="col-form-label">Day Filter</label>
   <div class="col-auto">
     <ChForm::Select @name="dayFilter" @value={{this.dayFilter}} @options={{this.dayOptions}}
-                    @onChange={{action (mut this.dayFilter)}} @controlClass="form-control"/>
+                    @onChange={{this.changeDayFilter}} @controlClass="form-control"/>
   </div>
 
   <label class="col-form-label">Active Filter</label>
   <div class="col-auto">
     <ChForm::Select @name="activeFilter" @value={{this.activeFilter}} @options={{this.activeOptions}}
-                    @onChange={{action (mut activeFilter)}} @controlClass="form-control"/>
+                    @onChange={{this.changeActiveFilter}} @controlClass="form-control"/>
   </div>
   <label class="col-form-label">Actions</label>
 
@@ -31,7 +31,8 @@
 {{else}}
   <ChNotice @title="{{this.year}} pre-event slot dates are not set" @type="danger">
     Pre-Event slots may not be properly vetted. Visit
-    <LinkTo @route="admin.event-dates">Admin &gt; Edit Event Dates</LinkTo> to set the dates.
+    <LinkTo @route="admin.event-dates">Admin &gt; Edit Event Dates</LinkTo>
+    to set the dates.
   </ChNotice>
 {{/if}}
 
@@ -46,84 +47,88 @@
   No slots were found for {{this.year}}?
 {{/if}}
 
-{{#each this.slotGroups as |group|}}
-  <ChAccordion as |box|>
+{{#each this.positionSlots as |position|}}
+  <ChAccordion @isInitOpen={{get this.positionsOpened position.position_id}}
+               @onClick={{action this.positionClicked position}} as |box|>
     <box.title>
-      {{group.title}} ({{group.slots.length}}
-      {{~#if group.inactive}}
-        / <span class="text-danger">{{group.inactive}} inactive</span>
+      {{position.title}} ({{position.slots.length}}
+      {{~#if position.inactive}}
+        / <span class="text-danger">{{position.inactive}} inactive</span>
       {{~/if}})
     </box.title>
     <box.body>
-      <p>
-        <button type="button" class="btn btn-primary btn-sm" {{action this.activate group}}>Activate All</button>
-        <button type="button" class="btn btn-primary btn-sm" {{action this.deactivate group}}>Deactivate All</button>
-        <button type="button" class="btn btn-secondary btn-sm" {{action this.startCopy group.position_id}}>
-          Bulk Copy
-        </button>
-      </p>
-      <table class="table table-sm table-hover">
-        <thead>
-        <tr>
-          <th>ID</th>
-          <th>From</th>
-          <th>To</th>
-          <th class="text-right">Max</th>
-          <th class="text-right">Count</th>
-          <th class="text-right">Credits</th>
-          <th>Description</th>
-          <th>Active</th>
-          <th>Actions</th>
-        </tr>
-        </thead>
-        <tbody>
-        {{#each group.slots as |slot|}}
-          <tr id="slot-{{slot.id}}">
-            <td>{{slot.id}}</td>
-            <td>{{shift-format slot.begins}}</td>
-            <td>{{shift-format slot.ends}}</td>
-            <td class="text-right">{{slot.max}}</td>
-            <td class="text-right">{{slot.signed_up}}</td>
-            <td class="text-right">{{credits-format slot.credits}}</td>
-            <td>
-              <SlotInfoLink @description={{slot.description}} @info={{slot.url}} />
-            </td>
-            <td clas="text-center">
-              {{#if slot.active}}
-                {{fa-icon "check" color="success"}}
-              {{else}}
-                {{fa-icon "times" color="danger"}}
-              {{/if}}
-            </td>
-            <td>
-              <button type="button" {{action this.repeatSlot slot}} class="btn btn-secondary btn-sm">
-                {{fa-icon "clone"}} Repeat
-              </button>
-              <button type="button" {{action this.repeatSlotAdd24Hours slot}} class="btn btn-secondary btn-sm">
-                {{fa-icon "clone"}} Repeat+24
-              </button>
-              <button type="button" {{action this.deleteSlot slot}} class="btn btn-danger btn-sm">
-                {{fa-icon "trash-alt"type="fas"}} Delete
-              </button>
-              <button type="button" {{action editSlot slot}} class="btn btn-primary btn-sm">
-                {{fa-icon "edit"}} Edit
-              </button>
-            </td>
+      {{#if box.isOpen}}
+        <p>
+          <button type="button" class="btn btn-primary btn-sm" {{action this.activate position}}>Activate All</button>
+          <button type="button" class="btn btn-primary btn-sm" {{action this.deactivate position}}>Deactivate All
+          </button>
+          <button type="button" class="btn btn-secondary btn-sm" {{action this.startCopy position.position_id}}>
+            Bulk Copy
+          </button>
+        </p>
+        <table class="table table-sm table-hover">
+          <thead>
+          <tr>
+            <th>ID</th>
+            <th>From</th>
+            <th>To</th>
+            <th class="text-right">Max</th>
+            <th class="text-right">Count</th>
+            <th class="text-right">Credits</th>
+            <th>Description</th>
+            <th>Active</th>
+            <th>Actions</th>
           </tr>
-          {{#if slot.trainer_slot}}
-            <tr class="{{if slot.trainer_slot "tr-no-border"}}">
-              <td colspan="8">
-                Multiplier slot:
-                <a href="#slot-{{slot.trainer_slot.id}}">
-                  #{{slot.trainer_slot.id}} {{slot.trainer_slot_title}} {{slot.trainer_slot.description}} {{shift-format
-                        slot.trainer_slot.begins}}
-                </a>
+          </thead>
+          <tbody>
+          {{#each position.slots as |slot|}}
+            <tr id="slot-{{slot.id}}">
+              <td>{{slot.id}}</td>
+              <td>{{shift-format slot.begins}}</td>
+              <td>{{shift-format slot.ends}}</td>
+              <td class="text-right">{{slot.max}}</td>
+              <td class="text-right">{{slot.signed_up}}</td>
+              <td class="text-right">{{credits-format slot.credits}}</td>
+              <td>
+                <SlotInfoLink @description={{slot.description}} @info={{slot.url}} />
+              </td>
+              <td class="text-center">
+                {{#if slot.active}}
+                  {{fa-icon "check" color="success"}}
+                {{else}}
+                  {{fa-icon "times" color="danger"}}
+                {{/if}}
+              </td>
+              <td>
+                <button type="button" {{action this.repeatSlot slot}} class="btn btn-secondary btn-sm">
+                  {{fa-icon "clone"}} Repeat
+                </button>
+                <button type="button" {{action this.repeatSlotAdd24Hours slot}} class="btn btn-secondary btn-sm">
+                  {{fa-icon "clone"}} Repeat+24
+                </button>
+                <button type="button" {{action this.deleteSlot slot}} class="btn btn-danger btn-sm">
+                  {{fa-icon "trash-alt"type="fas"}} Delete
+                </button>
+                <button type="button" {{action editSlot slot}} class="btn btn-primary btn-sm">
+                  {{fa-icon "edit"}} Edit
+                </button>
               </td>
             </tr>
-          {{/if}}
-        {{/each}}
-        </tbody>
-      </table>
+            {{#if slot.trainer_slot}}
+              <tr class="{{if slot.trainer_slot "tr-no-border"}}">
+                <td colspan="8">
+                  Multiplier slot:
+                  <a href="#slot-{{slot.trainer_slot.id}}">
+                    #{{slot.trainer_slot.id}} {{slot.trainer_slot_title}} {{slot.trainer_slot.description}}
+                    {{shift-format slot.trainer_slot.begins}}
+                  </a>
+                </td>
+              </tr>
+            {{/if}}
+          {{/each}}
+          </tbody>
+        </table>
+      {{/if}}
     </box.body>
   </ChAccordion>
 {{/each}}
@@ -142,16 +147,18 @@
         <fieldset>
           <legend>Add/Subtract Time to New Slots</legend>
           <div class="form-row">
-            <f.input @name="deltaDays" @label="Days" @type="number" @maxlength=5 @size=5 @grid="col-auto"/>
-            <f.input @name="deltaHours" @label="Hours" @type="number" @maxlength=5 @size=5 @grid="col-auto"/>
-            <f.input @name="deltaMinutes" @label="Minutes" @type="number" @maxlength=5 @size=5 @grid="col-auto"/>
+            <f.input @name="deltaDays" @label="Days" @type="number" @maxlength={{5}} @size={{5}} @grid="col-auto"/>
+            <f.input @name="deltaHours" @label="Hours" @type="number" @maxlength={{5}} @size={{5}} @grid="col-auto"/>
+            <f.input @name="deltaMinutes" @label="Minutes" @type="number" @maxlength={{5}} @size={{5}}
+                     @grid="col-auto"/>
           </div>
           <legend>Set New Slot Attributes</legend>
           <div class="form-row">
             <f.input @name="newPositionId" @label="Position" @type="select" @options={{this.positionOptionsForCopy}}
                      @grid="col-auto"/>
-            <f.input @name="description" @label="Description" @type="text" @maxlength=40 @size=40 @grid="col-auto"/>
-            <f.input @name="max" @label="Max" @type="number" @maxlength=3 @size=3 @grid="col-2"/>
+            <f.input @name="description" @label="Description" @type="text" @maxlength={{40}} @size={{40}}
+                     @grid="col-auto"/>
+            <f.input @name="max" @label="Max" @type="number" @maxlength={{3}} @size=3 @grid="col-2"/>
           </div>
           <div class="form-row">
             <f.input @name="url" @label="Information" @type="textarea" @rows=3 @cols=80 @maxlength=512
@@ -165,61 +172,62 @@
           <br>
           Note: training and mentor/mentee slots cannot be copied yet.
         </fieldset>
-        <p>
+        <div class="my-4">
           <f.submit @label={{concat "Copy " this.copySelectedSlotCount " selected slots"}}
                     @disabled={{this.isCopyingSlots}} />
           <f.cancel @disabled={{this.isCopyingSlots}} />
           {{#if this.isCopyingSlots}}
             <LoadingIndicator/>
           {{/if}}
-        </p>
+        </div>
         {{#each this.copySourcePositions as |position|}}
-          <table class="table table-sm table-box table-hover">
-            <caption>
-              {{position.selectedSlots.length}} / {{position.slots.length}} <strong>{{position.title}}</strong> slots to
-              copy
-              <button type="button" {{action "copyToggleExpanded" position}}>
-                {{#if position.expanded}}collapse{{else}}expand{{/if}}
-              </button>
-              <button type="button" {{action "copyPositionSelectAll" position}}>
+          <ChAccordion as |Accordion|>
+            <Accordion.title>
+              {{position.selectedSlots.length}} / {{position.slots.length}}
+              <b>{{position.title}}</b> slots to copy
+              <button type="button" {{on "click" (fn this.copyPositionSelectAll position)}}>
                 {{#if position.allSelected}}deselect{{else}}select{{/if}} all
               </button>
-            </caption>
-            <thead>
-            <tr>
-              <th>Copy</th>
-              <th>Start time</th>
-              <th>End time</th>
-              <th class="text-right">Max</th>
-              <th>Description</th>
-            </tr>
-            </thead>
-            <tbody>
-            {{#if position.expanded}}
-              {{#each position.slots as |slot|}}
-                <tr>
-                  {{#let (concat "copy-slot-" slot.source.id) as |checkid|}}
-                    <td><Input @type="checkbox" @checked={{slot.selected}} @id={{checkid}} /></td>
-                    <td>
-                      <label for={{checkid}}>
-                        {{shift-format slot.source.begins}} &rarr;
-                        <br>{{slot.begins}}
-                      </label>
-                    </td>
-                    <td>
-                      <label for={{checkid}}>
-                        {{shift-format slot.source.ends}} &rarr;<br>
-                        {{slot.ends}}
-                      </label>
-                    </td>
-                    <td class="text-right"><label for={{checkid}}>{{slot.source.max}}</label></td>
-                    <td><label for={{checkid}}>{{slot.source.description}}</label></td>
-                  {{/let}}
-                </tr>
-              {{/each}}
-            {{/if}}
-            </tbody>
-          </table>
+            </Accordion.title>
+            <Accordion.body>
+              {{#if Accordion.isOpen}}
+                <table class="table table-sm table-box table-hover">
+                  <thead>
+                  <tr>
+                    <th>Copy</th>
+                    <th>Start time</th>
+                    <th>End time</th>
+                    <th class="text-right">Max</th>
+                    <th>Description</th>
+                  </tr>
+                  </thead>
+                  <tbody>
+                  {{#each position.slots as |slot|}}
+                    <tr>
+                      {{#let (concat "copy-slot-" slot.source.id) as |checkid|}}
+                        <td><Input @type="checkbox" @checked={{slot.selected}} @id={{checkid}} /></td>
+                        <td>
+                          <label for={{checkid}}>
+                            {{shift-format slot.source.begins}} &rarr;
+                            <br>{{slot.begins}}
+                          </label>
+                        </td>
+                        <td>
+                          <label for={{checkid}}>
+                            {{shift-format slot.source.ends}} &rarr;<br>
+                            {{slot.ends}}
+                          </label>
+                        </td>
+                        <td class="text-right"><label for={{checkid}}>{{slot.source.max}}</label></td>
+                        <td><label for={{checkid}}>{{slot.source.description}}</label></td>
+                      {{/let}}
+                    </tr>
+                  {{/each}}
+                  </tbody>
+                </table>
+              {{/if}}
+            </Accordion.body>
+          </ChAccordion>
         {{/each}}
       </Modal.body>
     </ChForm>
@@ -229,9 +237,17 @@
 {{#if this.activatingSlot}}
   <ModalDialog @title="Activating Slots" as |Modal|>
     <Modal.body>
-      Saving slot id #{{this.activatingSlot.id}} - {{this.activatingSlot.begins}}
+      Updating slot id #{{this.activatingSlot.id}} - {{this.activatingSlot.begins}}
       - {{this.this.activatingSlot.description}}
       <LoadingIndicator/>
+    </Modal.body>
+  </ModalDialog>
+{{/if}}
+
+{{#if this.slots.isUpdating}}
+  <ModalDialog as |Modal|>
+    <Modal.body>
+      Updating slots lists
     </Modal.body>
   </ModalDialog>
 {{/if}}


### PR DESCRIPTION
- Removed @computed, and EmberObject usage on admin/{slots,credits} controllers. Switched over to @tracked variables.  Cleaned up code.
- Reworked <ChAccordion> for a smoother text reveal.
- Use Accordion.isOpen on <SchedulePositionList> for faster page rendering.