### PR TITLE
Various tweaks.

### DIFF
--- a/app/components/dashboard-pnv.hbs
+++ b/app/components/dashboard-pnv.hbs
@@ -3,8 +3,8 @@
   {{#if (eq @person.status "bonked")}}
     Hello {{@person.callsign}}.
   {{else}}
-    Hello Prospective Ranger {{@person.callsign}}.
-  {{/if}}
+    Hello {{if @person.isProspective "Prospective Ranger" "Alpha"}} {{@person.callsign}}.
+   {{/if}}
 </p>
 {{#if this.haveUrgentActions}}
   <p>

--- a/app/components/dashboard-pnv.js
+++ b/app/components/dashboard-pnv.js
@@ -83,7 +83,11 @@ const ALPHA_STEPS = [{
         if (milestones.alpha_shift.status === 'pending') {
           return {
             result: ACTION_NEEDED,
-            message: htmlSafe(`Please read "<a href="${milestones.alpha_shift_prep_link}" target="_blank" rel="noopener noreferrer">Becoming a Ranger: On-playa Alpha Shifts</a>"  on the Ranger website.<br>Your Alpha shift starts ${dayjs(milestones.alpha_shift.begins).format('ddd MMM DD [@] HH:mm')}.<br><b>ARRIVE 15 MINUTES EARLY. Late arrivals will NOT be allowed to walk.</b><br>If you know you won't be able to make your Alpha shift please email the Mentor Cadre or stop by Ranger HQ on playa.`),
+            message: htmlSafe(`<p>Please read "<a href="${milestones.alpha_shift_prep_link}" target="_blank" rel="noopener noreferrer">Becoming a Ranger: On-playa Alpha Shifts</a>"`
+                +` on the Ranger website.</p>Your Alpha shift starts ${dayjs(milestones.alpha_shift.begins).format('ddd MMM DD [@] HH:mm')}.`
+                +`<p><b class="text-danger">ARRIVE 30 MINUTES EARLY. Late arrivals will NOT be allowed to walk.</b></p>`
+                +`<p>Check-in at the Hat Rack located at Ranger HQ, 5:45 &amp; the Esplanda close to Center Camp.</p>`
+                +`If you know you won't be able to make your Alpha shift please email the Mentor Cadre or stop by Ranger HQ on playa.`),
             email: 'MentorEmail'
           };
         } else {

--- a/app/components/schedule-table.hbs
+++ b/app/components/schedule-table.hbs
@@ -44,7 +44,7 @@
         <div class="schedule-actions d-print-none">Actions</div>
       </div>
 
-      {{#each this.viewSlots as |slot| }}
+      {{#each this.viewSlots key="id" as |slot| }}
         <div class="schedule-row {{if slot.is_overlapping "schedule-overlapping"}}">
           <div class="schedule-icon">
             {{#if slot.is_overlapping}}

--- a/app/components/shift-check-in-out.js
+++ b/app/components/shift-check-in-out.js
@@ -183,8 +183,8 @@ export default class ShiftCheckInOutComponent extends Component {
               this.args.startShiftNotify();
             }
             if (+person.id === this.session.userId) {
-              // Ensure the navigation bar is updated with the signed into position
-              this.session.loadUser();
+              // Ensure the navigation bar is updated with the signed in to position
+              this.session.updateOnDuty();
             }
             break;
 
@@ -255,9 +255,10 @@ export default class ShiftCheckInOutComponent extends Component {
             this.toast.success(`${callsign} has been successfully signed off. Enjoy your rest.`);
             if (+this.args.person.id === this.session.userId) {
               // Update the user's navigation bar to remove the signed in position.
-              this.session.loadUser();
+              this.session.updateOnDuty();
             }
             break;
+
           case 'already-signed-off':
             this.toast.error(`${callsign} was already signed off.`);
             break;
@@ -288,7 +289,7 @@ export default class ShiftCheckInOutComponent extends Component {
 
   @action
   updatePositionAction() {
-    const {onDutyEntry} = this.args;
+    const {onDutyEntry,person} = this.args;
     this.isSubmitting = true;
     this.changePositionError = null;
 
@@ -312,6 +313,10 @@ export default class ShiftCheckInOutComponent extends Component {
             this.modal.info('Shift Position Update Forced', `WARNING: The person ${reason}. Because you are an admin or have the timesheet management role,the position has been updated anyways.`);
           } else {
             this.toast.success('Position has been successfully updated.');
+          }
+          if (+person.id === this.session.userId) {
+            // Ensure the navigation bar is updated with the signed in to position
+            this.session.updateOnDuty();
           }
           return;
 

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -3,11 +3,12 @@ import PersonMixin from 'clubhouse/mixins/models/person';
 import { tracked } from '@glimmer/tracking';
 
 /**
- * The logged in user.
+ * The logged-in user.
  */
 
 export default class UserModel extends PersonMixin(Object) {
   @tracked unread_message_count = 0;
+  @tracked onduty_position = null;
 
   constructor(userInfo) {
     super();

--- a/app/routes/hq.js
+++ b/app/routes/hq.js
@@ -25,7 +25,8 @@ export default class HqRoute extends ClubhouseRoute {
     this.store.unloadAll('timesheet');
     this.store.unloadAll('asset-person');
 
-    return RSVP.hash({
+
+    const requests = {
       person: this.store.findRecord('person', person_id, {reload: true}),
       personEvent: this.store.findRecord('person-event', `${person_id}-${year}`, {reload: true}),
       eventInfo: this.ajax.request(`person/${person_id}/event-info`, {data: {year}})
@@ -43,7 +44,14 @@ export default class HqRoute extends ClubhouseRoute {
       attachments: this.store.findAll('asset-attachment', {reload: true}),
       timesheetSummary: this.ajax.request(`person/${person_id}/timesheet-summary`, {data: {year}})
         .then((result) => result.summary),
-    });
+    }
+
+    if (!this.session.user.onduty_position) {
+      // Double check to see if the person is really off duty (another HQ worker might have signed them in)
+      requests.onduty = this.session.updateOnDuty();
+    }
+
+    return RSVP.hash(requests);
   }
 
   setupController(controller, model) {
@@ -53,12 +61,12 @@ export default class HqRoute extends ClubhouseRoute {
     person.set('unread_message_count', model.unread_message_count);
     controller.setProperties(model);
     controller.set('photo', null);
-    controller.set('userIsMentor', (onduty && onduty.subtype === 'mentor'));
+    controller.set('userIsMentor', (onduty?.subtype === 'mentor'));
 
     // Show a warning if the person is a PNV and the user is NOT a mentor.
     controller.set('showAlphaWarning', (person.isPNV && (!onduty || onduty.subtype !== 'mentor')));
 
-    // User should be signed into a shift
+    // User should be signed in to a shift
     controller.set('showSignInWarning', !onduty);
 
     controller.set('showNotAllowedToWork', !person.canStartShift);

--- a/app/services/session.js
+++ b/app/services/session.js
@@ -11,10 +11,11 @@ import {ADMIN, MANAGE, VC, VIEW_PII, VIEW_EMAIL} from 'clubhouse/constants/roles
 import MobileDetect from 'mobile-detect';
 
 const MOBILE_MAX_WIDTH = 991;
-const RESIZE_DEBOUNCE_DELY = 250;
+const RESIZE_DEBOUNCE_DELAY = 250;
 
 export default class extends SessionService {
   @service ajax;
+  @service house;
   @service router;
 
   // The logged-in user
@@ -23,7 +24,7 @@ export default class extends SessionService {
   // How many unread messages the user has
   @tracked unreadMessageCount = 0;
 
-  // Temporary login token used to login & change or set the password.
+  // Temporary login token used to log in & change or set the password.
   // Token becomes invalid once the password has changed.
   tempLoginToken = null;
 
@@ -74,7 +75,7 @@ export default class extends SessionService {
 
   @action
   _bounceResizeEvent() {
-    debounce(this, this._windowResized, RESIZE_DEBOUNCE_DELY);
+    debounce(this, this._windowResized, RESIZE_DEBOUNCE_DELAY);
   }
 
   /**
@@ -99,6 +100,7 @@ export default class extends SessionService {
    *
    * @returns {Promise<void>}
    */
+
   handleAuthentication() {
     return this.loadUser().then(() => {
       if (this.tempLoginToken) {
@@ -148,6 +150,17 @@ export default class extends SessionService {
   }
 
   /**
+   * Update the signed in position.
+   */
+
+  updateOnDuty() {
+    return this.ajax.request(`person/${this.userId}/onduty`)
+      .then(({onduty}) => this.user.onduty_position = onduty)
+      .catch((response) => this.house.handleErrorResponse(response))
+  }
+
+  /**
+   * Return the user id if available
    *
    * @returns {number|null}
    */

--- a/app/styles/notice.scss
+++ b/app/styles/notice.scss
@@ -1,8 +1,10 @@
 .notice-box {
   margin-bottom: 5px;
-  border: 1px solid;
+  border: 2px solid;
   border-radius: 5px;
   padding: 5px;
+
+  box-shadow: 0 1px 5px 0 rgb(50 50 50 / 50%);
 
   display: grid;
   grid-template-columns: auto 1fr;
@@ -60,7 +62,7 @@
 
 .notice-danger {
   border-color: #721c24;
-  background-color: #fff1f2;
+  background-color: #fff7f7;
 
   .notice-header {
     color: #9c0010;

--- a/app/templates/hq.hbs
+++ b/app/templates/hq.hbs
@@ -53,7 +53,8 @@
         </ChNotice>
       {{else if (and this.person.isPNV (not this.userIsMentor))}}
         <ChNotice @type="danger" @icon="exclamation" @title="Direct to the Hat Rack.">
-          {{this.person.callsign}} is an Alpha. Do not check in this person unless you are acting on the Mentors'
+          {{this.person.callsign}} is {{if this.person.isAlpha "an Alpha" "a Prospective"}}.
+          Do not check in this person unless you are acting on the Mentors'
           behalf.
         </ChNotice>
       {{/if}}
@@ -119,7 +120,7 @@
   <ModalDialog @title="Sign Into A Shift" @onEscape={{this.closeSignInWarning}} as |Modal|>
     <Modal.body>
       <b class="text-danger">WARNING:</b>
-      You are not signed into any shift. You can use the HQ Interface however we ask you sign into a shift first.
+      You are not signed in to any shift. You can use the HQ Interface however we ask you sign in to a shift first.
     </Modal.body>
     <Modal.footer>
       <UiCloseButton @onClick={{this.closeSignInWarning}} />
@@ -153,8 +154,10 @@
   <ModalDialog @title="Person may not work" @onEscape={{this.closeNotAllowedToWork}} as |Modal|>
     <Modal.body>
       <p>
-        <b class="text-danger"> {{this.person.callsign}} has the status "{{this.person.status}}" may not be given a BMID,
-          radios, and is NOT ALLOWED TO WORK.</b>
+        <b class="text-danger">
+          {{this.person.callsign}} has the status "{{this.person.status}}" may not be given a BMID,
+          radios, and is NOT ALLOWED TO WORK.
+        </b>
       </p>
       The HQ Window Interface cannot be for this person. Contact the HQ Lead, HQ Supervisor or the Personnel Manager.
     </Modal.body>

--- a/app/templates/reports/schedule-by-position.hbs
+++ b/app/templates/reports/schedule-by-position.hbs
@@ -22,7 +22,7 @@
   Showing {{this.viewPositions.length}} of {{pluralize this.positions.length "position"}} for year {{this.year}}.
 </p>
 
-{{#each this.viewPositions as |position|}}
+{{#each this.viewPositions key="id" as |position|}}
   <ChAccordion id="position-{{position.id}}" @isOpen={{mut (get this.showingPositions position.id)}} as |accordion|>
     <accordion.title>
       {{position-label position}} ({{pluralize position.activeCount "shift"~}}

--- a/app/templates/training/survey/report.hbs
+++ b/app/templates/training/survey/report.hbs
@@ -33,7 +33,7 @@
   {{/each}}
 
   {{#if (eq this.report.type "trainer")}}
-    {{#each this.report.trainers as |trainer|}}
+    {{#each this.report.trainers key="trainer_id" as |trainer|}}
       <ChAccordion id="trainer-{{trainer.trainer_id}}" as |Accordion|>
         <Accordion.title>
           Trainer {{trainer.callsign}}

--- a/app/templates/vc/access-documents/trs.hbs
+++ b/app/templates/vc/access-documents/trs.hbs
@@ -6,15 +6,15 @@
 <p>1. Select the type of Access Documents you're interested in and
   click "Filter"</p>
 
-<p>2. Click the "Download CSV for Upload to Ticket Request System"
-  link at the bottom of the page to download a CSV to upload into TRS.</p>
+<p>2. Click the "Export N Selected Documents" button at the bottom of the page to download a CSV to upload into TRS.</p>
 
-<p>3. If the upload succeeds, you can click "Mark Selected As Submitted"
-  at the bottom of the page to
-  marks these puppies as submitted.
-  (If some failed, you can uncheck the little check boxes on the left
+<p>
+  3. If the upload succeeds, you can click "Mark Selected As Submitted"
+  at the bottom of the page to marks these puppies as submitted.
+  (If some failed, you can uncheck the little checkboxes on the left
   for each record. Do this before you click on the button to mark them
-  as submitted.)</p>
+  as submitted.)
+</p>
 
 <p>Note that there is a recommended TRS batch size of not more than
   {{this.MAX_BATCH_SIZE}} items. (An item is any goodie of any sort.) If you have more
@@ -24,7 +24,11 @@
 
 {{#if this.badRecords}}
   <UiSection>
-    <:title><span class="text-danger">{{fa-icon "exclamation-triangle"}} {{pluralize this.badRecords.length "item"}} with errors</span></:title>
+    <:title>
+      <span class="text-danger">
+        {{fa-icon "exclamation-triangle"}} {{pluralize this.badRecords.length "item"}} with errors
+      </span>
+    </:title>
     <:body>
       <table class="table table-width-auto table-sm table-hover table-striped">
         <thead>
@@ -76,7 +80,10 @@
 
     {{#if this.viewBadRecords}}
       <p>
-        <b class="text-danger">{{pluralize this.viewBadRecords.length "item"}} with errors will not be bulk selected however, they may be individually selected.</b>
+        <b class="text-danger">
+          {{pluralize this.viewBadRecords.length "item"}} with errors will not be bulk selected
+          however, the rows may be individually selected.
+        </b>
       </p>
     {{/if}}
     Showing {{pluralize this.viewRecords.length "item"}} of type "{{this.filterLabel}}".
@@ -101,7 +108,7 @@
       {{#each this.viewRecords as |rec|}}
         <tr class={{if rec.has_error "table-danger"}}>
           <td>
-             {{#if rec.submitted}}
+            {{#if rec.submitted}}
               <span class="text-success">{{fa-icon "check"}}</span>
             {{else if (eq this.filter "all")}}
               &nbsp;


### PR DESCRIPTION
- Corrected Alpha versus Prospective greeting on PNV dashboard
- On the HQ Interface check with the backend to see if the user is signed in to a position before complaining about the person not signed in. Handles the case where a HQ Worker was signed in by another worker.
- Ensure the signed in position is cleared on the navbar when the user signs themselves out. Another HQ window work case.
- Corrected instructions on TRS export page.
- Added Ranger HQ location and sync'ed the language with the Alpha shift details on the ranger website to the Walk Alpha Shift dashboard step.