### PR TITLE
Fix action log crash when using an invalid callsign, plus other fixes.

### DIFF
--- a/app/components/autocomplete-input.hbs
+++ b/app/components/autocomplete-input.hbs
@@ -32,12 +32,12 @@
   </div>
   {{#if (and this.isFocused (or this.isSearching this.noResultsFound this.options))}}
     <div class="autocomplete-results-box mt-1 border rounded"
-      {{did-insert this.resutsBoxInsertedEvent}}
+      {{did-insert this.resultsBoxInsertedEvent}}
       {{will-destroy this.resultsBoxDestroy}}
     >
       <div class="autocomplete-list">
         {{~#if this.noResultsFound~}}
-          <div>No results found</div>
+          <div>{{this.noResultsText}}</div>
         {{~else if this.isSearching~}}
           <div class="text-muted">Searching <SpinIcon /></div>
         {{~/if~}}

--- a/app/components/autocomplete-input.js
+++ b/app/components/autocomplete-input.js
@@ -63,6 +63,19 @@ export default class AutocompleteInputComponent extends Component {
   }
 
   /**
+   * Obtain the mode text for display.
+   *
+   * @returns {string}
+   */
+
+  get modeText() {
+    const mode = this.args.mode;
+    const opt = this.args.modeOptions.find((o) => o.value == mode);
+
+    return opt ? opt.label : `Unknown ${mode}`;
+  }
+
+  /**
    * Handle input into the search field.
    *
    * @param {InputEvent} event
@@ -110,6 +123,12 @@ export default class AutocompleteInputComponent extends Component {
     this.isFocused = true;
     this.selectionIdx = -1;
     this.options = [];
+    this.hasSelected = false;
+
+    if (this.args.form) {
+      this.args.form.preventSubmit = true;
+    }
+
     if (this.args.onFocus) {
       this.args.onFocus();
     }
@@ -196,14 +215,28 @@ export default class AutocompleteInputComponent extends Component {
 
   @action
   blurEvent() {
-    if (!this.isFocused) {
-      return;
+    if (this.args.form) {
+      this.args.form.preventSubmit = false;
     }
+
+    if (!this.isFocused) {
+      return true;
+    }
+
     setTimeout(() => {
       schedule('afterRender', () => {
+        if (this.args.selectOnBlur && this.options.length > 0) {
+          if (this.options.length === 1 || this.selectionIdx === -1) {
+            this._selectOption(this.options[0]);
+          } else {
+            this._selectOption(this.options[this.selectionIdx]);
+          }
+        }
         this.isFocused = false;
       })
     }, 100);
+
+    return true;
   }
 
   /**
@@ -240,7 +273,10 @@ export default class AutocompleteInputComponent extends Component {
     this.isFocused = false;
     this.hasSelected = true;
     this.selectionIdx = -1;
-    this.inputElement.blur();
+
+    if (!this.args.keepFocusOnSelect) {
+      this.inputElement.blur();
+    }
   }
 
   /**
@@ -266,22 +302,10 @@ export default class AutocompleteInputComponent extends Component {
   @action
   selectModeEvent(value, event) {
     event.preventDefault();
-    if (this.args.onModeChange) {
-      this.args.onModeChange(value);
+    const {onModeChange} = this.args;
+    if (onModeChange) {
+      onModeChange(value);
     }
-  }
-
-  /**
-   * Obtain the mode text for display.
-   *
-   * @returns {string}
-   */
-
-  get modeText() {
-    const mode = this.args.mode;
-    const opt = this.args.modeOptions.find((o) => o.value == mode);
-
-    return opt ? opt.label : `Unknown ${mode}`;
   }
 
   /**
@@ -289,8 +313,9 @@ export default class AutocompleteInputComponent extends Component {
    *
    * @param {Element} element
    */
+
   @action
-  resutsBoxInsertedEvent(element) {
+  resultsBoxInsertedEvent(element) {
     this.resultsElement = element;
 
     schedule('afterRender', () => {
@@ -307,5 +332,15 @@ export default class AutocompleteInputComponent extends Component {
   resultsBoxDestroy() {
     this.resultsElement = null;
     this.hasSelected = false;
+  }
+
+  /**
+   * Return the text to show when no results were found.
+   *
+   * @returns {string}
+   */
+
+  get noResultsText() {
+    return this.args.noResultsText ?? 'No results found';
   }
 }

--- a/app/components/ch-form.js
+++ b/app/components/ch-form.js
@@ -14,6 +14,9 @@ export default class ChFormComponent extends Component {
 
   watchingModel = null;
 
+  // AutoComplete hack to prevent Enter from triggering a submit event
+  preventSubmit = false;
+
   constructor() {
     super(...arguments);
 
@@ -157,6 +160,10 @@ export default class ChFormComponent extends Component {
 
   @action
   submitForm(callback = null) {
+    if (this.preventSubmit) {
+      return;
+    }
+
     const model = this.model;
     const {formFor} = this.args;
 

--- a/app/components/ch-form/search-field.hbs
+++ b/app/components/ch-form/search-field.hbs
@@ -9,7 +9,11 @@
                        @onFocus={{@onFocus}}
                        @disabled={{@disabled}}
                        @autofocus={{@autofocus}}
+                       @selectOnBlur={{true}}
+                       @keepFocusOnSelect={{true}}
+                       @form={{@form}}
                        @inputClass="{{this.controlClass}} {{if this.errorMessages "is-invalid"}}"
+                       @noResultsText={{@noResultsText}}
                        @text={{this.modelValue}} as |item|>
       {{~item~}}
     </AutocompleteInput>

--- a/app/components/message-new.hbs
+++ b/app/components/message-new.hbs
@@ -26,7 +26,9 @@
                  @size={{30}}
                  @maxlength={{60}}
                  @onSearch={{this.searchCallsignAction}}
-                 @autofocus={{this.isFromMessage}}/>
+                 @autofocus={{this.isFromMessage}}
+                 @noResultsText="No callsigns found"
+        />
       </FormRow>
       <FormRow>
         <f.text @name="subject"

--- a/app/components/modal-dialog.js
+++ b/app/components/modal-dialog.js
@@ -32,7 +32,7 @@ export default class ModalDialogComponent extends Component {
   @action
   boxInserted(element) {
     this._element = element;
-    this.bootstrapModal = new bootstrap.Modal(this._element, {keyboard: false});
+    this.bootstrapModal = new bootstrap.Modal(this._element, {keyboard: false, backdrop: 'static'});
     this.bootstrapModal.show();
   }
 

--- a/app/controllers/admin/action-log.js
+++ b/app/controllers/admin/action-log.js
@@ -49,21 +49,19 @@ export default class AdminActionLogController extends ClubhouseController {
     set(this, 'page', +this.currentPage - 1);
   }
 
-  _performSearch(query, resolve, reject) {
-    if (query.match(/^\d+/)) {
-      return resolve([query]);
+  _performSearch(callsign, resolve, reject) {
+    callsign = callsign.trim();
+
+    if (callsign.match(/^\d+/)) {
+      return resolve([callsign]);
     }
 
-    return this.ajax
-      .request('callsigns', {
-        data: {query, type: 'all', limit: 20}
-      })
-      .then((result) => {
-        if (result.callsigns.length > 0) {
-          return resolve(result.callsigns.map((c) => c.callsign));
-        }
-        return reject();
-      }, reject);
+    if (callsign.length < 2) {
+      return reject();
+    }
+
+    return this.ajax.request('callsigns', { data: {query: callsign, type: 'all', limit: 20} })
+      .then(({callsigns}) => resolve(callsigns.map(row => row.callsign)), reject);
   }
 
   @action
@@ -81,7 +79,7 @@ export default class AdminActionLogController extends ClubhouseController {
   @action
   searchAction() {
     const params = {};
-
+    console.log('CALLED SEARCH');
     this.queryParams.forEach((param) => {
       if (this.query[param]) {
         if (params === 'events') {

--- a/app/routes/admin/action-log.js
+++ b/app/routes/admin/action-log.js
@@ -27,7 +27,16 @@ export default class AdminActionLogRoute extends ClubhouseRoute {
     }, {});
 
     this.searchParams = searchParams;
-    return this.ajax.request('action-log', {data: searchParams});
+    return this.ajax.request('action-log', {data: searchParams}).catch((response) => {
+      if (response.status !== 422) {
+        throw response;
+      }
+      return {
+        error: response.payload.errors[0].title,
+        action_logs: [],
+        meta: {}
+      }
+    });
   }
 
   setupController(controller, model) {

--- a/app/templates/admin/action-log.hbs
+++ b/app/templates/admin/action-log.hbs
@@ -9,19 +9,20 @@
 
   <ChForm @formId="query" @formFor={{this.query}} @changeSet={{false}} @onSubmit={{this.searchAction}} as |f|>
     <FormRow>
-      <f.text @name="person"
-              @label="Person"
-              @size={{30}}
-              @fieldSize="sm"
-              @hint="Callsign or person id"/>
+      <f.search @name="person"
+                @label="Person"
+                @size={{30}}
+                @hint="Callsign or person id"
+                @autofocus={{true}}
+                @onSearch={{this.searchCallsignAction}}
+                @noResultsText="No callsigns found"
+      />
       <f.datetime @name="start_time"
                   @label="Start time (UTC-7)"
-                  @fieldSize="sm"
-                  @size={{30}} />
+                  @size={{20}} />
       <f.datetime @name="end_time"
                   @label="End time (UTC-7)"
-                  @fieldSize="sm"
-                  @size={{30}} />
+                  @size={{20}} />
     </FormRow>
     <FormRow>
       <FormLabel @fixed={{true}}>Events</FormLabel>

--- a/app/templates/reports/vehicle-registry.hbs
+++ b/app/templates/reports/vehicle-registry.hbs
@@ -167,6 +167,7 @@ Showing {{this.viewVehicles.length}} of {{pluralize this.person_vehicle.length "
                           @label="Personal Vehicle Owner"
                           @controlClass="form-control form-control-sm autocomplete-input"
                           @onSearch={{this.searchCallsignAction}}
+                          @noResultsText="No callsigns found"
                 />
               {{else}}
                 <f.text


### PR DESCRIPTION
- Keep field focus when selecting an autocomplete suggestion.
- Allow AutocompleteInput no result text to be specified.
- Prevent form submission when hitting enter to select an autocomplete item.