### PR TITLE
Separated out rollcall sign in code into its own component. Various fixes.

### DIFF
--- a/app/components/autocomplete-input.hbs
+++ b/app/components/autocomplete-input.hbs
@@ -11,9 +11,9 @@
         </div>
       </div>
     {{/if}}
-    <Input @type="search"
+    <input type="search"
            placeholder={{@placeholder}}
-           @value={{@text}}
+           value={{@text}}
            class={{this.inputClass}}
            disabled={{@disabled}}
       {{on "keyup" this.keyUpEvent}}

--- a/app/components/ch-form/field.hbs
+++ b/app/components/ch-form/field.hbs
@@ -106,7 +106,7 @@
         <label class={{this.labelClass}} for={{concat this.domId idx}}>{{option.label}}</label>
       </div>
     {{/each}}
-  {{else if (eq @type "search")}}
+  {{~else if (eq @type "search")~}}
     <AutocompleteInput @placeholder={{@placeholder}}
                        @onSearch={{@onSearch}}
                        @onSelect={{this.update}}
@@ -115,20 +115,20 @@
                        @autofocus={{@autofocus}}
                        @inputClass="{{this.controlClass}} {{if this.errorMessages "is-invalid"}}"
                        @text={{get @model @name}} as |item|>
-      {{item}}
+      {{~item~}}
     </AutocompleteInput>
-  {{else}}
+  {{~else~}}
     Unknown field type [{{@type}}]
