### PR TITLE
PNV dashboard tweak. Accordion change. Added Scheduling page UI navigation guidance.

### DIFF
--- a/app/components/ch-accordion-title.hbs
+++ b/app/components/ch-accordion-title.hbs
@@ -1,5 +1,5 @@
 {{!template-lint-disable require-presentational-children}}
 <div class="accordion-title" role="button" {{action @onClick}} ...attributes>
-  <div class="accordion-title-text">{{yield}}{{#if @isWorking~}}<SpinIcon/>{{/if}}</div>
   <div class="accordion-title-icon">{{fa-icon (if @isOpen "minus" "plus")}}</div>
+  <div class="accordion-title-text">{{yield}}{{#if @isWorking~}}<SpinIcon/>{{/if}}</div>
 </div>

--- a/app/components/schedule-manage.hbs
+++ b/app/components/schedule-manage.hbs
@@ -52,13 +52,15 @@
                                 @onChange={{action (mut this.filterDay)}} />
               </div>
             </FormRow>
-
             <p>
+              Click on the position title to show the available shifts.
+            </p>
+            <div>
               <b>Showing {{this.viewSlots.length}} of {{this.availableSlots.length}}.</b>
               {{#if (not-eq this.viewSlots.length this.availableSlots.length)}}
-                <b> Adjust the filter above to show prior shifts &amp; trainings.</b>
+                <b> Adjust the day filter above to show prior shifts &amp; trainings.</b>
               {{/if}}
-            </p>
+            </div>
             {{#each this.positions key="position_id" as |position|}}
               <SchedulePositionList @position={{position}}
                                     @showPeople={{this.showPeople}}

--- a/app/components/schedule-manage.js
+++ b/app/components/schedule-manage.js
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import {action} from '@ember/object';
 import {set} from '@ember/object';
-import {Role} from 'clubhouse/constants/roles';
+//import {Role} from 'clubhouse/constants/roles';
 import dayjs from 'dayjs';
 import {schedule} from '@ember/runloop';
 import {tracked} from '@glimmer/tracking';
@@ -56,12 +56,12 @@ export default class ScheduleManageComponent extends Component {
      * TODO Revisit whether everyone should be able to see inactive slots if they choose.
      */
 
-    if (this.session.hasRole(
+  /*  if (this.session.hasRole(
       [Role.ADMIN, Role.EDIT_SLOTS, Role.GRANT_POSITION, Role.VC, Role.TRAINER, Role.ART_TRAINER])) {
       this.availableSlots = slots;
-    } else {
+    } else {*/
       this.availableSlots = slots.filter((slot) => slot.slot_active);
-    }
+   /* }*/
 
     this.inactiveSlots = this.availableSlots.filter((slot) => !slot.slot_active);
     this.isCurrentYear = (+year === this.house.currentYear());

--- a/app/constants/dashboard-steps.js
+++ b/app/constants/dashboard-steps.js
@@ -104,7 +104,7 @@ export const UPLOAD_PHOTO = {
         return {result: ACTION_NEEDED, isPhotoStep: true};
       case 'submitted':
       case 'approved':
-        return {result: isPNV ? COMPLETED : SKIP, isPhotoStep: (photo.photo_status === 'approved')};
+        return {result: isPNV ? COMPLETED : SKIP, isPhotoStep: (photo.photo_status !== 'approved')};
       default:
         return {
           result: NOT_AVAILABLE,

--- a/app/styles/accordion.scss
+++ b/app/styles/accordion.scss
@@ -6,7 +6,7 @@
 
 .accordion-title {
   display: flex;
-  justify-content: space-between;
+  /*  justify-content: space-between;*/
 
   padding: 10px;
   background-color: #e9ecef;
@@ -19,7 +19,7 @@
 }
 
 .accordion-title-icon {
-  margin-left: 5px;
+  margin-right: 5px;
   width: 15px;
 }
 


### PR DESCRIPTION

- PNV Dashboard: Don't show the photo upload link on the completed Photo Approval step. Only show it if the photo was denied.
- Moved the open / closed indicator back to the left on the accordion title. (possibly user confusion going on with the indicators on the right)
- Tell users to click on the position title to expand the accordions on the scheduling page.