### PR TITLE
Performance tweaks and UI cleanups.

### DIFF
--- a/app/components/hq-visits-table.hbs
+++ b/app/components/hq-visits-table.hbs
@@ -12,7 +12,7 @@
     </tr>
   </thead>
   <tbody>
-    {{#each @visits as |visit|}}
+    {{#each @visits key="period" as |visit|}}
       <tr class="{{if (and (not visit.windows) (not visit.shorts) (not visit.leads)) "bg-highlight"}}">
         <td>
           {{if (and (not visit.windows) (not visit.shorts) (not visit.leads)) (fa-icon "exclamation-triangle")}}

--- a/app/components/person/timesheet-manage.hbs
+++ b/app/components/person/timesheet-manage.hbs
@@ -21,7 +21,7 @@
     </tr>
     </thead>
     <tbody>
-    {{#each @timesheets as |ts|}}
+    {{#each @timesheets key="id" as |ts|}}
       <tr>
         <td>
           {{#if ts.off_duty}}

--- a/app/components/schedule-manage.hbs
+++ b/app/components/schedule-manage.hbs
@@ -58,7 +58,7 @@
         </div>
 
         <p>Showing {{this.viewSlots.length}} of {{this.availableSlots.length}}</p>
-        {{#each this.positions as |position|}}
+        {{#each this.positions key="position_id" as |position|}}
           <SchedulePositionList @position={{position}}
                                 @showPeople={{this.showPeople}}
                                 @joinSlot={{this.joinSlot}}

--- a/app/components/schedule-position-list.hbs
+++ b/app/components/schedule-position-list.hbs
@@ -17,7 +17,7 @@
         <div class="schedule-signups">Sign Ups</div>
         <div class="schedule-actions">Actions</div>
       </div>
-      {{#each @position.slots as |slot|}}
+      {{#each @position.slots key="id" as |slot|}}
         <div class="schedule-row {{if slot.person_assigned "table-success"}}" id="slot-{{slot.id}}">
           <div class="schedule-icon">
             {{#if slot.person_assigned}}

--- a/app/components/status-change-table.hbs
+++ b/app/components/status-change-table.hbs
@@ -30,7 +30,7 @@
       </tr>
       </thead>
       <tbody>
-      {{#each @people as |person|}}
+      {{#each @people key="id" as |person|}}
         <tr class="{{if person.error "bg-danger"}}">
           <td>
             {{#if person.converted}}

--- a/app/routes/reports/languages.js
+++ b/app/routes/reports/languages.js
@@ -1,11 +1,11 @@
 import ClubhouseRoute from 'clubhouse/routes/clubhouse-route';
 
 export default class ReportsLanguagesRoute extends ClubhouseRoute {
-    model() {
-      return this.ajax.request('person/languages');
-    }
+  model() {
+    return this.ajax.request('person/languages');
+  }
 
-    setupController(controller,model) {
-      controller.set('languages', model.languages);
-    }
+  setupController(controller, model) {
+    controller.set('languages', model.languages);
+  }
 }

--- a/app/routes/reports/on-duty.js
+++ b/app/routes/reports/on-duty.js
@@ -27,8 +27,8 @@ export default class ReportsOnDutyRoute extends ClubhouseRoute {
   }
 
   setupController(controller, model) {
-    const positions = _.sortBy(_.map(_.groupBy(model.timesheet, (ts) => ts.position.title), (timesheets, title) => {
-      return {title, timesheets};
+    const positions = _.sortBy(_.map(_.groupBy(model.timesheet, (ts) => ts.position_id), (timesheets, position_id) => {
+      return {id: position_id, title: timesheets[0].position.title, timesheets};
     }), ['title']);
 
     controller.set('positions', positions);

--- a/app/routes/reports/people-by-location.js
+++ b/app/routes/reports/people-by-location.js
@@ -13,6 +13,7 @@ export default class ReportsPeopleByLocationRoute extends ClubhouseRoute {
     }
 
     setupController(controller, model) {
+      controller.set('isRendering', false);
       controller.set('year', this.year);
       controller.set('people', model.people);
       controller.set('filter', 'all');

--- a/app/routes/reports/schedule-by-callsign.js
+++ b/app/routes/reports/schedule-by-callsign.js
@@ -14,10 +14,19 @@ export default class ReportsScheduleByCallsignRoute extends ClubhouseRoute {
   }
 
   setupController(controller, model) {
-    controller.set('year', this.year);
-    super.setupController(...arguments);
+    const { people, positions, slots} = model;
 
-    controller.set('people', model.people);
+    Object.keys(slots).forEach( (slotId) => {
+      const slot = slots[slotId];
+        slot.position = positions[slot.position_id];
+    });
+
+    people.forEach((person) => {
+      person.slots = person.slot_ids.map((slotId) => slots[slotId]);
+    });
+
+    controller.set('year', this.year);
+    controller.set('people', people);
     controller.set('isExpanding', false);
     controller.set('expandAll', false);
   }

--- a/app/routes/reports/timesheet-by-callsign.js
+++ b/app/routes/reports/timesheet-by-callsign.js
@@ -13,7 +13,13 @@ export default class ReportsTimesheetByCallsignRoute extends ClubhouseRoute {
   }
 
   setupController(controller, model) {
-    controller.set('people', model.people);
+    const { people, positions } = model;
+
+    people.forEach((person) => {
+      person.timesheet.forEach((t) => t.position = positions[t.position_id])
+    });
+
+    controller.set('people', people);
     controller.set('year', this.year);
   }
 

--- a/app/routes/reports/timesheet-by-position.js
+++ b/app/routes/reports/timesheet-by-position.js
@@ -13,7 +13,11 @@ export default class ReportsTimesheetByPositionRoute extends ClubhouseRoute {
   }
 
   setupController(controller, model) {
-    controller.set('positions', model.positions);
+    const { positions, people} = model;
+    positions.forEach((position) => {
+      position.timesheets.forEach((t) => t.person = people[t.person_id]);
+    })
+    controller.set('positions', positions);
     controller.set('year', this.year);
   }
 

--- a/app/services/house.js
+++ b/app/services/house.js
@@ -64,8 +64,10 @@ export default class HouseService extends Service {
     } else if (response instanceof TimeoutError ||
       response instanceof AbortError ||
       isAbortError(response) ||
-      isTimeoutError(response)) {
-      // Ajax Error
+      isTimeoutError(response) ||
+      (response.name === 'NetworkError' || response.message?.match(/NetworkError/))
+    ) {
+      // Offline errors.
       responseErrors = 'The request to the Clubhouse server could not be completed. The server might be offline or the Internet connection is spotty.';
       errorType = 'server';
     } else if (response instanceof NotFoundError) {

--- a/app/templates/admin/credits.hbs
+++ b/app/templates/admin/credits.hbs
@@ -59,7 +59,7 @@
           </tr>
           </thead>
           <tbody>
-          {{#each position.credits as |credit|}}
+          {{#each position.credits key="id" as |credit|}}
             <tr id="credit-{{credit.id}}">
               <td class="w-5">{{credit.id}}</td>
               <td class="w-15">{{shift-format credit.start_time}}</td>

--- a/app/templates/admin/hours-credits.hbs
+++ b/app/templates/admin/hours-credits.hbs
@@ -28,7 +28,7 @@
     </thead>
 
     <tbody>
-      {{#each this.people as |person|}}
+      {{#each this.people key="id" as |person|}}
         <tr>
           <td><PersonLink @person={{person}} /></td>
           <td>{{mail-to person.email}}</td>

--- a/app/templates/admin/positions.hbs
+++ b/app/templates/admin/positions.hbs
@@ -38,7 +38,7 @@ Showing {{this.viewPositions.length}} of {{this.positions.length}} positions
     </thead>
 
     <tbody>
-    {{#each this.viewPositions as |position|}}
+    {{#each this.viewPositions key="id" as |position|}}
       <tr>
         <td class="text-right">{{position.id}}</td>
         <td>{{position.title}}</td>

--- a/app/templates/admin/slots.hbs
+++ b/app/templates/admin/slots.hbs
@@ -81,7 +81,7 @@
           </tr>
           </thead>
           <tbody>
-          {{#each position.slots as |slot|}}
+          {{#each position.slots key="id" as |slot|}}
             <tr id="slot-{{slot.id}}">
               <td>{{slot.id}}</td>
               <td>{{shift-format slot.begins}}</td>

--- a/app/templates/me/timesheet.hbs
+++ b/app/templates/me/timesheet.hbs
@@ -34,7 +34,7 @@
       <div class="timesheet-credits">Credits</div>
       <div class="timesheet-position">Position</div>
     </div>
-    {{#each this.timesheets as |ts|}}
+    {{#each this.timesheets key="id" as |ts|}}
       <div class="timesheet-entry">
         <div class="timesheet-row">
           <div class="timesheet-time">{{shift-format ts.on_duty}}</div>

--- a/app/templates/reports/alpha-shirts.hbs
+++ b/app/templates/reports/alpha-shirts.hbs
@@ -25,7 +25,7 @@
     </thead>
 
     <tbody>
-      {{#each this.alphas as |person|}}
+      {{#each this.alphas key="id" as |person|}}
         <tr>
           <td><PersonLink @person={{person}} /></td>
           <td>{{person.status}}</td>

--- a/app/templates/reports/flakes.hbs
+++ b/app/templates/reports/flakes.hbs
@@ -36,77 +36,87 @@
 
 {{#each this.positions as |position|}}
   <div class="max-width-700">
-  <ChAccordion as |accordion|>
-    <accordion.title>{{position.title}}</accordion.title>
-    <accordion.body>
-      <table class="table table-sm">
-        <thead>
-        <tr>
-          <th>From</th>
-          <th>To</th>
-          <th>Description</th>
-          <th class="text-right">Signed Up</th>
-          <th class="text-right">Max</th>
-        </tr>
-        </thead>
-        <tbody>
-        {{#each position.slots as |slot|}}
-          <tr>
-            <td>{{shift-format slot.begins}}</td>
-            <td>{{shift-format slot.ends}}</td>
-            <td>{{slot.description}}</td>
-            <td class="text-right">{{slot.signed_up}}</td>
-            <td class="text-right">{{slot.max}}</td>
-          </tr>
-          <tr class="tr-no-border">
-            <td colspan="5">
+    <ChAccordion as |accordion|>
+      <accordion.title>{{position.title}}</accordion.title>
+      <accordion.body>
+        {{#if accordion.isOpen}}
+          {{#each position.slots key="id" as |slot idx|}}
+            <table class="table table-sm">
+              <thead>
+              <tr>
+                <th>From</th>
+                <th>To</th>
+                <th>Description</th>
+                <th class="text-right">Signed Up</th>
+                <th class="text-right">Max</th>
+              </tr>
+              </thead>
+              <tbody>
+              <tr>
+                <td>{{shift-format slot.begins}}</td>
+                <td>{{shift-format slot.ends}}</td>
+                <td>{{slot.description}}</td>
+                <td class="text-right">{{slot.signed_up}}</td>
+                <td class="text-right">{{slot.max}}</td>
+              </tr>
+              </tbody>
+            </table>
+            <div class="ml-1 {{unless idx "mb-2"}}">
               {{#if slot.checked_in}}
-                <b>Signed up &amp; in ({{slot.checked_in.length}}):</b>
-                {{#each slot.checked_in as |person idx|}}
-                  {{~if idx ", "}}<span class="d-inline-block"><PersonLink @person={{person}} /> ({{time-format
-                        person.timesheet.on_duty}})</span>
-                {{/each}}
+                <h6>Signed up &amp; in ({{slot.checked_in.length}})</h6>
+                <div class="callsign-list">
+                  {{#each slot.checked_in key="id" as |person|}}
+                    <div>
+                      <PersonLink @person={{person}} /><br>
+                      ({{time-format person.timesheet.on_duty}})
+                    </div>
+                  {{/each}}
+                </div>
               {{else if slot.signed_up}}
-                <b class="text-danger">No scheduled sign ups on shift.</b>
+                <div class="text-danger mb-1">No scheduled sign ups on shift.</div>
               {{else}}
-                <b class="text-danger">No shift sign ups.</b>
+                <div class="text-danger mb-1">No shift sign ups.</div>
               {{/if}}
-              <br>
               {{#if slot.different_shift}}
-                <b>Went on different shift ({{slot.different_shift.length}}):</b>
-                {{#each slot.different_shift as |person idx|}}
-                  {{~if idx ", "}}<span class="d-inline-block"><PersonLink
-                        @person={{person}} /> ({{person.timesheet.position_title}} @ {{time-format
-                        person.timesheet.on_duty}})</span>
-                {{/each}}
-                <br>
+                <h6>Went on different shift ({{slot.different_shift.length}}):</h6>
+                <div class="row mb-1">
+                  {{#each slot.different_shift key="id" as |person|~}}
+                    <div class="col-auto">
+                      <PersonLink @person={{person}} />
+                      <br>
+                      ({{person.timesheet.position_title}} @ {{time-format person.timesheet.on_duty}})
+                    </div>
+                  {{~/each}}
+                </div>
               {{/if}}
               {{#if slot.rogues}}
-                <b>Rogues / Overlaps ({{slot.rogues.length}}):</b>
-                {{#each slot.rogues as |person idx|}}
-                  {{~if idx ", "}}<span class="d-inline-block"><PersonLink @person={{person}} /> ({{dayjs
-                        person.on_duty "ddd DD @ HH:MM"}} -
-                  {{if person.off_duty (dayjs person.off_duty "ddd DD @ HH:MM") "now"}})</span>
-                {{~/each}}
-                <br>
+                <h6>Rogues / Overlaps ({{slot.rogues.length}}):</h6>
+                <div class="row mb-1">
+                  {{#each slot.rogues key="id" as |person|}}
+                    <div class="col-auto">
+                      <PersonLink @person={{person}} />
+                      <br>
+                      ({{dayjs-format person.on_duty "ddd DD @ HH:MM"}} -
+                      {{if person.off_duty (dayjs-format person.off_duty "ddd DD @ HH:MM") "now"}})
+                    </div>
+                  {{~/each}}
+                </div>
               {{/if}}
               {{#if slot.not_present}}
-                <b>Flakes ({{slot.not_present.length}}):</b>
-                {{#each slot.not_present as |person idx|}}
-                  {{~if idx ", "}}
-                  <PersonLink @person={{person}} />
-                {{/each}}
+                <h6>Flakes ({{slot.not_present.length}}):</h6>
+                <div class="callsign-list">
+                  {{#each slot.not_present key="id" as |person|}}
+                    <PersonLink @person={{person}} />
+                  {{/each}}
+                </div>
               {{else if slot.signed_up}}
                 <b class="text-success">No flakes.</b>
               {{/if}}
-              <br>
-            </td>
-          </tr>
-        {{/each}}
-        </tbody>
-      </table>
-    </accordion.body>
-  </ChAccordion>
+            </div>
+          {{/each}}
+        {{/if}}
+      </accordion.body>
+    </ChAccordion>
   </div>
 {{else}}
   <p class="mt-2">

--- a/app/templates/reports/languages.hbs
+++ b/app/templates/reports/languages.hbs
@@ -4,25 +4,29 @@
   This page will show all languages spoken by people marked as on site.
 </p>
 <p>
-  Use the <LinkTo @route="search.languages">Search Languages</LinkTo> page to search for people who speak a specific language and whom may or may not be on site, have a radio, etc.
+  Use the
+  <LinkTo @route="search.languages">Search Languages</LinkTo>
+  page to search for people who speak a specific language and whom may or may not be on site, have a radio, etc.
 </p>
 
 {{#each this.languages as |language|}}
-  <div class="border mb-2">
-    <div class="bg-light-gray p-2">
-      <a href class="h4" {{action this.toggleLanguage language}}>{{fa-icon (if language.showing "minus" "plus")}} {{language.language}}</a> ({{pluralize language.people.length "person"}})
-    </div>
-
-    <div class="row p-2 {{unless language.showing "d-none"}}">
-      {{#each language.people as |person|}}
-        <div class="col-sm-6 col-md-3 col-lg-2">
+  <ChAccordion as |Accordion|>
+    <Accordion.title>{{language.language}} ({{language.people.length}})</Accordion.title>
+    <Accordion.body>
+      <div class="callsign-list">
+        {{#each language.people key="id" as |person|}}
           <PersonLink @person={{person}} />
-        </div>
-      {{/each}}
-    </div>
-  </div>
+        {{/each}}
+      </div>
+    </Accordion.body>
+  </ChAccordion>
 {{else}}
   <p class="text-danger">
-    <b>It appears there are no people marked as on site. Try using the <LinkTo @route="search.languages">Search Languages</LinkTo> to find the language.</b>
+    <b>
+      It appears there are no people marked as on site.
+      Try using the
+      <LinkTo @route="search.languages">Search Languages</LinkTo>
+      to find the language.
+    </b>
   </p>
 {{/each}}

--- a/app/templates/reports/on-duty.hbs
+++ b/app/templates/reports/on-duty.hbs
@@ -33,50 +33,52 @@
   </button>
 
 </p>
-{{#each this.positions as |position|}}
+{{#each this.positions key="id" as |position|}}
   <div class="max-width-700">
-  <ChAccordion as |accordion|>
-    <accordion.title>
-      {{position.title}} - {{pluralize position.timesheets.length "person"}}
-    </accordion.title>
-    <accordion.body>
-      <table class="table table-sm table-striped table-hover table-width-auto">
-        <thead>
-        <tr>
-          <th class="w-25">Callsign</th>
-          {{#if this.duty_date}}
-            <th class="w-30">On Duty</th>
-            <th class="w-30">Off Duty</th>
-          {{else}}
-            <th class="w-60">On Duty Since</th>
-          {{/if}}
-          <th class="text-right w-15">Duration</th>
-        </tr>
-        </thead>
+    <ChAccordion as |accordion|>
+      <accordion.title>
+        {{position.title}} - {{pluralize position.timesheets.length "person"}}
+      </accordion.title>
+      <accordion.body>
+        {{#if accordion.isOpen}}
+          <table class="table table-sm table-striped table-hover table-width-auto">
+            <thead>
+            <tr>
+              <th class="w-25">Callsign</th>
+              {{#if this.duty_date}}
+                <th class="w-30">On Duty</th>
+                <th class="w-30">Off Duty</th>
+              {{else}}
+                <th class="w-60">On Duty Since</th>
+              {{/if}}
+              <th class="text-right w-15">Duration</th>
+            </tr>
+            </thead>
 
-        <tbody>
-        {{#each position.timesheets as |ts|}}
-          <tr>
-            <td class="w-25">
-              <PersonLink @person={{ts.person}} />
-            </td>
-            <td class={{if this.duty_date "w-30" "w-60"}}>{{shift-format ts.on_duty}}</td>
-            {{#if this.duty_date}}
-              <td class="w-30">
-                {{#if ts.off_duty}}
-                  {{shift-format ts.off_duty}}
-                {{else}}
-                  <i>On Duty</i>
+            <tbody>
+            {{#each position.timesheets key="id" as |ts|}}
+              <tr>
+                <td class="w-25">
+                  <PersonLink @person={{ts.person}} />
+                </td>
+                <td class={{if this.duty_date "w-30" "w-60"}}>{{shift-format ts.on_duty}}</td>
+                {{#if this.duty_date}}
+                  <td class="w-30">
+                    {{#if ts.off_duty}}
+                      {{shift-format ts.off_duty}}
+                    {{else}}
+                      <i>On Duty</i>
+                    {{/if}}
+                  </td>
                 {{/if}}
-              </td>
-            {{/if}}
-            <td class="w-15 text-right">{{hour-minute-format ts.duration}}</td>
-          </tr>
-        {{/each}}
-        </tbody>
-      </table>
-    </accordion.body>
-  </ChAccordion>
+                <td class="w-15 text-right">{{hour-minute-format ts.duration}}</td>
+              </tr>
+            {{/each}}
+            </tbody>
+          </table>
+        {{/if}}
+      </accordion.body>
+    </ChAccordion>
   </div>
 {{else}}
   <p>

--- a/app/templates/reports/people-by-location.hbs
+++ b/app/templates/reports/people-by-location.hbs
@@ -5,7 +5,7 @@
   </div>
   <div class="col-auto">
     <ChForm::Select @name="filter" @value={{this.filter}} @options={{this.filterOptions}}
-                    @onChange={{action (mut this.filter)}} @controlClass="form-control"/>
+                    @onChange={{action this.updateFilter}} @controlClass="form-control"/>
   </div>
   <div class="col-auto">
     <button type="button" class="btn btn-primary" disabled={{if this.viewPeople false true}}
@@ -19,7 +19,7 @@
 </div>
 
 Showing {{this.viewPeople.length}} of {{this.people.length}}.
-{{#each this.countries as |country idx|}}
+{{#each this.countries key="country" as |country idx|}}
   <ChAccordion id="country-{{idx}}" as |accordion|>
     <accordion.title>
       {{country.full_name}} ({{pluralize country.people.length "person"}})
@@ -45,7 +45,7 @@ Showing {{this.viewPeople.length}} of {{this.people.length}}.
         </tr>
         </thead>
         <tbody>
-        {{#each country.people as |person|}}
+        {{#each country.people key="id" as |person|}}
           <tr>
             <td>
               <PersonLink @person={{person}} />
@@ -73,3 +73,12 @@ Showing {{this.viewPeople.length}} of {{this.people.length}}.
     </accordion.body>
   </ChAccordion>
 {{/each}}
+
+{{#if this.isRendering}}
+  <ModalDialog as |Modal|>
+    <Modal.body>
+      Hang Tight - Filtering the list
+      <SpinIcon/>
+    </Modal.body>
+  </ModalDialog>
+{{/if}}

--- a/app/templates/reports/people-by-position.hbs
+++ b/app/templates/reports/people-by-position.hbs
@@ -60,7 +60,7 @@
             </p>
           {{/if}}
           <div class="callsign-list">
-            {{#each position.visiblePeople as |person|}}
+            {{#each position.visiblePeople key="id" as |person|}}
               <div>
                 <PersonLink @person={{person}} /> {{#if person.on_site}}{{fa-icon "check" color="success"}}{{/if}}<br>
                 &lt;{{person.status}}&gt;

--- a/app/templates/reports/people-by-role.hbs
+++ b/app/templates/reports/people-by-role.hbs
@@ -5,7 +5,7 @@
     <accordion.title>{{role.title}} ({{pluralize role.people.length "person"}})</accordion.title>
     <accordion.body>
       <div class="callsign-list">
-        {{#each role.people as |person|}}
+        {{#each role.people key="id" as |person|}}
           <div>
             <PersonLink @person={{person}} />
           </div>

--- a/app/templates/reports/potential-shirts.hbs
+++ b/app/templates/reports/potential-shirts.hbs
@@ -31,7 +31,7 @@ Showing  {{pluralize this.people.length "person"}}
   </thead>
 
   <tbody>
-  {{#each this.people as |person|}}
+  {{#each this.people key="id" as |person|}}
     <tr>
       <td>
         <PersonLink @person={{person}} />

--- a/app/templates/reports/radio-assets.hbs
+++ b/app/templates/reports/radio-assets.hbs
@@ -17,7 +17,7 @@
   </tr>
   </thead>
   <tbody>
-  {{#each (if this.summary this.radioSummaries this.assets) as |asset|}}
+  {{#each (if this.summary this.radioSummaries this.assets) key="id" as |asset|}}
     <tr>
       <td>{{asset.barcode}}</td>
       {{#if this.summary}}

--- a/app/templates/reports/sandman-qualified.hbs
+++ b/app/templates/reports/sandman-qualified.hbs
@@ -36,7 +36,7 @@
   </tr>
   </thead>
   <tbody>
-  {{#each this.viewPeople as |person|}}
+  {{#each this.viewPeople key="id" as |person|}}
     <tr>
       <td>
         <PersonLink @person={{person}} />

--- a/app/templates/reports/schedule-by-callsign.hbs
+++ b/app/templates/reports/schedule-by-callsign.hbs
@@ -14,9 +14,9 @@
   Showing {{pluralize this.people.length "person"}}
 </p>
 <div class="max-width-900">
-  {{#each this.people as |person|}}
+  {{#each this.people key="id" as |person|}}
     <ChAccordion id="person-{{person.id}}" as |accordion|>
-      <accordion.title>{{person.callsign}} </accordion.title>
+      <accordion.title>{{person.callsign}} &lt;{{person.status}}&gt; </accordion.title>
       <accordion.body>
         <p>
           <LinkTo @route="person.index" @model={{person.id}}>
@@ -37,7 +37,7 @@
           </tr>
           </thead>
           <tbody>
-          {{#each person.slots as |slot|}}
+          {{#each person.slots key="id" as |slot|}}
             <tr>
               <td>{{shift-format slot.begins}}</td>
               <td>{{shift-format slot.ends}}</td>

--- a/app/templates/reports/shift-coverage.hbs
+++ b/app/templates/reports/shift-coverage.hbs
@@ -47,7 +47,7 @@
                     {{#if (gt position.shifts.length 1)}}
                       <small class="d-inline-block">{{dayjs-format shift.begins "HH:mm"}} - {{dayjs-format shift.ends "HH:mm"}}</small><br>
                     {{/if}}
-                    {{#each shift.people as |person|~}}
+                    {{#each shift.people key="id" as |person|~}}
                       <PersonLink @person={{person}} />
                       {{~#if person.parenthetical}} ({{person.parenthetical}}){{/if~}}
                       <br>

--- a/app/templates/reports/shift-signups.hbs
+++ b/app/templates/reports/shift-signups.hbs
@@ -10,7 +10,7 @@
 <button type="button" class="btn btn-primary" {{action this.exportToCSV}}>Export to CSV</button>
 {{! template-lint-disable table-groups}}
 <table class="table table-sm table-hover table-width-auto mt-2">
-  {{#each this.positions as |position|}}
+  {{#each this.positions key="id" as |position|}}
     <thead>
     <tr>
       <th>Position</th>

--- a/app/templates/reports/timesheet-by-callsign.hbs
+++ b/app/templates/reports/timesheet-by-callsign.hbs
@@ -14,7 +14,7 @@
 <p>
   [hh:mm] = Time does not count towards appreciations.
 </p>
-{{#each this.people as |person|}}
+{{#each this.people key="id" as |person|}}
   <div class="max-width-700">
     <ChAccordion id="person-{{person.id}}" as |accordion|>
       <accordion.title>{{person.callsign}}</accordion.title>

--- a/app/templates/reports/timesheet-by-position.hbs
+++ b/app/templates/reports/timesheet-by-position.hbs
@@ -2,7 +2,7 @@
 <p>
   Showing {{pluralize this.positions.length "position"}}
 </p>
-{{#each this.positions as |position|}}
+{{#each this.positions key="id" as |position|}}
   <div class="max-width-700">
     <ChAccordion as |accordion|>
       <accordion.title>{{position-label position}} ({{pluralize position.timesheets.length "entry"}})</accordion.title>
@@ -24,7 +24,7 @@
             </tr>
             </thead>
             <tbody>
-            {{#each position.timesheets as |entry|}}
+            {{#each position.timesheets key="id" as |entry|}}
               <tr>
                 <td>{{shift-format entry.on_duty}}</td>
                 <td>

--- a/app/templates/reports/timesheet-totals.hbs
+++ b/app/templates/reports/timesheet-totals.hbs
@@ -16,8 +16,8 @@ Showing {{pluralize this.people.length "person"}}
     </tr>
   </thead>
   <tbody>
-    {{#each this.people as |person|}}
-      {{#each person.positions as |pos idx|}}
+    {{#each this.people key="id" as |person|}}
+      {{#each person.positions key="id" as |pos idx|}}
         <tr>
           {{#unless idx}}
             <td rowspan="{{add person.positions.length 1}}">

--- a/app/templates/training/session/index.hbs
+++ b/app/templates/training/session/index.hbs
@@ -148,7 +148,7 @@
     </thead>
 
     <tbody>
-    {{#each this.students as |student|}}
+    {{#each this.students key="id" as |student|}}
       <tr class="{{if (or student.is_retired student.is_inactive) "bg-highlight"}}">
         <td class="w-15">
           {{#if (or student.is_retired student.is_inactive)}}

--- a/app/utils/log-error.js
+++ b/app/utils/log-error.js
@@ -20,7 +20,8 @@ export default function logError(error, type) {
     || isTimeoutError(error)
     || isForbiddenError(error)
     || isUnauthorizedError(error)
-    || error.name === 'NetworkError'
+    // Offline errors..
+    || (error.name === 'NetworkError' || error.message?.match(/NetworkError/))
     || +error.status === 403) {
     // Don't record timeouts, unauthorized requests (aka expired authorization tokens), or offline errors.
     return;


### PR DESCRIPTION
- Added the #each key parameter to assist with rendering performance on a bunch of reports.
- Switched over reports/lanaguages to use the ChAccordion component
- Several report APIs now split out repeating inline joined table columns into their own response to reduce both the time to build the json response and size of the payload. (e.g., before timesheet={ on_duty: xxxx, position_title: "AAAA", position_active: true} -> timesheet={on_duty: xxxx, position_id: 999}, positions = { 999: { title: "AAA", active: true} })