### PR TITLE
Bypass address requirements for defunct accounts. Better uncaught error logging.

### DIFF
--- a/app/constants/person_status.js
+++ b/app/constants/person_status.js
@@ -26,3 +26,12 @@ export const ALLOWED_TO_WORK = [
   PROSPECTIVE,    // Mentor will need to convert Alpha
   RETIRED,
 ];
+
+// Admins or VCs may have to update legacy defunct accounts with little PII.
+// Allow address validation to be bypassed for such accounts.
+export const ADDRESS_VALIDATION_NOT_REQUIRED = [
+  DECEASED,
+  DISMISSED,
+  RESIGNED,
+  RETIRED
+];

--- a/app/controllers/person/personal-info.js
+++ b/app/controllers/person/personal-info.js
@@ -1,18 +1,28 @@
 import ClubhouseController from 'clubhouse/controllers/clubhouse-controller';
-import { action } from '@ember/object';
-import { Role } from 'clubhouse/constants/roles';
-import PersonInfoValidations from 'clubhouse/validations/person-info';
-import { ShortSleeve, LongSleeve } from 'clubhouse/constants/shirts';
-import { pronounOptions } from 'clubhouse/constants/pronouns';
+import {action} from '@ember/object';
+import {cached} from '@glimmer/tracking';
+import PersonInfoValidations, {REQUIRED_PII_VALIDATIONS} from 'clubhouse/validations/person-info';
+import {ShortSleeve, LongSleeve} from 'clubhouse/constants/shirts';
+import {pronounOptions} from 'clubhouse/constants/pronouns';
+import {ADMIN, VC} from 'clubhouse/constants/roles';
+import {ADDRESS_VALIDATION_NOT_REQUIRED} from 'clubhouse/constants/person_status';
 
 export default class PersonPersonalInfoController extends ClubhouseController {
-  personInfoValidations = PersonInfoValidations;
   shortSleeveOptions = ShortSleeve;
   longSleeveOptions = LongSleeve;
   pronounOptions = pronounOptions;
 
+  @cached
+  get personInfoValidations() {
+    if (ADDRESS_VALIDATION_NOT_REQUIRED.includes(this.person.status) && this.session.isAdmin) {
+      return REQUIRED_PII_VALIDATIONS;
+    } else {
+      return PersonInfoValidations;
+    }
+  }
+
   get canEditPersonalInfo() {
-    return this.session.hasRole(Role.ADMIN);
+    return this.session.hasRole([ADMIN, VC]);
   }
 
   @action

--- a/app/models/person.js
+++ b/app/models/person.js
@@ -25,6 +25,7 @@ export default class PersonModel extends PersonMixin(Model) {
   @attr('boolean') on_site;
   @attr('boolean') has_reviewed_pi;   // pseudo field, write only
   @attr('string') reviewed_pi_at;
+  @attr('string') pi_reviewed_for_dashboard_at;
   @attr('string', {readOnly: true}) logged_in_at;
   @attr('string', {readOnly: true}) last_seen_at;
 

--- a/app/routes/error.js
+++ b/app/routes/error.js
@@ -23,8 +23,6 @@ export default class ErrorRoute extends ClubhouseRoute {
     controller.set('isOffline', isOffline);
     controller.set('notAuthorized', (error && (isForbiddenError(error) || error.status === 403)));
 
-    if (!error.message?.match(/Network request failed/i)) {
-      logError(error, 'client-ember-route-error');
-    }
+    logError(error, 'client-ember-route-error');
   }
 }

--- a/app/templates/person/personal-info.hbs
+++ b/app/templates/person/personal-info.hbs
@@ -8,9 +8,10 @@
     Has not updated their Personal Information yet.
   {{/if}}
   <br>
+  {{log this.person}}
   {{#if this.person.pi_reviewed_for_dashboard_at}}
     Last reviewed for dashboard on
-    {{dayjs-format this.person.reviewed_pi_at "MMM DD, YYYY @ HH:mm"}} (UTC-7).
+    {{dayjs-format this.person.pi_reviewed_for_dashboard_at "MMM DD, YYYY @ HH:mm"}} (UTC-7).
   {{else}}
     Has not reviewed for dashboard yet.
   {{/if}}

--- a/app/validations/person-info.js
+++ b/app/validations/person-info.js
@@ -4,7 +4,7 @@ import {
 import validateState from 'clubhouse/validators/state';
 import validatePronouns from 'clubhouse/validators/pronouns';
 
-export default {
+export const REQUIRED_PII_VALIDATIONS = {
   first_name: [
     validatePresence(true)
   ],
@@ -16,7 +16,10 @@ export default {
   email: [
     validateFormat({ type: 'email' })
   ],
+};
 
+export default {
+  ...REQUIRED_PII_VALIDATIONS,
   street1: [
     validatePresence(true),
   ],

--- a/config/environment.js
+++ b/config/environment.js
@@ -19,7 +19,12 @@ module.exports = function (environment) {
     },
 
     APP: {
-      buildTimestamp: new Date().toISOString()
+      buildTimestamp: new Date().toLocaleString('en-US', {
+        dateStyle: "medium",
+        timeStyle: "long",
+        hourCycle: "h24",
+        timeZone: "America/Los_Angeles"
+      })
     },
 
     'ember-simple-auth': {


### PR DESCRIPTION

- Admin & VCs: Do not require addresses for old defunct accounts (mid-to-late 2000s, no address, retired/resigned/deceased/dismissed status)
- Top level window error handler (window.onerror) was not grabbing the stack trace when logging the exception.
- Show the build-stamp in a more human friendly format with the Pacific timezone, not UTC.