### PR TITLE
More provision work.

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -6,8 +6,6 @@ import config from 'clubhouse/config/environment';
 import LinkComponent from '@ember/routing/link-component';
 import RSVP from 'rsvp';
 import buildErrorHandler from 'ember-test-friendly-error-handler';
-import {isAbortError, isTimeoutError, isForbiddenError, isUnauthorizedError} from 'ember-ajax/errors';
-import {TimeoutError, AbortError, ForbiddenError, UnauthorizedError} from '@ember-data/adapter/error';
 import logError from 'clubhouse/utils/log-error';
 
 RSVP.on('error', function (error) {
@@ -35,18 +33,6 @@ Ember.onerror = buildErrorHandler('Ember.onerror', (error) => {
   }
 
   console.error(error);
-
-  if (error instanceof TimeoutError
-    || error instanceof AbortError
-    || error instanceof ForbiddenError
-    || isAbortError(error)
-    || isTimeoutError(error)
-    || isForbiddenError(error)
-    || isUnauthorizedError(error)
-    || error instanceof UnauthorizedError) {
-    // Don't bother with offline, timeouts, or unauthorized
-    return;
-  }
 
   logError(error, 'ember-onerror');
 

--- a/app/components/bmid-edit.hbs
+++ b/app/components/bmid-edit.hbs
@@ -11,7 +11,7 @@
     {{/if}}
   </p>
   <p>
-    {{fa-icon "plus-circle" color="success"}} = if present, person has claimed provision (showers, meals).
+    {{fa-icon "plus-circle" color="success"}} = if present, person has qualified provision (showers, meals).
   </p>
   <div class="form-row">
     <f.input @name="status" @label="BMID Status" @type="select" @options={{this.bmidStatusOptions}}  @fieldSize="sm"/>

--- a/app/components/ticket-appreciations.hbs
+++ b/app/components/ticket-appreciations.hbs
@@ -5,76 +5,66 @@
                @showing={{@showing}}>
   <:title>
     Provisions
-    <div class="d-inline-block">- {{this.titleCounts}}</div>
+    {{#if this.availableItems}}
+      <TicketSectionStatus @status="claimed" @text="{{pluralize this.availableItems.length "item"}} claimed" />
+    {{/if}}
+    {{#if this.bankedItems}}
+      <TicketSectionStatus @status="banked" @text="{{pluralize this.bankedItems.length "item"}} banked"/>
+    {{/if}}
   </:title>
   <:body>
-    <p>
-      Please CLAIM or BANK/RELEASE {{pluralize this.items.length "provision"}}:
-    </p>
-    {{#each this.items as |item|}}
-      <div class="mt-2">
-        <div class="font-weight-bold">
-          {{item.typeHuman}}
-          {{#if item.isEventRadio}}
-            (count {{item.item_count}})
-          {{/if}}
-          {{#if item.isQualified}}
-            <span class="text-success"> - Available</span>
-          {{else if item.isBanked}}
-            <span class="text-muted"> - Banked</span>
-          {{else if item.isClaimed}}
-            <span class="text-success"> - Claimed {{fa-icon "check"}}</span>
-          {{else if item.isSubmitted}}
-            <span class="text-muted"> - Submitted</span>
-          {{/if}}
-        </div>
-        Expires {{mdy-format item.expiry_date}}<br>
-        {{#if item.isSubmitted}}
-          This item has been submitted and may not be claimed or banked thru the Clubhouse. Please contact the Ranger
-          Ticketing Team if you need help.
-        {{else if item.isEventRadio}}
-          If you decide not to use your Event Radio(s), you will be given a Shift Radio at the beginning of your shift,
-          and is returned at the end of the shift.
-        {{else if item.isMealPass}}
-          If you decide to bank your meal pass, you will be given a meal pog for every 6 hour shift worked.
+    {{#if this.availableItems}}
+      <p>
+        <b>Unless you state otherwise, the following {{pluralize this.availableItems.length "provision"}}
+          will be automatically used for this event:</b>
+      </p>
+      <ul>
+        {{#each this.availableItems as |item|}}
+          <li>{{item.typeHuman}}</li>
+        {{/each}}
+      </ul>
+      <p>
+        You may bank the provision(s) to use in a future event if you are taking
+        this year off or are planning to have a "light" Ranger schedule.
+      </p>
+      <button type="button" class="btn btn-primary btn-responsive"
+        {{action this.updateItems "bank"}} disabled={{@isSubmitting}}>
+        Bank the provision(s)
+        {{#if @isSavingDocumentStatus}}
+          <SpinIcon/>
         {{/if}}
-      </div>
-      <div class="mt-2">
-        {{#if item.isSubmitted}}
-          <b class="text-danger">Item has been submitted, and can no longer be adjusted through the Clubhouse.</b>
-        {{else}}
-          {{#if (or item.isBanked item.isQualified)}}
-            <button type="button" class="btn btn-primary btn-responsive"
-              {{action @setDocumentStatus item "claimed"}} disabled={{@isSavingDocumentStatus}}>
-              Claim {{item.typeHuman}}
-              {{#if @isSavingDocumentStatus}}
-                <SpinIcon/>{{/if}}
-            </button>
-          {{/if}}
-          {{#if item.isEventRadio}}
-            {{#if item.isClaimed}}
-              <button type="button" class="btn btn-primary btn-responsive"
-                {{action @setDocumentStatus item "qualified"}} disabled={{@isSavingDocumentStatus}}>
-                Release Event Radio
-                {{#if @isSavingDocumentStatus}}
-                  <SpinIcon/>{{/if}}
-              </button>
-            {{/if}}
-          {{else}}
-            {{#if item.isQualified}}
-              <div class="mx-2 my-2 h4 text-center d-sm-block d-lg-inline-block">OR</div>
-            {{/if}}
-            {{#if (or item.isClaimed item.isQualified)}}
-              <button type="button" class="btn btn-primary btn-responsive"
-                {{action @setDocumentStatus item "banked"}} disabled={{@isSavingDocumentStatus}}>
-                Bank {{item.typeHuman}}
-                {{#if @isSavingDocumentStatus}}
-                  <SpinIcon/>{{/if}}
-              </button>
-            {{/if}}
-          {{/if}}
+      </button>
+    {{/if}}
+    {{#if this.bankedItems}}
+      <p>
+        <b>You have chosen to bank the following {{pluralize this.bankedItems.length "provision"}}:</b>
+      </p>
+      <ul>
+        {{#each this.bankedItems as |item|}}
+          <li>{{item.typeHuman}} expiring after {{mdy-format item.expiry_date full=true}}</li>
+        {{/each}}
+      </ul>
+      <button type="button" class="btn btn-primary btn-responsive"
+        {{action this.updateItems "claim"}} disabled={{@isSubmitting}}>
+        Use the provision(s) for this event
+        {{#if @isSavingDocumentStatus}}
+          <SpinIcon/>
         {{/if}}
-      </div>
-    {{/each}}
+      </button>
+    {{/if}}
+    {{#if this.submittedItems}}
+      <p class="mt-2">
+        The follow provisions have been submitted for processing and may not be adjusted through the Clubhouse.
+      </p>
+      <ul>
+        {{#each this.submittedItems as |item|}}
+          <li>{{item.typeHuman}} - SUBMITTED</li>
+        {{/each}}
+      </ul>
+      <p>
+         Contact the Ranger Ticketing Team if you have questions or concerns.
+        {{mail-to @ticketingInfo.ranger_ticketing_email}}
+      </p>
+    {{/if}}
   </:body>
 </TicketSection>

--- a/app/components/ticket-info.hbs
+++ b/app/components/ticket-info.hbs
@@ -87,8 +87,10 @@
       {{else if @ticket.isQualified}}
         <h4>You qualified for a {{@ticket.typeHuman}} in {{@ticket.source_year}}!</h4>
         <p>
-          You may <b>Claim</b> your ticket for this year's event, or <b>Bank</b> it for a future event.<br>
-          Note: your {{@ticket.humanType}} will expire on {{mdy-format @ticket.expiry_date full=true}}.
+          You may <b>Claim</b> your ticket for this year's event, or <b>Bank</b> it for a future event.
+        </p>
+        <p>
+          Note: the {{@ticket.typeHuman}} will expire on {{mdy-format @ticket.expiry_date full=true}}.
         </p>
 
         <div class="my-2"><b>What do you want to do with your {{@ticket.typeHuman}}?</b></div>
@@ -96,7 +98,8 @@
           {{action @setDocumentStatus @ticket "claimed"}} disabled={{@isSavingDocumentStatus}}>
           Claim Ticket
           {{#if @isSavingDocumentStatus}}
-            <SpinIcon/>{{/if}}
+            <SpinIcon/>
+          {{/if}}
         </button>
         <span class="mx-2 h5">OR</span>
         <button type="button" class="btn btn-primary"

--- a/app/routes/vc/bmid-print.js
+++ b/app/routes/vc/bmid-print.js
@@ -39,7 +39,7 @@ export default class VcBmidPrintRoute extends ClubhouseRoute {
     this.store.unloadAll('bmid');
 
     model.bmids.forEach((bmid) => {
-      bmid = this.house.pushPayload('bmid', bmid);
+      bmid = bmid.id ? this.house.pushPayload('bmid', bmid) : this.store.createRecord('bmid', bmid);
       switch (bmid.status) {
         case 'do_not_print':
           doNotPrint.push(bmid);

--- a/app/templates/vc/bmid.hbs
+++ b/app/templates/vc/bmid.hbs
@@ -65,7 +65,7 @@
 
   <p>
     {{fa-icon "exclamation-circle"}} = indicates person has not signed up for any shifts.
-    {{fa-icon "plus-circle" color="success"}} = person has claimed provision (showers, meals).
+    {{fa-icon "plus-circle" color="success"}} = person has a qualified provision (showers, meals).
   </p>
 
   Showing {{this.viewBmids.length}} of {{this.bmids.length}}
@@ -169,7 +169,7 @@
                               @controlClass="form-control-sm" @disabled={{bmid.wapDisabled}} />
               {{#if bmid.wapDisabled}}
                 {{#if bmid.wapMissing}}
-                  <strong class="text-danger">WAP misssing</strong>
+                  <strong class="text-danger">WAP missing</strong>
                 {{else}}
                   <strong class="text-danger">WAP submitted</strong>
                 {{/if}}
@@ -220,7 +220,7 @@
             <td>
               {{bmid.mealsHuman}}
               {{#if bmid.want_meals}}
-                <div class="text-success">{{fa-icon "plus-circle"}} {{bmid.want_meals}}</div>
+                <div class="text-success no-wrap">{{fa-icon "plus-circle"}} {{bmid.want_meals}}</div>
               {{/if}}
             </td>
             <td class="w-10">

--- a/app/utils/log-error.js
+++ b/app/utils/log-error.js
@@ -20,7 +20,8 @@ export default function logError(error, type) {
     || isTimeoutError(error)
     || isForbiddenError(error)
     || isUnauthorizedError(error)
-    || error.status == 403) {
+    || error.name === 'NetworkError'
+    || +error.status === 403) {
     // Don't record timeouts, unauthorized requests (aka expired authorization tokens), or offline errors.
     return;
   }

--- a/config/environment.js
+++ b/config/environment.js
@@ -45,6 +45,8 @@ module.exports = function (environment) {
       includeCss: false
     },
 
+    exportApplicationGlobal: true,  // Setup 'window.Clubhouse' so error logging can grab the current user's id.
+
     showAjaxErrors: true,
 
     logRoutes: false, // Send each route transition to the backend for analytic reporting


### PR DESCRIPTION
- Only allow provisions to be 'claimed' or 'banked' in bulk.
- Ticket type was not being shown correctly.
- Prevent word wrapping on BMID edit field.
- Marcato Export was failing to load a in-prep BMID.