-  {{/if}}
-  {{#if (has-block)}}
+  {{~/if~}}
+  {{~#if (has-block)~}}
     {{yield}}
-  {{/if}}
+  {{~/if~}}
 
-  {{#if @hint~}}
+  {{~#if @hint~}}
     <small class="form-text text-muted">{{nl2br @hint}}</small>
   {{~/if~}}
 
-  {{#each this.errorMessages as |msg|~}}
+  {{~#each this.errorMessages as |msg|~}}
     <div class="text-danger is-invalid">&bullet; {{msg}}</div>
   {{~/each~}}
 {{/if}}

--- a/app/components/rollcall-sign-in.hbs
+++ b/app/components/rollcall-sign-in.hbs
@@ -1,0 +1,87 @@
+{{#if this.isLoading}}
+  <LoadingDialog @items="loading shifts"/>
+{{else}}
+  <UiSection>
+    <:title>Sign In People {{fa-icon "walking"}}</:title>
+    <:body>
+      {{#if this.positions}}
+        <div class="row form-group">
+          <label class="col-form-label col-sm-12 col-lg-auto">Position</label>
+          <div class="col-sm-12 col-lg-auto">
+            <ChForm::Select @name="positionId" @value={{this.positionId}} @options={{this.positionOptions}}
+                            @onChange={{action this.selectPosition}} @controlClass="form-control"/>
+          </div>
+          <label class="col-form-label col-sm-12 col-lg-auto">Shift</label>
+          <div class="col-sm-12 col-lg-auto">
+            <ChForm::Select @name="slotId" @value={{this.slotId}}
+                            @options={{this.slotOptions}}
+                            @onChange={{action this.selectSlot}}
+                            @disabled={{eq this.positionId 0}} @controlClass="form-control"/>
+          </div>
+        </div>
+      {{else}}
+        <div class="my-2">
+          <b class="text-danger">No shifts found starting within the next 4 hours.</b>
+        </div>
+      {{/if}}
+
+      {{#if this.slot}}
+        <div class="row">
+          <div class="h4 col-auto">{{this.position.title}}</div>
+          <div class="h4 col-auto">{{this.slot.description}}</div>
+          <div class="h4 col-auto">{{shift-format this.slot.begins}}</div>
+        </div>
+      {{/if}}
+      {{#if this.isRetrievingPeople}}
+        <LoadingDialog @item="the signups"/>
+      {{else if this.people}}
+        <p>
+          {{pluralize this.people.length "sign up"}}. Click the box to sign the person in OR out.
+        </p>
+
+        <div class="rollcall-grid">
+          {{#each this.people as |person|}}
+            <a href
+               class="rollcall-person {{if person.on_duty "rollcall-problem" (if person.signedIn "rollcall-success")}}"
+              {{action this.clickPerson person}}>
+              <div class="rollcall-photo">
+                {{#if person.photo_url}}
+                  <img src={{person.photo_url}} alt={{person.callsign}} loading="lazy"/>
+                {{else}}
+                  {{fa-icon "user"}}
+                {{/if}}
+              </div>
+              <div class="rollcall-indicator">
+                {{#if person.isSubmitting}}
+                  {{fa-icon "spinner" spin=true}}
+                {{else if person.on_duty}}
+                  {{fa-icon "walking" color="danger"}}
+                {{else if person.signedIn}}
+                  {{fa-icon "walking" color="success"}}
+                {{/if}}
+              </div>
+              <div class="rollcall-name">
+                {{person.callsign}}
+              </div>
+              <div class="rollcall-info">
+                {{#if person.on_duty}}
+                  <b>Already on duty</b><br>
+                  {{person.on_duty.position.title}}<br>
+                  {{shift-format person.on_duty.on_duty}}
+                {{else if person.signedIn}}
+                  <b>ON DUTY</b><br>
+                  {{this.position.title}}<br>
+                  {{shift-format person.startTime}}
+                {{/if}}
+              </div>
+            </a>
+          {{/each}}
+        </div>
+      {{else if (gt this.slotId 0)}}
+        <p class="text-danger">
+          <b>No sign ups found for the shift.</b>
+        </p>
+      {{/if}}
+    </:body>
+  </UiSection>
+{{/if}}

--- a/app/components/rollcall-sign-in.js
+++ b/app/components/rollcall-sign-in.js
@@ -1,0 +1,272 @@
+import Component from '@glimmer/component';
+import {action} from '@ember/object';
+import {tracked} from '@glimmer/tracking';
+import {inject as service} from '@ember/service';
+import _ from 'lodash';
+import dayjs from 'dayjs';
+import {ART_CAR_WRANGLER, BURN_PERIMETER, SANDMAN} from 'clubhouse/constants/positions';
+
+class PersonSignIn {
+  @tracked signedIn = false; // is the person signed in?
+  @tracked on_duty; // Timesheet person is already signed into.
+  @tracked timesheet_id = null;
+  @tracked isSubmitting = false;
+  @tracked startTime; // What time did the person start the shift?
+
+  constructor(obj) {
+    Object.assign(this, obj);
+  }
+}
+
+export default class RollcallSignInComponent extends Component {
+  @service ajax;
+  @service house;
+  @service modal;
+  @service toast;
+
+  @tracked positionId = 0;
+  @tracked slotId = 0;
+  @tracked slot = null;
+  @tracked people = null;
+  @tracked positions = null;
+  @tracked position = null;
+
+  @tracked isRetrievingPeople = false;
+  @tracked isSubmitting = false;
+  @tracked isLoading = false;
+
+  constructor() {
+    super(...arguments);
+
+    this.isLoading = true;
+
+    // Load up all available slots
+    this.ajax.request('slot', {data: {for_rollcall: 1}})
+      .then(({slot}) => this._setupPositions(slot))
+      .catch((response) => this.house.handleErrorResponse(response))
+      .finally(() => this.isLoading = false);
+  }
+
+  /**
+   * Build the slot options
+   *
+   * @returns {[]}
+   */
+
+  get slotOptions() {
+    const position = this.positions.find((p) => +p.id === this.positionId);
+    if (position == null) {
+      return [];
+    }
+
+    const options = position.slots.map((s) => [`${dayjs(s.begins).format('ddd MMM DD [@] HH:mm')} (${s.description})`, s.id]);
+    options.unshift(['Select Shift', 0]);
+    return options;
+  }
+
+  /**
+   * Take the slots returned by the backend, build up the positions.
+   * @param slots
+   * @private
+   */
+  _setupPositions(slots) {
+    const positions = _.sortBy(_.map(_.groupBy(slots, 'position_id'), (slots) => {
+      const position = slots[0].position;
+
+      return {
+        id: +position.id,
+        title: position.title,
+        slots
+      };
+    }), 'title');
+
+    this.positions = positions;
+    this.positionId = 0;
+    this.people = null;
+
+    // Organize the positions options so the Burn shifts are on top.
+    const options = positions.map((p) => [p.title, +p.id]);
+    const burnPositions = [];
+    [SANDMAN, BURN_PERIMETER, ART_CAR_WRANGLER].forEach((burnPosition) => {
+      const found = options.find((p) => p[1] === burnPosition);
+      if (found) {
+        burnPositions.unshift(found);
+        options.removeObject(found);
+      }
+    });
+
+    this.positionOptions = [
+      ['Select Position', 0],
+      {
+        groupName: 'Burn Positions',
+        options: burnPositions
+      },
+      {
+        groupName: 'Everything Else',
+        options
+      }
+    ];
+
+  }
+
+  /**
+   * Select a new position, and clear out the shift selection.
+   *
+   * @param {number} positionId
+   */
+
+  @action
+  selectPosition(positionId) {
+    positionId = +positionId;
+    this.positionId = positionId;
+    this.people = [];
+    this.position = this.positions.find((p) => p.id === positionId);
+    if (this.position && this.position.slots.length === 1) {
+      const slot = this.position.slots[0];
+      // Go ahead and preselect the only slot.
+      this.slotId = slot.id;
+      this.slot = slot;
+      this._retrievePeople();
+    } else {
+      this.slotId = 0;
+      this.slot = null;
+    }
+  }
+
+  /**
+   * Select a shift, and look up who has signed up
+   *
+   * @param {number} slotId
+   */
+
+  @action
+  selectSlot(slotId) {
+    slotId = +slotId;
+    this.slotId = slotId;
+    if (!slotId) {
+      return;
+    }
+
+    this.slot = this.position.slots.find((s) => s.id === slotId);
+    this._retrievePeople();
+  }
+
+  /**
+   * Retrieve the people signed up for a given slot/shift
+   * @private
+   */
+
+  _retrievePeople() {
+    this.isRetrievingPeople = true;
+    this.ajax.request(`slot/${this.slot.id}/people`, {data: {is_onduty: 1, include_photo: 1}})
+      .then((result) => this.people = result.people.map((p) => new PersonSignIn(p)))
+      .catch((response) => this.house.handleErrorResponse(response))
+      .finally(() => this.isRetrievingPeople = false);
+  }
+
+  /**
+   * Sign in or out a person
+   *
+   * @param {PersonSignIn} person
+   */
+
+  @action
+  clickPerson(person) {
+    if (person.isSubmitting) {
+      // double click?
+      return;
+    }
+
+    if (!person.signedIn && !person.on_duty) {
+      this._signonPerson(person);
+    } else {
+      // Person is on duty - confirm sign out.
+      this.modal.confirm(`Sign Out ${person.callsign}`, `Do you wish to sign out ${person.callsign}?`, () => {
+        const timesheetId = (person.on_duty ? person.on_duty.id : person.timesheet_id);
+        person.isSubmitting = true;
+        this.ajax.request(`timesheet/${timesheetId}/signoff`, {method: 'POST'})
+          .then((result) => {
+            person.signedIn = false;
+            person.on_duty = null;
+            person.timesheet_id = null;
+
+            switch (result.status) {
+              case 'success':
+                break;
+
+              case 'already-signed-off':
+                this.toast.error(`${person.callsign} was already signed off.`);
+                break;
+
+              default:
+                this.toast.error(`Unknown signoff response [${result.status}].`);
+                break;
+            }
+          }).catch((response) => this.house.handleErrorResponse(response))
+          .finally(() => person.isSubmitting = false)
+      });
+    }
+  }
+
+  /**
+   * Sign a person into a shift
+   *
+   * @param {PersonSignIn} person
+   * @private
+   */
+
+  _signonPerson(person) {
+    person.isSubmitting = true;
+    this.ajax.request('timesheet/signin', {
+      method: 'POST',
+      data: {
+        position_id: this.positionId,
+        person_id: person.id,
+        slot_id: this.slotId
+      }
+    }).then((result) => {
+      const {callsign} = person;
+      switch (result.status) {
+        case 'success':
+          if (result.forced) {
+            let reason;
+            if (result.unqualified_reason === 'untrained') {
+              reason = `has not completed '${result.required_training}'`;
+            } else {
+              reason = `is unqualified ('${result.unqualified_message}')`;
+            }
+            this.modal.info('Sign In Forced', `<p><b class="text-danger">WARNING: The person ${reason}.</b></p> Because you are an admin or have the timesheet management role, we have signed them in anyways. Hope you know what you're doing! ${callsign} is now on duty.`);
+          }
+          person.signedIn = true;
+          person.timesheet_id = result.timesheet_id;
+          person.startTime = result.on_duty;
+          console.log('RESULT ', result);
+          break;
+
+        case 'position-not-held':
+          this.modal.info('Position Not Held', `${callsign} does hold the position in order to start the shift.`);
+          break;
+
+        case 'already-on-duty':
+          this.modal.info('Already On Shift', 'The person is already on duty.');
+          person.signedIn = true;
+          person.on_duty = result.timesheet;
+          person.timesheet_id = result.timesheet.id;
+          break;
+
+        case 'not-trained':
+          this.modal.info('Not Trained', `${callsign} has has not completed "${result.position_title}" and cannot be signed into the shift.`);
+          break;
+
+        case 'not-qualified':
+          this.modal.info('Not Qualified', `${callsign} has not meet one or more of the qualifiers needed to sign into the shift.<br>Reason: ${result.unqualified_message}`);
+          break;
+
+        default:
+          this.modal.info('Unknown Server Status', `An unknown status [${result.status}] from the server. This is a bug. Please report this to the Tech Ninjas.`);
+          break;
+      }
+    }).catch((response) => this.house.handleErrorResponse(response))
+      .finally(() => person.isSubmitting = false);
+  }
+}

--- a/app/components/rollcall-sign-out.hbs
+++ b/app/components/rollcall-sign-out.hbs
@@ -1,19 +1,33 @@
-<h3>Sign People OUT {{fa-icon "bed"}}</h3>
-{{#if this.isLoading}}
-  <LoadingIndicator/>
-{{else}}
-  {{#each this.positions key="id" as |position|}}
-    <ChAccordion as |Accordion|>
-      <Accordion.title>{{position.title}} [{{pluralize position.people.length "person"}}]</Accordion.title>
-      <Accordion.body>
+<UiSection>
+  <:title>Sign OUT People {{fa-icon "bed"}}</:title>
+  <:body>
+    {{#if this.isLoading}}
+      <LoadingDialog @item="positions"/>
+    {{else if this.positions}}
+      <div class="row form-group">
+        <label class="col-form-label col-sm-12 col-lg-auto">Position</label>
+        <div class="col-sm-12 col-lg-auto">
+          <ChForm::Select @name="positionId"
+                          @value={{this.positionId}}
+                          @options={{this.positionOptions}}
+                          @onChange={{action this.selectPosition}}
+                          @controlClass="form-control"/>
+        </div>
+      </div>
+
+      {{#if this.position}}
+        <h4>
+          {{this.position.title}} - {{pluralize this.position.people.length "person"}}
+        </h4>
         <p>
-          Click on the person to sign them out. Click again to resume their shift if they were accidentally signed out.
+          Click on the person to sign them out. Click again to resume their shift if they were accidentally signed
+          out.
         </p>
         <p>
           {{fa-icon "walking"}} = person is on shift. {{fa-icon "bed"}} = person has been signed off.
         </p>
         <div class="rollcall-grid">
-          {{#each position.people key="id" as |person|}}
+          {{#each this.position.people key="id" as |person|}}
             <a href class="rollcall-person {{unless person.isSignedIn "text-muted"}}"
               {{action this.clickPerson person}}>
               <div class="rollcall-photo">
@@ -47,18 +61,20 @@
                 {{else}}
                   <b class="text-success">Off Duty</b><br>
                 {{/if}}
-                {{position.title}}<br>
+                {{this.position.title}}<br>
                 {{#if person.isSignedIn}}
-                  {{shift-format person.on_duty}}<br>
-                {{/if}}
+                  {{shift-format person.on_duty}}
+                {{/if}}<br>
                 Duration {{hour-minute-format person.duration}}
               </div>
             </a>
           {{/each}}
         </div>
-      </Accordion.body>
-    </ChAccordion>
-  {{else}}
-    <b class="text-success">Congratulations! No on duty personnel were found.</b>
-  {{/each}}
-{{/if}}
+      {{/if}}
+    {{else}}
+      <p>
+        <b class="text-danger">No one appears to be on duty?</b>
+      </p>
+    {{/if}}
+  </:body>
+</UiSection>

--- a/app/components/shift-check-in-out.hbs
+++ b/app/components/shift-check-in-out.hbs
@@ -73,8 +73,7 @@
         <thead>
         <tr>
           <th>Shift</th>
-          <th>Starts</th>
-          <th>Ends</th>
+          <th>Time</th>
           <th>Action</th>
         </tr>
         </thead>
@@ -84,8 +83,7 @@
           <tr>
             <td class="align-middle">{{slot.position_title}}{{#if slot.slot_description}}
               - {{slot.slot_description}}{{/if}}</td>
-            <td class="align-middle">{{shift-format slot.slot_begins}}</td>
-            <td class="align-middle">{{shift-format slot.slot_ends}}</td>
+            <td class="align-middle">{{shift-format slot.slot_begins slot.slot_ends}}</td>
             <td class="align-middle">
               {{#if (and (not slot.is_untrained) (not slot.is_unqualified))}}
                 <button type="button" class="btn {{if slot.is_within_start_time "btn-primary" "btn-warning"}}" {{action

--- a/app/controllers/reports/rollcall.js
+++ b/app/controllers/reports/rollcall.js
@@ -1,179 +1,20 @@
 import ClubhouseController from 'clubhouse/controllers/clubhouse-controller';
-import {action, set} from '@ember/object';
+import {action} from '@ember/object';
 import {tracked} from '@glimmer/tracking';
-import dayjs from 'dayjs';
 
 export default class ReportsRollcallController extends ClubhouseController {
-  @tracked positionId;
-  @tracked slotId;
-  @tracked slot;
-  @tracked people;
-  @tracked positions;
-  @tracked position;
-
-  @tracked isRetrievingPeople = false;
-  @tracked isSubmitting = false;
-
   @tracked isSignOut = false;
-  @tracked askForInOrOut = true;
+  @tracked isSignIn = false;
 
   @action
-  chooseInOrOut(signOut) {
-    this.askForInOrOut = false;
-    this.isSignOut = signOut;
+  chooseSignIn(event) {
+    this.isSignOut = false;
+    this.isSignIn = true;
   }
 
   @action
-  askAgain() {
-    this.askForInOrOut = true;
-  }
-
-  get slotOptions() {
-    const position = this.positions.find((p) => +p.id === this.positionId);
-    if (position == null) {
-      return [];
-    }
-
-    const options = position.slots.map((s) => [`${dayjs(s.begins).format('ddd MMM DD [@] HH:mm')} (${s.description})`, s.id]);
-    options.unshift(['Select Shift', 0]);
-    return options;
-  }
-
-  /*
-   * Select a new position, and clear out the shift selection.
-   */
-
-  @action
-  selectPosition(positionId) {
-    positionId = +positionId;
-    this.positionId = positionId;
-    this.people = [];
-    this.position = this.positions.find((p) => +p.id === positionId);
-    if (this.position && this.position.slots.length === 1) {
-      const slot = this.position.slots[0];
-      // Go ahead and preselect the only slot.
-      this.slotId = slot.id;
-      this.slot = slot;
-      this._retrievePeople();
-    } else {
-      this.slotId = 0;
-      this.slot = null;
-    }
-  }
-
-  /*
-   * Select a shift, and look up who has signed up
-   */
-
-  @action
-  selectSlot(slotId) {
-    slotId = +slotId;
-    this.slotId = slotId;
-    if (!slotId) {
-      return;
-    }
-
-    this.slot = this.position.slots.find((s) => s.id === slotId);
-    this._retrievePeople();
-  }
-
-  _retrievePeople() {
-    this.isRetrievingPeople = true;
-    this.ajax.request(`slot/${this.slot.id}/people`, {data: {is_onduty: 1, include_photo: 1}})
-      .then((result) => this.people = result.people)
-      .catch((response) => this.house.handleErrorResponse(response))
-      .finally(() => this.isRetrievingPeople = false);
-  }
-
-  /*
-   * Sign in or out a person
-   */
-
-  @action
-  clickPerson(person) {
-    if (person.isSubmitting) {
-      // double click?
-      return;
-    }
-
-    if (!person.signedIn && !person.on_duty) {
-      this._signonPerson(person);
-    } else {
-      this.modal.confirm(`Sign Out ${person.callsign}`, `Do you wish to sign out ${person.callsign}?`, () => {
-        const timesheetId = (person.on_duty ? person.on_duty.id : person.timesheet_id);
-        set(person, 'isSubmitting', true);
-        this.ajax.request(`timesheet/${timesheetId}/signoff`, {method: 'POST'})
-          .then((result) => {
-            set(person, 'signedIn', false);
-            set(person, 'on_duty', null);
-            set(person, 'timesheet_id', null);
-
-            switch (result.status) {
-              case 'success':
-                break;
-
-              case 'already-signed-off':
-                this.toast.error(`${person.callsign} was already signed off.`);
-                break;
-
-              default:
-                this.toast.error(`Unknown signoff response [${result.status}].`);
-                break;
-            }
-          }).catch((response) => this.house.handleErrorResponse(response))
-          .finally(() => set(person, 'isSubmitting', false))
-      });
-    }
-  }
-
-  _signonPerson(person) {
-    set(person, 'isSubmitting', true);
-    this.ajax.request('timesheet/signin', {
-      method: 'POST',
-      data: {
-        position_id: this.positionId,
-        person_id: person.id,
-        slot_id: this.slotId
-      }
-    }).then((result) => {
-      const callsign = person.callsign;
-      switch (result.status) {
-        case 'success':
-          if (result.forced) {
-            let reason;
-            if (result.unqualified_reason === 'untrained') {
-              reason = `has not completed '${result.required_training}'`;
-            } else {
-              reason = `is unqualified ('${result.unqualified_message}')`;
-            }
-            this.modal.info('Sign In Forced', `WARNING: The person ${reason}. Because you are an admin or have the timesheet management role, we have signed them in anyways. Hope you know what you're doing! ${callsign} is now on duty.`);
-          }
-          set(person, 'signedIn', true);
-          set(person, 'timesheet_id', result.timesheet_id);
-          break;
-
-        case 'position-not-held':
-          this.modal.info('Position Not Held', `${callsign} does hold the position in order to start the shift.`);
-          break;
-
-        case 'already-on-duty':
-          this.modal.info('Already On Shift', 'The person is already on duty.');
-          set(person, 'on_duty', result.timesheet);
-          break;
-
-        case 'not-trained':
-          this.modal.info('Not Trained', `${callsign} has has not completed "${result.position_title}" and cannot be signed into the shift.`);
-          break;
-
-        case 'not-qualified':
-          this.modal.info('Not Qualified', `${callsign} has not meet one or more of the qualifiers needed to sign into the shift.<br>Reason: ${result.unqualified_message}`);
-          break;
-
-        default:
-          this.modal.info('Unknown Server Status', `An unknown status [${result.status}] from the server. This is a bug. Please report this to the Tech Ninjas.`);
-          break;
-      }
-    }).catch((response) => this.house.handleErrorResponse(response))
-      .finally(() => set(person, 'isSubmitting', false));
+  chooseSignOut(event) {
+    this.isSignOut = true;
+    this.isSignIn = false;
   }
 }

--- a/app/controllers/reports/rollcall.js
+++ b/app/controllers/reports/rollcall.js
@@ -7,13 +7,13 @@ export default class ReportsRollcallController extends ClubhouseController {
   @tracked isSignIn = false;
 
   @action
-  chooseSignIn(event) {
+  chooseSignIn() {
     this.isSignOut = false;
     this.isSignIn = true;
   }
 
   @action
-  chooseSignOut(event) {
+  chooseSignOut() {
     this.isSignOut = true;
     this.isSignIn = false;
   }

--- a/app/controllers/reports/vehicle-registry.js
+++ b/app/controllers/reports/vehicle-registry.js
@@ -257,11 +257,6 @@ export default class ReportsPersonVehiclesController extends ClubhouseController
   }
 
   @action
-  selectCallsignAction(model, option) {
-    model.callsign = option;
-  }
-
-  @action
   exportToCSV(event) {
     event.preventDefault();
 

--- a/app/helpers/shift-format.js
+++ b/app/helpers/shift-format.js
@@ -1,12 +1,13 @@
 import {helper} from '@ember/component/helper';
 import dayjs from 'dayjs';
+import { htmlSafe } from '@ember/string';
 
 const MONTH_DAY_TIME = 'ddd MMM DD [@] HH:mm';
 const MONTH_DAY_TIME_YEAR = 'ddd MMM DD [@] HH:mm YYYY';
-//const DAY_TIME = 'ddd [@] HH:mm';
 const HOUR_MINS = 'HH:mm';
+const HOUR_MIN_DAY = 'ddd [@] HH:mm'
 
-export function shiftFormat([shiftDate, toDate], hash) {
+export function shiftFormat([shiftDate, endDate], hash) {
   let datetime;
 
   if (!shiftDate) {
@@ -18,18 +19,30 @@ export function shiftFormat([shiftDate, toDate], hash) {
     return shiftDate;
   }
 
-  if (!toDate) {
+  if (!endDate) {
     return datetime.format(hash.year ? MONTH_DAY_TIME_YEAR : MONTH_DAY_TIME);
   }
 
-  const toDt = dayjs(toDate);
-  if (!toDt.isValid()) {
+  const endDatetime = dayjs(endDate);
+  if (!endDatetime.isValid()) {
     return datetime.format(MONTH_DAY_TIME);
 
   }
 
+  if (hash.year) {
+    return datetime.format(MONTH_DAY_TIME_YEAR) + ' to ' + endDatetime.format(MONTH_DAY_TIME_YEAR);
+  }
 
-  return  datetime.format(hash.year ? MONTH_DAY_TIME_YEAR : MONTH_DAY_TIME) + ' to ' + toDt.format(hash.year ? MONTH_DAY_TIME_YEAR : HOUR_MINS);
+  const startDay = datetime.date(), endDay = endDatetime.date();
+  let endFormat = null;
+
+  if ((startDay === endDay)) {
+    // Don't bother with added the day on the end time if its only to midnight
+    endFormat = endDatetime.format(HOUR_MINS);
+  } else {
+    endFormat = endDatetime.format(HOUR_MIN_DAY);
+  }
+  return htmlSafe(`${datetime.format(MONTH_DAY_TIME)} to <span class="d-inline-block">${endFormat}</span>`);
 }
 
 export default helper(shiftFormat);

--- a/app/routes/reports/rollcall.js
+++ b/app/routes/reports/rollcall.js
@@ -1,51 +1,8 @@
 import ClubhouseRoute from 'clubhouse/routes/clubhouse-route';
-import _ from 'lodash';
-import {ART_CAR_WRANGLER, BURN_PERIMETER, SANDMAN} from 'clubhouse/constants/positions';
 
 export default class ReportsRollcallRoute extends ClubhouseRoute {
-  model() {
-    return this.ajax.request('slot', {data: {for_rollcall: 1}});
-  }
-
-  setupController(controller, model) {
-    const positions = _.sortBy(_.map(_.groupBy(model.slot, 'position_id'), (slots) => {
-      const position = slots[0].position;
-
-      return {
-        id: position.id,
-        title: position.title,
-        slots
-      };
-    }), 'title');
-
-    controller.set('positions', positions);
-    controller.set('people', null);
+  setupController(controller) {
     controller.set('isSignOut', false);
-    controller.set('askForInOrOut', true);
-
-    const options = positions.map((p) => [p.title, p.id]);
-    const burnPositions = [];
-    [SANDMAN, BURN_PERIMETER, ART_CAR_WRANGLER].forEach((burnPosition) => {
-      const found = options.find((p) => p[1] == burnPosition);
-      if (found) {
-        burnPositions.unshift(found);
-        options.removeObject(found);
-      }
-    });
-    //burnPositions.unshift([ 'Select Position', 0])
-
-    controller.set('positionOptions', [
-      [ 'Select Position', 0],
-      {
-        groupName: 'Burn Positions',
-        options: burnPositions
-      },
-      {
-        groupName: 'Everything Else',
-        options
-      }
-    ]);
-
-    controller.set('positionId', 0);
+    controller.set('isSignIn', false);
   }
 }

--- a/app/styles/schedule.scss
+++ b/app/styles/schedule.scss
@@ -53,7 +53,7 @@
     text-align: center;
   }
   .schedule-time {
-    width: 22%;
+    width: 26%;
   }
 
   .schedule-duration {
@@ -68,13 +68,13 @@
 
 
   .schedule-signup-description {
-    width: 28%;
-    margin-left: 10px;
+    width: 24%;
+    margin-left: 5px;
   }
 
   .schedule-table-description {
     width: 35%;
-    margin-left: 10px;
+    margin-left: 5px;
   }
 
   @media print {

--- a/app/templates/hq/shift.hbs
+++ b/app/templates/hq/shift.hbs
@@ -44,8 +44,7 @@
         <thead>
         <tr>
           <th>Position</th>
-          <th>From</th>
-          <th>To</th>
+          <th>Time</th>
           <th class="text-right">Duration</th>
           <th class="text-right">Credits</th>
           <th>Correct?</th>
@@ -59,10 +58,7 @@
               {{entry.position.title}}
             </td>
             <td class="align-middle">
-              {{shift-format entry.on_duty}}
-            </td>
-            <td class="align-middle">
-              {{shift-format entry.off_duty}}
+              {{shift-format entry.on_duty entry.off_duty}}
             </td>
             <td class="text-right align-middle">
               {{hour-minute-format entry.duration}}
@@ -153,12 +149,12 @@
         </dl>
         <p>
           Provide as much information as possible to help the reviewer understand why this entry should be fixed.
-          <ul>
-            <li>Why does {{this.person.callsign}} think the entry is wrong?</li>
-            <li><b>Wrong times?</b> State the correct times. Don't forget to include the month and day.</li>
-            <li><b>Is the position "{{this.entry.position.title}}" wrong?</b> State the correct position</li>
-            <li><b>Who was their shift partner(s)?</b></li>
-          </ul>
+        <ul>
+          <li>Why does {{this.person.callsign}} think the entry is wrong?</li>
+          <li><b>Wrong times?</b> State the correct times. Don't forget to include the month and day.</li>
+          <li><b>Is the position "{{this.entry.position.title}}" wrong?</b> State the correct position</li>
+          <li><b>Who was their shift partner(s)?</b></li>
+        </ul>
         </p>
         <f.input @name="additional_notes" @label="Timesheet entry correction note:" @type="textarea"
                  @autofocus={{true}}

--- a/app/templates/reports/rollcall.hbs
+++ b/app/templates/reports/rollcall.hbs
@@ -1,102 +1,18 @@
 <h1>{{this.year}} Roll Call Interface</h1>
-{{#if this.askForInOrOut}}
-  <p>
-    Use this page to sign people into a shift they have signed up for OR sign out. The interface
-    is intended for Burn Perimeter checkins were people do not need gear
-    before being deployed or who are returning from the burn.
-  </p>
-  <p>
-    <button class="btn btn-primary btn-responsive mb-4" type="button" {{action this.chooseInOrOut false}}>
-      Sign IN People {{fa-icon "walking"}}
-    </button>
-    <button class="btn btn-primary btn-responsive mb-4" type="button" {{action this.chooseInOrOut true}}>
-      Sign OUT People {{fa-icon "bed"}}
-    </button>
-  </p>
-{{else}}
-  <p>
-    <a href {{action this.askAgain}}>Back to choose between sign out and in</a>
-  </p>
-  {{#if this.isSignOut}}
-    <RollcallSignOut/>
-  {{else}}
-    <h3>Sign People IN {{fa-icon "walking"}}</h3>
+<p>
+  Use this page to sign people into a shift they have signed up for OR sign out. The interface
+  is intended for Burn Perimeter Rangers who do not require gear to be issued before or collected afterwards.
+</p>
 
-    {{#if this.positions}}
-      <div class="row form-group">
-        <label class="col-form-label col-sm-12 col-lg-auto">Position</label>
-        <div class="col-sm-12 col-lg-auto">
-          <ChForm::Select @name="positionId" @value={{this.positionId}} @options={{this.positionOptions}}
-                          @onChange={{action this.selectPosition}} @controlClass="form-control"/>
-        </div>
-        <label class="col-form-label col-sm-12 col-lg-auto">Shift</label>
-        <div class="col-sm-12 col-lg-auto">
-          <ChForm::Select @name="slotId" @value={{this.slotId}}
-                          @options={{this.slotOptions}}
-                          @onChange={{action this.selectSlot}}
-                          @disabled={{eq this.positionId 0}} @controlClass="form-control"/>
-        </div>
-      </div>
-    {{else}}
-      <div class="my-2">
-        <b class="text-danger">No shifts found starting within the next 4 hours.</b>
-      </div>
-    {{/if}}
+<button class="btn btn-primary btn-responsive mb-4" type="button" {{action this.chooseSignIn}}>
+  Sign IN People {{fa-icon "walking"}}
+</button>
+<button class="btn btn-primary btn-responsive mb-4" type="button" {{action this.chooseSignOut}}>
+  Sign OUT People {{fa-icon "bed"}}
+</button>
 
-    {{#if this.slot}}
-      <div class="row">
-        <div class="h4 col-auto">{{this.position.title}}</div>
-        <div class="h4 col-auto">{{this.slot.description}}</div>
-        <div class="h4 col-auto">{{shift-format this.slot.begins}}</div>
-      </div>
-    {{/if}}
-    {{#if this.isRetrievingPeople}}
-      <LoadingDialog @item="the sign ups"/>
-    {{else if this.people}}
-      <p>
-        {{pluralize this.people.length "sign up"}}. Click the box to sign the person in OR out.
-      </p>
-
-      <div class="rollcall-grid">
-        {{#each this.people as |person|}}
-          <a href
-             class="rollcall-person {{if person.on_duty "rollcall-problem" (if person.signedIn "rollcall-success")}}"
-            {{action this.clickPerson person}}>
-            <div class="rollcall-photo">
-              {{#if person.photo_url}}
-                <img src={{person.photo_url}} alt={{person.callsign}} loading="lazy"/>
-              {{else}}
-                {{fa-icon "user"}}
-              {{/if}}
-            </div>
-            <div class="rollcall-indicator">
-              {{#if person.isSubmitting}}
-                {{fa-icon "spinner" spin=true}}
-              {{else if person.on_duty}}
-                {{fa-icon "walking" color="danger"}}
-              {{else if person.signedIn}}
-                {{fa-icon "walking" color="success"}}
-              {{/if}}
-            </div>
-            <div class="rollcall-name">
-              {{person.callsign}}
-            </div>
-            <div class="rollcall-info">
-              {{#if person.on_duty}}
-                <b>Already on duty</b><br>
-                {{person.on_duty.position.title}}<br>
-                {{shift-format person.on_duty.on_duty}}
-              {{else if person.signedIn}}
-                Signed in.
-              {{/if}}
-            </div>
-          </a>
-        {{/each}}
-      </div>
-    {{else if (gt this.slotId 0)}}
-      <p class="text-danger">
-        <b>No sign ups found for the shift.</b>
-      </p>
-    {{/if}}
-  {{/if}}
+{{#if this.isSignOut}}
+  <RollcallSignOut/>
+{{else if this.isSignIn}}
+  <RollcallSignIn/>
 {{/if}}

--- a/app/templates/reports/vehicle-registry.hbs
+++ b/app/templates/reports/vehicle-registry.hbs
@@ -144,12 +144,16 @@ Showing {{this.viewVehicles.length}} of {{pluralize this.person_vehicle.length "
               <f.input @name="type" @type="radioGroup" @options={{this.typeOptions}} @inline={{true}}
                        @wrapClass="col-auto mt-2"/>
               <label class="col-form-label col-auto">Event Year</label>
-              <f.input @name="event_year" @type="text" @size=4 @wrapClass="col-auto mt-1"
+              <f.input @name="event_year"
+                       @type="text"
+                       @size={{4}}
+                       @wrapClass="col-auto mt-1"
                        @controlClass="form-control form-control-sm"/>
               {{#if (eq f.model.type "personal")}}
                 <label class="col-form-label">Personal Vehicle Owner</label>
                 <div class="col-auto mt-1">
-                  <f.input @name="callsign" @type="search"
+                  <f.input @name="callsign"
+                           @type="search"
                            @controlClass="form-control form-control-sm autocomplete-input"
                            @onSearch={{this.searchCallsignAction}}
                   />
@@ -157,7 +161,11 @@ Showing {{this.viewVehicles.length}} of {{pluralize this.person_vehicle.length "
               {{else}}
                 <label class="col-form-label">Team Assignment</label>
                 <div class="col-auto mt-1">
-                  <f.input @name="team_assignment" @type="text" @size="10" @controlClass="form-control form-control-sm"/>
+                  <f.input
+                    @name="team_assignment"
+                    @type="text"
+                    @size={{10}}
+                    @controlClass="form-control form-control-sm"/>
                 </div>
               {{/if}}
             </div>
@@ -167,17 +175,24 @@ Showing {{this.viewVehicles.length}} of {{pluralize this.person_vehicle.length "
             <div class="row form-group">
               <f.input @name="vehicle_class" @label="Class" @type="select" @options={{this.vehicleClassOptions}}
                        @wrapClass="col-auto" @controlClass="form-control form-control-sm"/>
-              <f.input @name="vehicle_year" @label="Year" @type="text" @size="4"
-                       @maxlength="4"
+              <f.input @name="vehicle_year"
+                       @label="Year"
+                       @type="text"
+                       @size={{4}}
+                       @maxlength={{4}}
                        @wrapClass="col-auto" @controlClass="form-control form-control-sm"/>
-              <f.input @name="vehicle_make" @label="Make" @type="text" @size="15"
+              <f.input @name="vehicle_make"
+                       @label="Make"
+                       @type="text"
+                       @size={{15}}
                        @hint="e.g., Ford, GMC, Toyota, etc."
-                       @wrapClass="col-auto" @controlClass="form-control form-control-sm"/>
+                       @wrapClass="col-auto"
+                       @controlClass="form-control form-control-sm"/>
               <f.input @name="vehicle_model" @label="Model"
                        @hint="e.g., F-350, Tacoma, etc."
-                       @type="text" @size="15"
+                       @type="text" @size={{15}}
                        @wrapClass="col-auto" @controlClass="form-control form-control-sm"/>
-              <f.input @name="vehicle_color" @label="Color" @type="text" @size="15"
+              <f.input @name="vehicle_color" @label="Color" @type="text" @size={{15}}
                        @wrapClass="col-auto" @controlClass="form-control form-control-sm"/>
             </div>
             <div class="row form-group">
@@ -186,14 +201,14 @@ Showing {{this.viewVehicles.length}} of {{pluralize this.person_vehicle.length "
                        @controlClass="form-control form-control-sm"
                        @disabled={{eq f.model.type "personal"}}
               />
-              <f.input @name="sticker_number" @label="Driving Sticker #" @type="text" @size="10"
+              <f.input @name="sticker_number" @label="Driving Sticker #" @type="text" @size={{10}}
                        @wrapClass="col-auto"
                        @controlClass="form-control form-control-sm"
               />
               <f.input @name="license_state" @label="License State/Province" @type="select"
                        @options={{this.stateOptions}}
                        @wrapClass="col-auto" @controlClass="form-control form-control-sm"/>
-              <f.input @name="license_number" @label="License Plate #" @type="text" @size="10" @wrapClass="col-auto"
+              <f.input @name="license_number" @label="License Plate #" @type="text" @size={{10}} @wrapClass="col-auto"
                        @controlClass="form-control form-control-sm"/>
             </div>
           </fieldset>
@@ -201,7 +216,9 @@ Showing {{this.viewVehicles.length}} of {{pluralize this.person_vehicle.length "
             <legend>Personal Vehicle Use Items (Stickers &amp; Other Items)</legend>
             <div class="form-row">
               <label class="col-form-label col-form-label-fixed ">Driving Sticker</label>
-              <f.input @name="driving_sticker" @type="radioGroup" @options={{this.drivingStickerOptions}}
+              <f.input @name="driving_sticker"
+                       @type="radioGroup"
+                       @options={{this.drivingStickerOptions}}
                        @inline={{true}} />
             </div>
             <div class="form-row">
@@ -220,16 +237,16 @@ Showing {{this.viewVehicles.length}} of {{pluralize this.person_vehicle.length "
           <fieldset class="mt-2">
             <legend>Notes &amp; Status</legend>
             <div class="form-row">
-              <f.input @name="notes" @label="Private Notes" @type="textarea" @rows="2" @cols="80"
+              <f.input @name="notes" @label="Private Notes" @type="textarea" @rows={{2}} @cols={{80}}
                        @wrapClass="col-auto"/>
             </div>
             <div class="form-row mt-3">
-              <f.input @name="request_comment" @label="Comment from person (only used for personal vehicles)" @type="textarea" @rows="2" @cols="80"
+              <f.input @name="request_comment" @label="Comment from person (only used for personal vehicles)" @type="textarea" @rows={{2}} @cols={{80}}
                        @wrapClass="col-auto" @disabled={{not-eq f.model.type "personal"}}/>
             </div>
             <div class="form-row mt-3">
               <f.input @name="response" @label="Response to person (only used for personal vehicles)" @type="textarea"
-                       @rows="2" @cols="80" @wrapClass="col-auto" @disabled={{not-eq f.model.type "personal"}}
+                       @rows={{2}} @cols={{80}} @wrapClass="col-auto" @disabled={{not-eq f.model.type "personal"}}
               />
             </div>
             <div class="row form-group">
@@ -294,7 +311,7 @@ Showing {{this.viewVehicles.length}} of {{pluralize this.person_vehicle.length "
           {{#if (and this.entry.isApproved (not-eq this.entry.driving_sticker "none"))}}
             <div class="form-row mt-2">
               <f.input @name="sticker_number" @label="Enter Driving Sticker #"
-                       @type="text" @size="10" @wrapClass="col-auto" @autofocus={{true}} />
+                       @type="text" @size={{10}} @wrapClass="col-auto" @autofocus={{true}} />
             </div>
           {{/if}}
         {{/if}}


### PR DESCRIPTION
- AutocompleteInput component was not updating the field after user clicked on dropdown suggestion.
- Rollcall sign in & out layouts mirror each other.
- On shift management page and shift check in/out component: merged Starts & Ends columns into a Time column and show the start & ends as simplified range. (e.g. Fri Aug 31 @ 17:30 to 19:30 or Fri Aug 31 @ 17:30 to Sat @ 01:00)
- Tweaked schedule CSS to allocate more space to the Time column, and reduced right margins for duration & credits.