### PR TITLE
Various UI Tweaks

### DIFF
--- a/app/components/dashboard-group.hbs
+++ b/app/components/dashboard-group.hbs
@@ -1,7 +1,7 @@
 <div class="dashboard-group {{if @isActive "dashboard-group-active"}}">
   <div class="dashboard-group-title-box {{if @hasTopArrow "dashboard-group-top-arrow"}} {{if @hasBottomArrow
                                                                                              "dashboard-group-bottom-arrow"}}">
-    <div class="dashboard-group-title-text">{{@title}}</div>
+    <div class="dashboard-group-title-text  {{if @isUrgent "dashboard-group-title-urgent"}}">{{@title}}</div>
   </div>
   <div class="dashboard-steps">
     {{yield}}

--- a/app/components/dashboard-links.hbs
+++ b/app/components/dashboard-links.hbs
@@ -7,7 +7,9 @@
       <div class="dashboard-step">
         <div class="dashboard-step-description">
           <p>
-          <a href={{config "RangerManualUrl"}}  rel="noopener noreferrer" target="_blank">Ranger Manual (online)</a>
+            <a href={{config "RangerManualUrl"}}  rel="noopener noreferrer" target="_blank">
+              Ranger Manual (online)
+            </a>
           </p>
           {{#unless @isPNV}}
             <p>
@@ -21,8 +23,14 @@
               </a>
             </p>
             <p>
-              <a href={{config "RangerPoliciesUrl"}} rel="noopener noreferrer" target="_blank">Ranger Department
-                Policies</a>
+              <a href={{config "RangerPoliciesUrl"}} rel="noopener noreferrer" target="_blank">
+                Ranger Department Policies
+              </a>
+            </p>
+            <p>
+              <a href="http://brcdim.org/" rel="noopener noreferrer" target="_blank">
+                Department of Institutional Memory
+              </a>
             </p>
           {{/unless}}
           <a href {{action this.toggleIconLegend}}>Dashboard/Checklist icon legend</a>

--- a/app/components/dashboard-ranger.hbs
+++ b/app/components/dashboard-ranger.hbs
@@ -21,7 +21,7 @@
 </p>
 
 <p>
-Need help? <a href="#contacts">Jump to the contact section</a> below to see who to email.
+  Need help? <a href="#contacts">Jump to the contact section</a> below to see who to email.
 </p>
 
 {{#unless this.isAfterEvent}}
@@ -35,6 +35,7 @@ Need help? <a href="#contacts">Jump to the contact section</a> below to see who 
   {{#each this.stepGroups as |group idx|}}
     <DashboardGroup @title={{group.title}}
                     @isActive={{eq idx 0}}
+                    @isUrgent={{group.isUrgent}}
                     @hasTopArrow={{or @motds idx}}
                     @hasBottomArrow={{not group.isLast}}
                     @includeSidePhoto={{eq idx 0}}

--- a/app/components/dashboard-ranger.js
+++ b/app/components/dashboard-ranger.js
@@ -39,11 +39,13 @@ class StepGroup {
   @tracked steps;
   @tracked title;
   @tracked isActive;
+  @tracked isUrgent;
 
-  constructor(title, steps, isActive) {
+  constructor(title, steps, isActive, isUrgent = false) {
     this.title = title;
     this.steps = steps;
     this.isActive = isActive;
+    this.isUrgent = isUrgent;
   }
 }
 
@@ -484,7 +486,7 @@ export default class DashboardRangerComponent extends Component {
     } = this._processStepGroup(this.args.person.isNonRanger ? NON_RANGER_STEPS : STEPS);
 
     if (immediateSteps.length) {
-      groups.push(new StepGroup('IMMEDIATE ACTION REQUIRED', immediateSteps, true));
+      groups.push(new StepGroup('IMMEDIATE ACTION REQUIRED', immediateSteps, true, true));
     }
 
     if (!steps.length) {

--- a/app/components/dashboard-step-ticketing.hbs
+++ b/app/components/dashboard-step-ticketing.hbs
@@ -6,14 +6,23 @@
   {{else if @step.tickets.claimed}}
     You have claimed {{pluralize @step.tickets.claimed.length "item"}}:
     <ul>
-      {{#each @step.tickets.claimed as |ticket|}}
+      {{#each @step.tickets.claimed as |item|}}
         <li>
-          {{#if ticket.isWAPSO}}
-            Significant Other WAP for: <i>{{ticket.name}}</i>
-          {{else if ticket.isWAP}}
+          {{#if item.isWAPSO}}
+            Significant Other WAP for: <i>{{item.name}}</i>
+          {{else if item.isWAP}}
             Work Access Pass for yourself
+          {{else if item.isProvision}}
+            {{item.typeLabelWithCounts}}
+            {{#if item.earned_as_well}}
+              (allocated &amp; qualified)
+            {{else if item.is_allocated}}
+              (allocated)
+            {{else}}
+              (qualified)
+            {{/if}}
           {{else}}
-            {{ticket.typeLabel}} {{if ticket.isStaffCredential "which is also your WAP"}}
+            {{item.typeLabel}} {{if item.isStaffCredential "which is also your WAP"}}
           {{/if}}
         </li>
       {{/each}}
@@ -29,7 +38,8 @@
   </div>
 {{/if}}
 <div class="mt-1">
-  Visit <LinkTo @route="me.tickets">Me &gt; Tickets &amp; Stuff</LinkTo>
+  Visit
+  <LinkTo @route="me.tickets">Me &gt; Tickets &amp; Stuff</LinkTo>
   {{#if @step.ticketingOpen}}
     to claim or adjust your item(s).
   {{else}}

--- a/app/components/person/schedule-log.hbs
+++ b/app/components/person/schedule-log.hbs
@@ -32,7 +32,7 @@
         </thead>
         <tbody>
         {{#each this.logs as |entry|}}
-          <tr>
+          <tr class="{{if entry.no_signup "text-decoration-line-through"}}">
             <td>
               {{#if entry.no_signup}}
                 {{fa-icon "times" color="danger"}}

--- a/app/components/photo-table.hbs
+++ b/app/components/photo-table.hbs
@@ -20,8 +20,12 @@
   {{#each @photos as |photo|}}
     <tr>
       <td>
-        <img id="photo-{{photo.id}}" src={{photo.image_url}} class="photo-icon" role="button"
-          {{on "click" (fn this.showPhotoAction photo)}} alt={{photo.person.callsign}}
+        <img id="photo-{{photo.id}}"
+             src={{photo.image_url}}
+             class="photo-icon" role="button"
+             alt={{photo.person.callsign}}
+             loading="lazy"
+          {{on "click" (fn this.showPhotoAction photo)}}
         />
       </td>
       {{#unless @person}}
@@ -29,9 +33,7 @@
           <PersonLink @person={{photo.person}} />
         </td>
       {{/unless}}
-      <td>
-        {{photo.id}}
-      </td>
+      <td>{{photo.id}}</td>
       <td>
         {{#if (eq photo.status "approved")}}
           <b class="text-success">{{fa-icon "check"}} {{photo.status}}</b>
@@ -41,9 +43,9 @@
           {{photo.status}}
         {{/if}}<br>
         {{#if photo.is_active}}
-          <b>ACTIVE</b>
+          <b>CURRENT</b>
         {{else}}
-          <span class="text-muted">inactive</span>
+          <span class="text-muted">archived</span>
         {{/if}}
       </td>
       <td>

--- a/app/styles/dashboard.scss
+++ b/app/styles/dashboard.scss
@@ -19,6 +19,7 @@
     margin-top: 10px;
   }
 }
+
 .dashboard-links-things {
   margin-bottom: 20px;
 }
@@ -28,6 +29,9 @@
   font-weight: 400;
 }
 
+.dashboard-group-title-urgent {
+  color: #bd0010 !important;
+}
 
 .dashboard-steps {
   flex: 1;
@@ -89,7 +93,7 @@
 .dashboard-art-table {
   margin: 10px 0 15px 0;
   background-color: #ffffff;
- // box-shadow: 5px 5px 5px #888888;
+  // box-shadow: 5px 5px 5px #888888;
   //box-shadow: 0 0 5px 5px #dcdcdc;
   box-shadow: rgba(14, 30, 37, 0.12) 0px 2px 4px 0px, rgba(14, 30, 37, 0.32) 0px 2px 16px 0px;
 }
@@ -97,6 +101,7 @@
 .dashboard-art-header {
   padding: 5px;
 }
+
 .dashboard-art-row {
   padding: 5px 5px 0 5px;
 }
@@ -282,7 +287,7 @@
   }
 
   .dashboard-art-position {
-   min-width: 150px;
+    min-width: 150px;
   }
 
   .dashboard-art-status {

--- a/app/templates/me/homepage.hbs
+++ b/app/templates/me/homepage.hbs
@@ -43,7 +43,7 @@ then let them know what's up.
 {{/if}}
 
 <UiSection id="contacts">
-  <:title>Need Help?</:title>
+  <:title>Who To Contact For Help</:title>
   <:body>
     <p>
       Contact the Volunteer Coordinators for general questions &amp; support:<br>

--- a/app/templates/vc/photos.hbs
+++ b/app/templates/vc/photos.hbs
@@ -1,7 +1,10 @@
 <main>
-  <h1>Photo Uploads</h1>
+  <h1>Clubhouse Photos</h1>
   <p>
-    Click on the photo to show a larger version and rejection messages (if any). Active = photo in use. Inactive = photo is archived.
+    Click on the photo to show a larger version, photo metadata, and rejection messages (if any).
+    </p>
+  <p>
+    Legend: Current = photo in use. Archived = photo is no longer used and archived for historical purposes.
   </p>
 
   Showing page {{this.currentPage}} of {{this.total_pages}}


### PR DESCRIPTION
- Added text strikethrough on schedule log for removed shift.
- Color red the Immediate Action Required text on the Ranger dashboard
- Added a link to D.I.M. in the Links & Things group
- Indicated allocated & qualified provisions on the ticketing completed step. Mirrors the Provision accordion on the ticketing interface.
- Switched from 'active' to 'current' labeling on the vc/photos page to avoid terminology conflict with an account status.
