### PR TITLE
Various HQ Window interface changes and bug fixes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
-# Clubhouse 2.0 - A Single Page Application (SPA) frontend
+# The Black Rock Rangers Clubhouse 2.0 - A Single Page Application (SPA) frontend
 
 [![Build Status](https://github.com/burningmantech/ranger-clubhouse-web/workflows/CI%2fCD/badge.svg)](https://github.com/burningmantech/ranger-clubhouse-web/actions)
+
+The Clubhouse is a volunteer coordination website to help manage the Burning Man Project's Black Rock Rangers department.
+
+Want to know more about the Rangers? [Visit the Rangers' website](https://rangers.burningman.org) for more information.
 
 This README outlines the details of collaborating on this Ember application.
 A short introduction of this app could easily go here.

--- a/app/components/appreciation-progress.hbs
+++ b/app/components/appreciation-progress.hbs
@@ -7,7 +7,7 @@
       Certain shifts such as Training sessions and On Call positions fall into this category.
     </ChNotice>
   {{/if}}
-  <table class="table table-sm table-hover">
+  <table class="table table-hover">
     <thead>
     <tr>
       <th class="w-40">Tickets</th>
@@ -24,7 +24,7 @@
     <AppreciationProgressRow @item={{this.staffCredential}} @name="Staff Credential"/>
     </tbody>
   </table>
-  <table class="table table-sm table-hover">
+  <table class="table table-hover">
     <thead>
     <tr>
       <th class="w-40">Meal Passes</th>
@@ -43,7 +43,7 @@
                              @subtext="(pre/event/post-week hours)"/>
     </tbody>
   </table>
-  <table class="table table-sm table-hover">
+  <table class="table table-hover">
     <thead>
     <tr>
       <th class="w-40">Org Shower Access</th>
@@ -58,7 +58,7 @@
     <AppreciationProgressRow @item={{this.showerAccess}} @name="Wet Spot Access for NEXT event"/>
     </tbody>
   </table>
-  <table class="table table-sm table-hover">
+  <table class="table table-hover">
     <thead>
     <tr>
       <th class="w-40">Ranger Clothing</th>

--- a/app/components/autocomplete-input.hbs
+++ b/app/components/autocomplete-input.hbs
@@ -25,12 +25,11 @@
            autocomplete="off"
            spellcheck="false"
     />
-
-    {{#if @appendSearchIcon}}
+    {{~#if @appendSearchIcon~}}
       <div class="input-group-append">
         <span class="input-group-text">{{fa-icon "search"}}</span>
       </div>
-    {{/if}}
+    {{~/if~}}
   </div>
   {{#if (and this.isFocused (or this.isSearching this.noResultsFound this.options))}}
     <div class="autocomplete-results-box mt-1 border rounded"
@@ -38,12 +37,12 @@
       {{will-destroy this.resultsBoxDestroy}}
     >
       <div class="autocomplete-list">
-        {{#if this.noResultsFound}}
+        {{~#if this.noResultsFound~}}
           <div>No results found</div>
-        {{else if this.isSearching}}
+        {{~else if this.isSearching~}}
           <div class="text-muted">Searching {{fa-icon "spinner" spin=true}}</div>
-        {{/if}}
-        {{#each this.options as |opt idx|}}
+        {{~/if~}}
+        {{~#each this.options as |opt idx|~}}
           <div class="{{if (eq idx this.selectionIdx) "autocomplete-option-selected"}}"
                data-result-id={{idx}}
                role="link"
@@ -51,9 +50,9 @@
             {{!template-lint-disable no-down-event-binding}}
             {{on "mousedown" (fn this.clickSelection opt)}}
           >
-            {{yield opt}}
+            {{~yield opt~}}
           </div>
-        {{else}}
+        {{~else~}}
           {{#if (and (not this.noResultsFound) (not this.isSearching))}}
             <div class="text-muted">Start typing to search</div>
           {{/if}}

--- a/app/components/ch-form/field.hbs
+++ b/app/components/ch-form/field.hbs
@@ -129,6 +129,6 @@
   {{~/if~}}
 
   {{#each this.errorMessages as |msg|~}}
-    <div class="text-danger">&bullet; {{msg}}</div>
+    <div class="text-danger is-invalid">&bullet; {{msg}}</div>
   {{~/each~}}
 {{/if}}

--- a/app/components/hours-credits-breakdown.hbs
+++ b/app/components/hours-credits-breakdown.hbs
@@ -110,7 +110,7 @@
         <td class="text-right">{{hour-minute-format @timesheetSummary.post_event_duration}}</td>
       </tr>
       <tr>
-        <td colspan="2" class="pb-3">The hours have been earned during the post-event week (after Labor Day)
+        <td colspan="2" class="pb-3">The hours have been worked during the post-event week (after Labor Day)
         </td>
       </tr>
       <tr>

--- a/app/components/hq-provision-info.hbs
+++ b/app/components/hq-provision-info.hbs
@@ -1,0 +1,28 @@
+<dl class="row">
+  <dt class="col-auto">Meals</dt>
+  <dd class="col-auto">
+      {{#if this.hasEatItAll}}
+        <b class="text-danger">{{fa-icon "ban"}} NO MEAL POGS</b><br>
+        Has Eat-It-All BMID
+        {{else if this.onlyPogs}}
+        <b class="text-success">{{fa-icon "check"}} Pogs for every shift</b>
+      {{else}}
+        <span class="text-danger">{{fa-icon "ban"}} NO POGS FOR {{this.mealPogInfo.exclude}}</span><br>
+        <b class="text-success">{{fa-icon "check"}} Pogs for {{this.mealPogInfo.issue}} ONLY</b>
+      {{/if}}
+      {{#unless this.hasEatItAll}}
+        <br>
+        Full Pog: 6 or more hours<br>
+        Half Pog: less than 6 hours
+      {{/unless}}
+    </dd>
+  <dt class="col-auto">Showers</dt>
+    <dd class="col-auto">
+      {{#if @eventInfo.showers}}
+        <b class="text-danger">{{fa-icon "ban"}} NO SHOWER POGS</b><br>
+        Has Wet Spot Access BMID
+      {{else}}
+        Every 40 hours worked
+      {{/if}}
+    </dd>
+</dl>

--- a/app/components/hq-provision-info.js
+++ b/app/components/hq-provision-info.js
@@ -1,0 +1,44 @@
+import Component from '@glimmer/component';
+import {isEmpty} from '@ember/utils';
+
+const MEAL_POGS = {
+  'pre': {
+    exclude: 'PRE-EVENT',
+    issue: 'Event Week & Post-Event'
+  },
+  'pre+event': {
+    exclude: 'PRE-EVENT & EVENT WEEK',
+    issue: 'Post-Event'
+  },
+  'pre+post': {
+    exclude: 'PRE-EVENT & POST-EVENT',
+    issue: 'Event Week',
+  },
+  'event': {
+    exclude: 'EVENT WEEK',
+    issue: 'Pre-Event & Post-Event'
+  },
+  'event+post': {
+    exclude: 'EVENT WEEK & POST-EVENT',
+    issue: 'Pre-Event'
+  },
+  'post': {
+    exclude: 'PRE-EVENT & EVENT WEEK',
+    issue: 'Post-Event'
+  }
+}
+
+export default class HqProvisionInfoComponent extends Component {
+  get hasEatItAll() {
+    return this.args.eventInfo.meals === 'all';
+  }
+
+  get onlyPogs() {
+    return isEmpty(this.args.eventInfo.meals);
+  }
+
+  get mealPogInfo() {
+    console.log('MEALS POGS', this.args.eventInfo)
+    return MEAL_POGS[this.args.eventInfo.meals];
+  }
+}

--- a/app/components/person/timesheet-manage.js
+++ b/app/components/person/timesheet-manage.js
@@ -5,7 +5,6 @@ import {validatePresence} from 'ember-changeset-validations/validators';
 import validateDateTime from 'clubhouse/validators/datetime';
 import {tracked} from '@glimmer/tracking';
 import {inject as service} from '@ember/service';
-import {ONE_POSITIONS} from 'clubhouse/constants/positions';
 
 export default class PersonTimesheetManageComponent extends Component {
   @service ajax;
@@ -49,15 +48,10 @@ export default class PersonTimesheetManageComponent extends Component {
 
   @action
   editEntryAction(timesheet) {
-    const {positions, year} = this.args;
+    const {positions} = this.args;
 
-    if (+year === 2021) {
-      // TODO: Remove post ONE
-      this.positionOptions = positions.filter(p => ONE_POSITIONS.includes(+p.id)).map((p) => [p.title, p.id]);
-    } else {
-      // The positions the person can be part of
-      this.positionOptions = positions.map((p) => [p.title, p.id]);
-    }
+    // The positions the person can be part of
+    this.positionOptions = positions.map((p) => [p.title, p.id]);
 
     if (!positions.find((p) => p.id === timesheet.position_id)) {
       // Might be something like a mentee shift and the person no longer has the position grant, yet

--- a/app/components/progress-bar.hbs
+++ b/app/components/progress-bar.hbs
@@ -1,5 +1,6 @@
 {{! template-lint-disable no-inline-styles}}
-<div class="progress" style="height: 25px;">
+<div class="progress position-relative" style="height: 1.75em;">
   {{! template-lint-disable no-inline-styles  style-concatenation}}
-  <div class="progress-bar text-black bg-{{@type}} text-center" role="progressbar" style="width: {{@width}}%">{{@text}}</div>
+  <div class="progress-bar text-black bg-{{@type}}" role="progressbar" style="width: {{@width}}%"></div>
+  <span class="justify-content-center d-flex position-absolute w-100">{{@text}}</span>
 </div>

--- a/app/components/search-item-bar.hbs
+++ b/app/components/search-item-bar.hbs
@@ -19,23 +19,22 @@
                        @mode={{this.searchForm.mode}}
                        @appendSearchIcon={{true}}
                        as |item|>
-      {{#if (eq this.searchType "asset")}}
+      {{~#if (eq this.searchType "asset")~}}
         {{this.searchYear}} #{{item.barcode}} {{item.description}} {{item.type}}
-      {{else}}
-        {{#if (eq this.searchType "person-id")}}
+      {{~else~}}
+        {{~#if (eq this.searchType "person-id")~}}
           ID #{{item.id}} -
-        {{/if}}
-        <strong>{{item.callsign}}</strong>
-        &lt;{{item.first_name}} {{item.last_name}}, {{item.status}}&gt;
-        {{#if item.fka_match}}
-          <b>(FKA: {{item.fka_match}})</b>
-        {{/if}}
-        {{#if (eq item.email_match "full")}}
-          - email exact match
-        {{else if (eq item.email_match "partial")}}
-          - email partial match
-        {{/if}}
-      {{/if}}
+        {{~/if~}}
+        <b>{{item.callsign}}</b> &lt;{{item.first_name}} {{item.last_name}}, {{item.status}}&gt;
+        {{~#if item.fka_match~}}
+          <span class="ml-4 d-block">- FKA: {{item.fka_match}}</span>
+        {{~/if~}}
+        {{~#if (eq item.email_match "full")~}}
+          <span class="ml-4 d-block">- email exact match</span>
+        {{~else if (eq item.email_match "partial")~}}
+          <span class="ml-4 d-block">- email partial match</span>
+        {{~/if~}}
+      {{~/if~}}
     </AutocompleteInput>
     {{#if this.showSearchOptions}}
       <div class="bg-white p-2">

--- a/app/components/search-item-bar.js
+++ b/app/components/search-item-bar.js
@@ -24,6 +24,8 @@ const MODE_ROUTES = {
   'timesheet': 'person.timesheet'
 };
 
+const SEARCH_MODE_KEY = 'search-mode';
+
 class SearchForm {
   @tracked query = '';
   @tracked name = true;
@@ -61,9 +63,20 @@ export default class SearchItemBarComponent extends Component {
     super(...arguments);
 
     const onduty = this.session.user.onduty_position;
-    this.searchForm = new SearchForm({
-      mode: (onduty && (onduty.subtype === 'hq' || onduty.subtype === 'mentor')) ? 'hq' : 'account',
-    });
+
+    const savedMode = this.house.getKey(SEARCH_MODE_KEY);
+    const options = this.modeOptions;
+
+    let mode = '';
+    if (options.find((opt) => opt.value === savedMode)) {
+      mode = savedMode;
+    } else {
+      mode = (onduty && (onduty.subtype === 'hq' || onduty.subtype === 'mentor')) ? 'hq' : 'account';
+    }
+
+    this.house.setKey(SEARCH_MODE_KEY, mode);
+
+    this.searchForm = new SearchForm({mode});
 
     const searchPrefs = this.house.getKey('person-search-prefs');
     if (searchPrefs) {
@@ -75,6 +88,7 @@ export default class SearchItemBarComponent extends Component {
     });
 
     this._buildPlaceholder();
+
    }
 
   /**
@@ -134,6 +148,7 @@ export default class SearchItemBarComponent extends Component {
     this._buildPlaceholder();
 
     this.showSearchOptions = (this.searchForm.mode !== 'hq');
+    this.house.setKey(SEARCH_MODE_KEY, mode);
 
     if (!route.startsWith('person.') && !route.startsWith('hq.')) {
       return;

--- a/app/components/shift-check-in-out.hbs
+++ b/app/components/shift-check-in-out.hbs
@@ -68,11 +68,10 @@
       <p>
         {{pluralize @imminentSlots.length "upcoming shift"}} found.
       </p>
-      <table class="table table-hover table-striped table-sm m-0">
+      <table class="table table-width-auto table-hover table-striped m-0">
         <thead>
         <tr>
-          <th>Position</th>
-          <th class="w-25">Description</th>
+          <th>Shift</th>
           <th>Starts</th>
           <th>Ends</th>
           <th>Action</th>
@@ -82,8 +81,7 @@
         <tbody>
         {{#each @imminentSlots as |slot|}}
           <tr>
-            <td class="align-middle">{{slot.position_title}}</td>
-            <td class="w-25 align-middle">{{slot.slot_description}}</td>
+            <td class="align-middle">{{slot.position_title}}{{#if slot.slot_description}} - {{slot.slot_description}}{{/if}}</td>
             <td class="align-middle">{{shift-format slot.slot_begins}}</td>
             <td class="align-middle">{{shift-format slot.slot_ends}}</td>
             <td class="align-middle">
@@ -112,8 +110,8 @@
             {{#unless slot.is_within_start_time}}
               <tr>
                 <td colspan="5" class="text-danger">
-                  <b>WARNING: Most shifts may only be signed into within 15 minutes of the actual start time.
-                    The shift above can be signed into {{pluralize slot.can_start_in "minute"}} from now.</b>
+                  <b>WARNING: Most shifts may only be signed into within 15 minutes of the actual start time.<br>
+                    Suggest to {{@person.callsign}} they come back in {{pluralize slot.can_start_in "minute"}} to start their shift.</b>
                 </td>
               </tr>
             {{/unless}}
@@ -152,7 +150,7 @@
 {{#if this.showPositionDialog}}
   <ModalDialog @title="Update shift position" as |Modal|>
     <Modal.body>
-      Select the new position the on duty timesheet
+      Select the new position the shift should be updated to:
       <div class="form-row">
         <div class="col-auto">
           <ChForm::Select @name="newPositionId" @controlClass="form-control" @value={{this.newPositionId}}

--- a/app/constants/positions.js
+++ b/app/constants/positions.js
@@ -117,15 +117,3 @@ export const ONE_RSCI = 136;
 export const ONE_HQ_WINDOW = 137;
 export const ONE_OPS_MANAGER = 140;
 export const ONE_OPS_DEPUTY = 141;
-
-// TODO: REMOVE After ONE spins down
-export const ONE_POSITIONS = [
-  ONE_SHIFT_LEAD,
-  ONE_TROUBLESHOOTER,
-  ONE_GREEN_DOT,
-  ONE_GERLACH_PATROL_DIRT,
-  ONE_RSCI,
-  ONE_OPS_MANAGER,
-  ONE_OPS_DEPUTY,
-  ONE_HQ_WINDOW,
- ];

--- a/app/controllers/reports/schedule-by-callsign.js
+++ b/app/controllers/reports/schedule-by-callsign.js
@@ -33,7 +33,7 @@ export default class ReportsScheduleByCallsignController extends ClubhouseContro
   @action
   scrollToCallsign(id, event) {
     event.preventDefault();
-    this.house.scrollToElement(`#person-${id}`, false);
+    this.house.scrollToElement(`#person-${id}`, false, true);
   }
 
   get letterOptions() {

--- a/app/controllers/reports/schedule-by-position.js
+++ b/app/controllers/reports/schedule-by-position.js
@@ -94,7 +94,7 @@ export default class ReportsScheduleByPositionController extends ClubhouseContro
   @action
   scrollToPosition(id, event) {
     event.preventDefault();
-    this.house.scrollToElement(`#position-${id}`, true);
+    this.house.scrollToElement(`#position-${id}`, true, true);
   }
 
   @action

--- a/app/controllers/reports/timesheet-by-callsign.js
+++ b/app/controllers/reports/timesheet-by-callsign.js
@@ -6,7 +6,7 @@ export default class ReportsTimesheetByCallsignController extends ClubhouseContr
 
   @action
   scrollToCallsign(id) {
-    this.house.scrollToElement(`#person-${id}`, false);
+    this.house.scrollToElement(`#person-${id}`, false, true);
   }
 
   get letterOptions() {

--- a/app/routes/hq/shift.js
+++ b/app/routes/hq/shift.js
@@ -7,13 +7,9 @@ export default class HqShiftRoute extends ClubhouseRoute {
     const year = this.house.currentYear();
 
     return RSVP.hash({
-      imminentSlots: this.ajax.request(`person/${person_id}/schedule/imminent`)
-        .then((result) => result.slots),
+      imminentSlots: this.ajax.request(`person/${person_id}/schedule/imminent`).then((result) => result.slots),
       scheduleRecommendations: this.ajax.request(`person/${person_id}/schedule/recommendations`),
-      timesheetSummary: this.ajax.request(`person/${person_id}/timesheet-summary`, { data: { year }})
-        .then((result) => result.summary),
       timesheets: this.store.query('timesheet', { person_id, year }),
-      expected: this.ajax.request(`person/${person_id}/schedule/expected`),
     });
   }
 

--- a/app/services/house.js
+++ b/app/services/house.js
@@ -294,11 +294,12 @@ export default class HouseService extends Service {
    *
    * @param {string} selector Element ID to scroll to
    * @param {boolean} scroll [scroll=true] Use smooth scrolling (true) or jump scroll (false)
+   * @param {boolean} scrollToTop Scroll the element to top regardless if element is in view.
    */
 
-  scrollToElement(selector, scroll = true) {
+  scrollToElement(selector, scroll = true, scrollToTop = false) {
     run('afterRender', () => {
-      const element = document.querySelector(selector);
+      const element = (selector instanceof Element) ? selector : document.querySelector(selector);
       if (!element) {
         return;
       }
@@ -307,6 +308,9 @@ export default class HouseService extends Service {
 
       if (bottom > window.innerHeight || top < 0) {
         element.scrollIntoView({behavior: scroll ? 'smooth' : 'auto'});
+      } else if (scrollToTop) {
+        // Element is already in view, scroll element mostly to the top.
+        window.scroll({ top: top + window.scrollY - 100, behavior: scroll ? 'smooth' : 'auto'});
       }
     });
   }

--- a/app/templates/hq.hbs
+++ b/app/templates/hq.hbs
@@ -62,7 +62,7 @@
       {{outlet}}
     </div>
 
-    <div class="mt-4 ml-auto d-print-none pl-2">
+    <div class=" ml-auto d-print-none pl-4">
       <div class="mugshot">
         {{#if this.photo}}
           {{#if this.photo.photo_url}}
@@ -87,59 +87,56 @@
         {{/if}}
       </div>
       <dl>
-        <dt>Meal Pogs</dt>
+        <dt>Earned Credits</dt>
+        <dd>{{credits-format this.timesheetSummary.total_credits}}</dd>
+
+        <dt>Worked Hours</dt>
         <dd>
-          {{#if (eq this.meals "all")}}
-            <b class="text-danger">{{fa-icon "ban"}} NO POGS</b><br>
-            Has Eat-It-All BMID
-          {{else if (eq this.meals "pre")}}
-            <b class="text-danger">{{fa-icon "ban"}} NO POGS FOR PRE-EVENT</b><br>
-            Pogs for Event &amp; Post-Event
-          {{else if (eq this.meals "post")}}
-            <b class="text-danger">{{fa-icon "ban"}} NO POGS FOR POST-EVENT</b><br>
-            Pogs for Pre-Event &amp; Event Week
-          {{else if (eq this.meals "event")}}
-            <b class="text-danger">{{fa-icon "ban"}} NO POGS FOR EVENT WEEK</b><br>
-            Pogs for Pre- &amp; Post-Event
-          {{else if (eq this.meals "pre+event")}}
-            <b class="text-danger">{{fa-icon "ban"}} NO POGS FOR PRE- &amp; EVENT WEEK</b><br>
-            Pogs for Post-Event
-          {{else if (eq this.meals "event+post")}}
-            <b class="text-danger">{{fa-icon "ban"}} NO POGS FOR EVENT WEEK & POST-EVENT</b><br>
-            Pogs for Pre-Event
-          {{else if (eq this.meals "pre+post")}}
-            <b class="text-danger">{{fa-icon "ban"}} NO POGS FOR PRE- &AMP; POST-EVENT</b><br>
-            Pogs for Event Week
-          {{else}}
-            <span class="text-success">{{fa-icon "check"}} Pogs for every shift</span>
-          {{/if}}
-          {{#if (not-eq this.meals "all")}}
-            <br>
-            Full Pog: 6 or more hours<br>
-            &frac12; Pog: less than 6 hours
-          {{/if}}
+          {{hour-minute-format this.timesheetSummary.counted_duration}}
         </dd>
-        <dt>Shower Pogs</dt>
         <dd>
-          {{#if this.eventInfo.showers}}
-            <div class="text-danger">{{fa-icon "ban"}} NO POG</div>
-            Has Wet Spot BMID
-          {{else}}
-            Every 40 hrs
-          {{/if}}
-        </dd>
-        <dt>Motorpool Policy</dt>
-        <dd>
-          {{#if this.personEvent.signed_motorpool_agreement}}
-            {{fa-icon "check"}} Signed
-          {{else}}
-            <span class="text-danger">NOT SIGNED</span>
-          {{/if}}
+          <button type="button" class="btn btn-secondary btn-sm btn-block mb-2"
+            {{action this.toggleAppreciationsProgress}}>
+            Ticket &amp; Provisions Progress
+          </button>
+          <button type="button" class="btn btn-secondary btn-sm btn-block" {{action this.toggleHoursCreditBreakdown}}
+                  disabled={{this.isLoadingBreakdown}}>
+            {{#if this.isLoadingBreakdown}}
+              {{fa-icon "spinner" spin=true}}
+            {{/if}}
+            Credits &amp; Hours Breakdown
+          </button>
         </dd>
       </dl>
     </div>
   </div>
 </main>
+
+
+{{#if this.showAppreciationsProgress}}
+  <ModalDialog @title="Appreciations Progress"  as |Modal|>
+    <Modal.body>
+      <AppreciationProgress @timesheetSummary={{this.timesheetSummary}} @isShinyPenny={{this.isShinyPenny}} />
+    </Modal.body>
+    <Modal.footer>
+      <Modal.button @label="Close" @action={{this.toggleAppreciationsProgress}} @type="primary"/>
+    </Modal.footer>
+  </ModalDialog>
+{{/if}}
+
+{{#if this.showHoursCreditsBreakdown}}
+  <ModalDialog @title="Hours And Credits Breakdown" as |Modal|>
+    <Modal.body>
+      <HoursCreditsBreakdown @timesheetSummary={{this.timesheetSummary}}
+                             @countedDurationExpected={{this.countedDurationExpected}}
+                             @creditsExpected={{this.creditsExpected}} />
+    </Modal.body>
+    <Modal.footer>
+      <Modal.button @label="Close" @action={{this.toggleHoursCreditBreakdown}} @type="primary"/>
+    </Modal.footer>
+  </ModalDialog>
+{{/if}}
+
 
 {{#if this.showSignInWarning}}
   <ModalDialog @title="Sign Into A Shift" as |Modal|>

--- a/app/templates/hq/shift.hbs
+++ b/app/templates/hq/shift.hbs
@@ -9,7 +9,7 @@
     <p>
       Follow the procedures on the Site Check In page before signing the person into a shift.
     </p>
-    <LinkTo @route="hq.site-checkin" @model={{this.person.id}} class="btn btn-danger">Site Check In</LinkTo>
+    <LinkTo @route="hq.site-checkin" @model={{this.person.id}} class="btn btn-danger">Begin Site Check In</LinkTo>
   </ChNotice>
 {{/unless}}
 
@@ -27,25 +27,8 @@
   </ChNotice>
 {{/if}}
 
-<div class="my-2">
-  <div class="d-inline-block align-middle">
-    <b>Earned Credits:</b> {{credits-format this.timesheetSummary.total_credits}}
-    <b>Worked Hours:</b> {{hour-minute-format this.timesheetSummary.counted_duration}}
-  </div>
-  <div class="ml-2 d-inline-block">
-    <button type="button" class="btn btn-sm btn-secondary align-middle" {{action this.toggleAppreciationsProgress}}>
-      Ticket &amp; Provisions Progress
-    </button>
-    <button type="button" class="btn btn-sm btn-secondary ml-2 align-middle" {{action this.toggleHoursCreditBreakdown}}>
-      Credits &amp; Hours Breakdown
-    </button>
-  </div>
-</div>
-
-<hr>
-
 <h3>
-  Timesheet Verification -
+  Timesheet Entry Verification -
   {{#if this.hasUnverifiedTimesheet}}
     <span class="text-danger">{{pluralize this.unverifiedTimesheets.length "entry" }}</span>
   {{else}}
@@ -124,8 +107,9 @@
   No timesheet entries need review at this time.
 {{/if}}
 
-<hr class="my-3">
-<h3>Shift Management
+<hr class="my-2">
+<h3 class="mb-2">
+  Shift Check In/Out
   <HelpPopover @slug="hq-shift-management"/>
 </h3>
 <ShiftCheckInOut @positions={{this.positions}}
@@ -140,7 +124,9 @@
                  @year={{this.session.currentYear}}
 />
 
+<hr>
 
+<HqProvisionInfo @eventInfo={{this.eventInfo}} />
 {{#if this.showCorrectionForm}}
   <ModalDialog @title="Timesheet Entry Correction" as |Modal|>
     <ChForm @formId="correction" @formFor={{this.entry}}
@@ -185,9 +171,18 @@
   </ModalDialog>
 {{/if}}
 <hr>
-<h3 class="mb-2">Radio &amp; Assets
+<h3 class="mb-4">
+  Radios, Sandman Gear, &amp; Other Assets
   <HelpPopover @slug="hq-assets"/>
 </h3>
+{{#unless this.personEvent.asset_authorized}}
+  <h4 class="text-danger">{{fa-icon "exclamation-triangle"}} Radio Checkout Agreement NOT SIGNED - DO NOT ISSUE RADIOS</h4>
+  <p>
+    Direct {{this.person.callsign}} to the kiosk shack so they can login into the Clubhouse, review and sign
+    the agreement.
+  </p>
+
+{{/unless}}
 {{#unless this.eventInfo.radio_info_available}}
   <ChNotice @type="warning" @icon="exclamation">
     Event radio information has not been posted yet. Radio eligibility cannot be determined.
@@ -212,14 +207,10 @@
 </div>
 
 {{#if this.personEvent.asset_authorized}}
-  <AssetCheckoutForm @person={{this.person}} @assets={{this.assets}} @attachments={{this.attachments}}
+  <AssetCheckoutForm @person={{this.person}}
+                     @assets={{this.assets}}
+                     @attachments={{this.attachments}}
                      @eventInfo={{this.eventInfo}} />
-{{else}}
-  <h3 class="text-danger">Radio Checkout Agreement NOT SIGNED - DO NOT ISSUE RADIOS</h3>
-  <p>
-    Direct {{this.person.callsign}} to the kiosk shack so they can login into the Clubhouse, review and sign
-    the agreement.
-  </p>
 {{/if}}
 
 <table class="table table-striped table-width-auto">
@@ -277,15 +268,15 @@
   {{/if}}
 </div>
 
+
 {{#if (or this.person.on_site this.isMarkingOffSite)}}
-  <div class="mt-4">
-    <button type="button" class="btn btn-secondary" {{action this.markOffSite}} disabled={{this.isMarkingOffSite}}>
-      Mark As Off Site
-    </button>
-    {{#if this.isMarkingOffSite}}
-      <SpinIcon/>
-    {{/if}}
-  </div>
+  <hr>
+  <button type="button" class="btn btn-secondary" {{action this.markOffSite}} disabled={{this.isMarkingOffSite}}>
+    Mark As Off Site
+  </button>
+  {{#if this.isMarkingOffSite}}
+    <SpinIcon/>
+  {{/if}}
 {{/if}}
 
 {{#if this.showSiteLeaveDialog}}
@@ -322,30 +313,6 @@
     <Modal.footer>
       <Modal.button @label="Mark As Off Site" @action={{this.forceMarkOffSite}} @type="secondary"/>
       <Modal.button @label="Deal With Items" @action={{this.cancelSiteLeaveDialog}} @type="primary"/>
-    </Modal.footer>
-  </ModalDialog>
-{{/if}}
-
-{{#if this.showAppreciationsProgress}}
-  <ModalDialog @title="Appreciations Progress" as |Modal|>
-    <Modal.body>
-      <AppreciationProgress @timesheetSummary={{this.timesheetSummary}} @isShinyPenny={{this.isShinyPenny}} />
-    </Modal.body>
-    <Modal.footer>
-      <Modal.button @label="Close" @action={{this.toggleAppreciationsProgress}} @type="primary"/>
-    </Modal.footer>
-  </ModalDialog>
-{{/if}}
-
-{{#if this.showHoursCreditsBreakdown}}
-  <ModalDialog @title="Hours And Credits Breakdown" as |Modal|>
-    <Modal.body>
-      <HoursCreditsBreakdown @timesheetSummary={{this.timesheetSummary}}
-                             @countedDurationExpected={{this.countedDurationExpected}}
-                             @creditsExpected={{this.creditsExpected}} />
-    </Modal.body>
-    <Modal.footer>
-      <Modal.button @label="Close" @action={{this.toggleHoursCreditBreakdown}} @type="primary"/>
     </Modal.footer>
   </ModalDialog>
 {{/if}}

--- a/app/templates/hq/site-checkin.hbs
+++ b/app/templates/hq/site-checkin.hbs
@@ -24,7 +24,7 @@
 
 <ChForm @formId="contact" @formFor={{this.person}} @onSubmit={{this.saveContactForm}} as |f|>
   <div class="form-row">
-    <f.input @name="camp_location" @type="textarea" @label="Camp Name & Location" @autofocus={{true}} @rows={{2}} @cols={{80}}/>
+    <f.input @name="camp_location" @type="textarea" @label="Camp Name & Location" @autofocus={{true}} @rows={{4}} @cols={{80}}/>
   </div>
   {{#if this.session.isLMOPEnabled}}
     <p class="ml-2">


### PR DESCRIPTION
- HQ Window shift manage page: Place meal & shower pog info directly below shift check in/out area.
- ChForm: Scan all validation errors to find the field which is top most on the page to scroll to.
- Removed O.N.E. 2 hackery
- Credit & Hour Breakdown dialog dynamically retrieves the breakdown info.
- Cleaned up the search bar callsign results. The FKA and email match indicators are on a newline.
- Persist the selected search bar mode so the state is not lost when the user refreshes the website.
- Added 'Black Rock Rangers' to README.md so the Internet does not confuse this Clubhouse with that other Clubhouse.