### PR TITLE
Switch dependabot dependency check to be "direct" not "all".

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     allow:
-      - dependency-type: "all"
+      - dependency-type: "direct"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10


### PR DESCRIPTION
"direct" reports on out dated indirect dependencies which can be problematic.