### PR TITLE
Various tweaks and bug fixes.

### DIFF
--- a/app/components/schedule-position-list.hbs
+++ b/app/components/schedule-position-list.hbs
@@ -5,6 +5,9 @@
   </Accordion.title>
   <Accordion.body>
     {{#if Accordion.isOpen}}
+      {{#if this.haveNoAppreciationSlots}}
+      <NoAppreciateIcon /> = the shift hours will not count towards appreciations.
+      {{/if}}
       <div class="schedule-row schedule-header">
         <div class="schedule-icon">&nbsp;</div>
         <div class="schedule-time">Time</div>

--- a/app/components/schedule-position-list.js
+++ b/app/components/schedule-position-list.js
@@ -1,6 +1,10 @@
 import Component from '@glimmer/component';
 
 export default class SchedulePositionListComponent extends Component {
+  constructor() {
+    super(...arguments);
+    this.haveNoAppreciationSlots = !!this.args.position.slots.find((s) => !s.position_count_hours);
+  }
   get signupCount() {
     return this.args.position.slots.reduce((signups, s) => ((s.person_assigned ? 1 : 0) + signups), 0);
   }

--- a/app/components/sidebar/link-text.hbs
+++ b/app/components/sidebar/link-text.hbs
@@ -3,4 +3,4 @@
 {{else}}
   <span class="fa{{@iconType}} fa-{{@icon}} fa-fw mr-1"></span>
 {{/if}}
-{{@title}}{{#if @badgeText}} <span class="badge badge-pill badge-success ml-1">{{@badgeText}}</span>{{/if}}
+<span class="sidebar-link-text">{{@title}}{{#if @badgeText}} <span class="badge badge-pill badge-success ml-1">{{@badgeText}}</span>{{/if}}</span>

--- a/app/controllers/admin/positions.js
+++ b/app/controllers/admin/positions.js
@@ -63,7 +63,7 @@ export default class PositionController extends ClubhouseController {
 
   @action
   newAction() {
-    this.position = this.store.createRecord('position');
+    this.position = this.store.createRecord('position', { type: 'Frontline' });
   }
 
   @action

--- a/app/initializers/polyfill-blob.js
+++ b/app/initializers/polyfill-blob.js
@@ -1,9 +1,4 @@
-import AdvancedFormat from 'dayjs/plugin/advancedFormat';
-import dayjs from 'dayjs';
-
 export function initialize(/* application */) {
-  dayjs.extend(AdvancedFormat);
-
   if ('toBlob' in HTMLCanvasElement.prototype) {
     return;
   }

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -661,17 +661,17 @@ caption {
 }
 
 .callsign-list {
-  display: flex;
-  flex-wrap: wrap;
+  column-count: auto;
+  column-width: 140px;
 
   > a {
     display: block;
   }
 
   > div, > a {
-    width: 130px;
-    padding: 5px;
     overflow-wrap: break-word;
+    padding: 0 5px;
+    margin-bottom: 5px;
   }
 
   > div:hover, > a:hover {

--- a/app/styles/sidebar.scss
+++ b/app/styles/sidebar.scss
@@ -33,6 +33,17 @@ a.sidebar-link {
   height: 45px;
 }
 
+// The sidebar link includes an icon, and unfortunately the icon is not underlined when the cursor hovers.
+// This results is the space between the icon and text being underlined as well, and looks bad.
+// The solution is just to underline the actual text.
+.sidebar-link:hover {
+  text-decoration: none;
+}
+
+.sidebar-link-text:hover {
+  text-decoration: underline;
+}
+
 .sidebar-group-title {
   overflow: hidden;
   text-overflow: ellipsis !important;

--- a/app/templates/admin/slots.hbs
+++ b/app/templates/admin/slots.hbs
@@ -153,19 +153,28 @@
                      @grid="col-auto"/>
           </div>
           <legend>Set New Slot Attributes</legend>
+          <p>
+            The new slots will be cloned as-is (except with the new times used above) from slots being copied.
+          </p>
+          <p>
+            Use the fields below if a different position, description, max (sign up count), information, and/or active
+            field is desired for the new slots. Leaving the fields blank will cause the original slot values to be used.
+          </p>
           <div class="form-row">
             <f.input @name="newPositionId" @label="Position" @type="select" @options={{this.positionOptionsForCopy}}
                      @grid="col-auto"/>
             <f.input @name="description" @label="Description" @type="text" @maxlength={{40}} @size={{40}}
                      @grid="col-auto"/>
-            <f.input @name="max" @label="Max" @type="number" @maxlength={{3}} @size=3 @grid="col-2"/>
+            <f.input @name="max" @label="Max" @type="number" @maxlength={{3}} @size={{3}} @grid="col-2"/>
           </div>
           <div class="form-row">
-            <f.input @name="url" @label="Information" @type="textarea" @rows=3 @cols=80 @maxlength=512
+            <f.input @name="url" @label="Information" @type="textarea" @rows={{3}} @cols={{80}} @maxlength={{512}}
                      @wrapClass="col-12"/>
           </div>
-          <div class="form-row">
+          <div class="form-row my-2">
+            <div class="col-auto">
             <f.input @name="activate" @label="Activate new slots" @type="checkbox"/>
+            </div>
           </div>
           Labor Day of {{this.year}} is {{this.selectedYearLaborDay}}.
           Labor Day of {{this.presentYear}} is {{this.presentYearLaborDay}}, {{this.laborDayDiff}} days later.

--- a/app/utils/labor-day.js
+++ b/app/utils/labor-day.js
@@ -2,7 +2,7 @@ import dayjs from 'dayjs';
 
 export default function laborDay(year) {
   for (let i = 1; i <= 7; i++) {
-    let day = dayjs({ year, month: 8, day: i});
+    const day = dayjs({ year, month: 8, day: i});
     if (day.day() === 1) { // first Monday of September
       return day;
     }


### PR DESCRIPTION
- Fixed CSS so only the sidebar link text is underlined on hover. The icon is not being highlighted so the space between the icon and text was highlighted and looked bad.
- Added the no-appreciation-icon legend to each shift sign up section.
- Switched the callsign-list css selector from a flex layout to a column count method.
- Dayjs was missing the Object Support plugin causing the laborDay() method to fail.
- Added an explanation on the Copy Slots dialog to what the override fields do.
- The setup to a create a new position was causing the type field to be blank by not supplying a default.