### PR TITLE
Evolve FCC handle rule into Inappropriate Words; add Roma slurs

### DIFF
--- a/app/controllers/vc/handle-checker.js
+++ b/app/controllers/vc/handle-checker.js
@@ -9,7 +9,7 @@ import {
   EditDistanceRule,
   ExperimentalEyeRhymeRule,
   EyeRhymeRule,
-  FccRule,
+  InappropriateRule,
   MinLengthRule,
   PhoneticAlphabetRule,
   SubstringRule
@@ -86,7 +86,7 @@ export default class VcHandlerCheckerController extends ClubhouseController {
     // No input yet on ideal ordering for all checks.
     addRule(new SubstringRule(handles), 'Substring');
     addRule(new MinLengthRule(), 'Minimum Length');
-    addRule(new FccRule(), 'FCC naughty words');
+    addRule(new InappropriateRule(), 'Inappropriate words');
     addRule(new PhoneticAlphabetRule(handles), 'Phonetic alphabet');
     addRule(new EditDistanceRule(handles), 'Edit distance');
     addRule(new AmericanSoundexRule(handles), 'American Soundex');

--- a/app/utils/handle-rules.js
+++ b/app/utils/handle-rules.js
@@ -22,33 +22,54 @@ export class MinLengthRule {
 }
 
 
-/** Enforces the FCC's no-swearing-on-the-radio rule. */
-export class FccRule {
+/** Warns abuout words the FCC could fine us about or ethnic slurs that shouldn't be part of a callsign. */
+export class InappropriateRule {
   constructor() {
-    // TODO consider putting these in the HandleController data response so rhyming checkers
-    // can catch thins that rhyme with obscenities.
-    this.obsceneWords = {
+    const fcc = 'is frowned on by the FCC';
+    const roma = 'is an ethnic slur for the Roma people';
+    this.inappropriateWords = {
       // the Carlin 7
-      'shit': true,
-      'piss': true,
-      'fuck': true,
-      'cunt': true,
-      'cocksucker': true,
-      'motherfucker': true,
-      'tits': true,
-      // TODO other words?
+      'shit': fcc,
+      'piss': fcc,
+      'fuck': fcc,
+      'cunt': fcc,
+      'cocksucker': fcc,
+      'motherfucker': fcc,
+      'tits': fcc,
+      // TODO are there FCC swear words George Carlin didn't share?
+
+      // Roma ethnic slurs per https://github.com/burningmantech/ranger-clubhouse-api/issues/1087
+      'gypsy': roma,
+      'gipsy': roma,
+      'gypsi': roma,
+      'gypsys': roma,
+      'gipsys': roma,
+      'gypsis': roma,
+      'gypsies': roma,
+      'zingara': roma,
+      'zingaro': roma,
+      'tzigan': roma,
+      'tzigane': roma,
+      'gyppo': roma,
+      'cigano': roma,
+      'zigeuner': roma,
+      'gitan': roma,
+      'gitano': roma,
+
+      // TODO slurs for more ethnic groups?
     };
   }
 
   get id() {
-    return 'fcc';
+    return 'inappropriate';
   }
 
   check(name) {
     const result = [];
     for (const word of name.toLowerCase().split(/[^a-z]+/)) {
-      if (this.obsceneWords[word]) {
-        result.push(new HandleConflict(name, `${word} is frowned on by the FCC`, 'high', this.id));
+      const reason = this.inappropriateWords[word];
+      if (reason) {
+        result.push(new HandleConflict(name, `${word} ${reason}`, 'high', this.id));
       }
     }
     return result;
@@ -554,7 +575,7 @@ export const ALL_RULE_CLASSES = [
   EditDistanceRule,
   EyeRhymeRule,
   ExperimentalEyeRhymeRule,
-  FccRule,
+  InappropriateRule,
   MinLengthRule,
   PhoneticAlphabetRule,
   SubstringRule

--- a/tests/unit/utils/handle-rules-test.js
+++ b/tests/unit/utils/handle-rules-test.js
@@ -5,7 +5,7 @@ import {
   EditDistanceRule,
   // TODO test ExperimentalEyeRhymeRule
   EyeRhymeRule,
-  FccRule,
+  InappropriateRule,
   MinLengthRule,
   PhoneticAlphabetRule,
   SubstringRule,
@@ -68,7 +68,7 @@ module('Unit | Utility | handle-rules', function(hooks) {
       'edit-distance',
       'experimental-eye-rhyme',
       'eye-rhyme',
-      'fcc',
+      'inappropriate',
       'min-length',
       'phonetic-alphabet',
       'substring'
@@ -142,17 +142,17 @@ module('Unit | Utility | handle-rules', function(hooks) {
     checkit(String.fromCodePoint(0x1F4A9));
   });
 
-  // === FccRule tests ===
+  // === InappropriateRule tests ===
   // eslint-disable-next-line qunit/require-expect
-  test('fcc accepts non-swear words', function(assert) {
-    const rule = new FccRule();
+  test('inappropriate accepts non-swear words', function(assert) {
+    const rule = new InappropriateRule();
     noConflicts(assert, rule, 'Puppy');
-    noConflicts(assert, rule, 'Mike Hawk'); // rquires human detection
+    noConflicts(assert, rule, 'Mike Hunt'); // rquires human detection
   });
 
   // eslint-disable-next-line qunit/require-expect
-  test('fcc rejects the Carlin 7', function(assert) {
-    const rule = new FccRule();
+  test('inappropriate rejects the Carlin 7', function(assert) {
+    const rule = new InappropriateRule();
     let checkit = (name) => {
       let conflicts = rule.check(name);
       assert.strictEqual(conflicts.length, 1, `${JSON.stringify(conflicts.length)} conflicts for ${name}`);
@@ -166,6 +166,21 @@ module('Unit | Utility | handle-rules', function(hooks) {
     checkit('CockSucker');
     checkit('Charismatic Motherfucker');
     checkit('2Tits');
+  });
+
+  // eslint-disable-next-line qunit/require-expect
+  test('inappropriate rejects the Roma slurs', function(assert) {
+    const rule = new InappropriateRule();
+    let checkit = (name) => {
+      let conflicts = rule.check(name);
+      assert.strictEqual(conflicts.length, 1, `${JSON.stringify(conflicts.length)} conflicts for ${name}`);
+      assert.strictEqual(conflicts[0].candidateName, name);
+      assert.ok(conflicts[0].description.match(/Roma/));
+    };
+    checkit('Gypsy Child');
+    checkit('Band of Gypsies');
+    checkit('Zingara');
+    checkit('Big-Gitan');
   });
 
   // === PhoneticAlphabetRule tests ===


### PR DESCRIPTION
This fixes the immediate request from
https://github.com/burningmantech/ranger-clubhouse-api/issues/1087
though I imagine we'll want to add other ethnic slurs and words you
shouldn't say on the radio at some future date.  Doing so is now a
simple matter of creating a reason string and associating each
inappropriate word with that reason in the inappropriateWords object.