### PR TITLE
BMID sanity checker worker. Ticketing close tweaks.

### DIFF
--- a/app/components/ticketing-closed.hbs
+++ b/app/components/ticketing-closed.hbs
@@ -122,7 +122,8 @@
           </li>
         {{/if}}
 
-        {{#unless this.usingStaffCredential}}
+        {{#if (or this.usingWAP (not this.usingStaffCredential))}}
+          {{! A person may have a SC with a later access date, and then a WAP with an earler corrected access date}}
           <li class="mt-2">
             {{#if this.usingWAP}}
               <b class="text-success">A Work Access Pass will be emailed to you.</b><br>
@@ -138,7 +139,7 @@
               {{fa-icon "times" color="danger"}} No Work Access Pass was claimed.
             {{/if}}
           </li>
-        {{/unless}}
+        {{/if}}
 
         {{#if this.hasFullPackage}}
           <li class="mt-2">

--- a/app/templates/vc/bmid-sanity-check.hbs
+++ b/app/templates/vc/bmid-sanity-check.hbs
@@ -11,7 +11,9 @@
       <ChAccordion as |Accordion|>
         <Accordion.title>
           {{#if (eq asylum.type "shifts-before-access-date")}}
-            Signed Up For Shifts Earlier Than WAP Access Date
+            Signed Up For Shifts Earlier Than Non-Submitted WAP Access Date
+          {{else if (eq asylum.type "shifts-before-submitted-wap")}}
+            Signed Up For Shifts Earlier Than Submitted WAP Access Date
           {{else if (eq asylum.type "shifts-no-wap")}}
             Signed Up For Pre-Event Shifts But No WAP
           {{else if (eq asylum.type "rpt-before-box-office")}}


### PR DESCRIPTION
- Report separately submitted versus claimed/qualified WAPs access date after first shift sign up.
- Always show a submitted WAP regardless if a S.C. is being used on the ticketing closed page.