### PR TITLE
Various UF changes.

### DIFF
--- a/app/components/intake-note-edit.hbs
+++ b/app/components/intake-note-edit.hbs
@@ -64,10 +64,9 @@
         {{/if}}
       </ChForm>
     {{else}}
-      <p>
+      <div class="text-end">
         <UiCloseButton @onClick={{@closeNoteAction}} />
-      </p>
+      </div>
     {{/if}}
   </Modal.body>
-
 </ModalDialog>

--- a/app/components/intake-notes.hbs
+++ b/app/components/intake-notes.hbs
@@ -1,5 +1,5 @@
 {{#each this.teamNotes as |intake|}}
-  <div class="mb-1">
+  <div class="mb-2">
     <b>{{intake.year}}
       <IntakeRanking @rank={{intake.rank}} />
     </b>
@@ -23,13 +23,17 @@
     {{/if}}
   </div>
 {{else}}
-  No {{uppercase @type}} notes
+  <div class="mb-2">
+    No {{uppercase @type}} notes
+  </div>
 {{/each}}
-<div class="my-2">
-  <UiButton @type="secondary" @size="sm" @onClick={{this.addNoteAction}}>
-    {{if this.canAddNote "Add" "View"}} {{uppercase @type}} note / rank
-  </UiButton>
-</div>
+{{#if (or this.canAddNote this.teamNotes)}}
+  <div class="mb-2">
+    <UiButton @type="secondary" @size="sm" @onClick={{this.addNoteAction}}>
+      {{if this.canAddNote "Add" "View"}} {{uppercase @type}} note / rank
+    </UiButton>
+  </div>
+{{/if}}
 
 {{#if this.addingNotes}}
   <IntakeNoteEdit @teamNotes={{this.teamNotes}}

--- a/app/components/intake-notes.js
+++ b/app/components/intake-notes.js
@@ -24,6 +24,10 @@ export default class IntakeNotesComponent extends Component {
   get canAddNote() {
     let role;
 
+    if (!this.args.onSubmit) {
+      return false;
+    }
+
     switch (this.args.type) {
       case 'mentor':
         role = MENTOR;

--- a/app/controllers/mentor/convert-prospectives.js
+++ b/app/controllers/mentor/convert-prospectives.js
@@ -11,7 +11,18 @@ export default class MentorConvertController extends ClubhouseController {
   toggleAll(event) {
     const checked = event.target.checked;
     this.selectedAll = checked;
-    this.prospectives.forEach((p) => p.selected = checked);
+    this.prospectives.forEach((p) => {
+      if (p.personnel_issue) {
+        p.selected = false;
+      } else {
+        p.selected = checked;
+      }
+    });
+  }
+
+  @cached
+  get personnelFlagCount() {
+    return this.prospectives.filter((p) => p.personnel_issue).length;
   }
 
   @cached

--- a/app/controllers/mentor/potentials.js
+++ b/app/controllers/mentor/potentials.js
@@ -44,6 +44,11 @@ export default class MentorPotentialsController extends ClubhouseController {
   }
 
   @cached
+  get personnelIssuesCount() {
+    return this.mentees.filter((m) => m.personnel_issue).length;
+  }
+
+  @cached
   get filterNames() {
     const names = [];
 

--- a/app/templates/mentor/convert-prospectives.hbs
+++ b/app/templates/mentor/convert-prospectives.hbs
@@ -9,10 +9,16 @@
   </LoadingDialog>
 {{/if}}
 
+{{#if this.personnelFlagCount}}
+  <p>
+    <b class="text-danger">The Personnel Flag has been raised on {{pluralize this.personnelFlagCount "person"}}. The prospective(s) have to be selected by hand.</b>
+  </p>
+{{/if}}
+
 <UiSection>
   <:title>{{pluralize this.prospectives.length "Alpha candidate"}}</:title>
   <:body>
-    <table class="table table-striped table-width-auto table-sm table-hover">
+    <table class="table table-striped table-sm table-hover">
       <thead>
       <tr>
         <th class="w-15">
@@ -39,9 +45,7 @@
             {{/if}}
             {{#if person.personnel_issue}}
               <div class="mb-2">
-                <b class="text-danger">PERSONNEL FLAG RAISED<br>
-                  TAKE NO ACTION UNTIL RESOLVED
-                </b>
+                <b class="text-danger">PERSONNEL FLAG RAISED &mdash; TAKE NO ACTION UNTIL RESOLVED</b>
               </div>
             {{/if}}
             <p>

--- a/app/templates/mentor/potentials.hbs
+++ b/app/templates/mentor/potentials.hbs
@@ -37,30 +37,36 @@
   Legend: RRN Rank = Ranger Regional Network. VC = Volunteer Coordinators.<br>
   Rankings: 1/Green = Above Avg., 2/Normal = Average, 3/Yellow = Below Avg., 4/FLAG = Major issue.
 </p>
+<p>
+  {{#if this.personnelIssuesCount}}
+    <b class="text-danger">The Personnel Flag has been raised on {{pluralize this.personnelIssuesCount "person"}}.</b>
+  {{else}}
+    Congratulations! No one has the Personnel Flag raised.
+  {{/if}}
+</p>
+
 Showing {{this.viewPotentials.length}} of {{pluralize this.mentees.length "potential alpha"}}
 <table class="table table-sm table-striped table-hover">
   <thead>
   <tr>
-    <th>Callsign / Name / Gender</th>
-    <th>Status</th>
-    <th>History</th>
-    <th>RRN Rank</th>
-    <th>VC Rank</th>
-    <th>FKA / Mentor Notes &amp; Rank</th>
-    <th>Training</th>
+    <th class="w-15">Callsign / Name / Gender</th>
+    <th class="w-10">Mentor History</th>
+    <th class="w-75">Training &amp; Notes</th>
   </tr>
   </thead>
   <tbody>
-  {{#each this.viewPotentials as |person|}}
+  {{#each this.viewPotentials key="id" as |person|}}
     <tr>
-      <td>
-        <PersonLink @person={{person}} />
-        <br>
+      <td class="w-15">
+        {{#if person.personnel_issue}}
+          <b class="text-danger">{{fa-icon "flag"}} PERSONNEL FLAG</b><br>
+        {{/if}}
+        <PersonLink @person={{person}} /> &lt;{{person.status}}&gt;<br>
         {{person.first_name}} {{person.last_name}}<br>
         <PresentOrNot @value={{person.gender}} @empty="no gender stated"/>
+        <br>
       </td>
-      <td>{{person.status}}</td>
-      <td>
+      <td class="w-10">
         {{#each person.mentor_history as |history|}}
           {{history.year}}
           {{#if (eq history.status "bonk")~}}
@@ -76,51 +82,36 @@ Showing {{this.viewPotentials.length}} of {{pluralize this.mentees.length "poten
           <i>no history</i>
         {{/each}}
       </td>
-      <td>
-        {{#each person.rrn_ranks as |yearRank|}}
-          {{yearRank.year}}
-          <IntakeRanking @rank={{yearRank.rank}} />
-          <br>
-        {{else}}
-          none
-        {{/each}}
-      </td>
-      <td>
-        {{#each person.vc_ranks as |yearRank|}}
-          {{yearRank.year}}
-          <IntakeRanking @rank={{yearRank.rank}} />
-          <br>
-        {{else}}
-          none
-        {{/each}}
-      </td>
-      <td>
+      <td class="w-75">
         {{#if person.has_note_on_file}}
           <div class="mb-2"><b class="text-danger">Personnel Note</b></div>
         {{/if}}
         {{#if person.personnel_issue}}
           <div class="mb-2">
-            <b class="text-danger">PERSONNEL FLAG RAISED<br>
-              TAKE NO ACTION UNTIL RESOLVED
-            </b>
+            <h4 class="text-danger">{{fa-icon "flag"}} PERSONNEL FLAG RAISED &mdash; TAKE NO ACTION UNTIL RESOLVED</h4>
           </div>
         {{/if}}
+        FKA:
         {{#if person.fkas}}
-          <div class="mb-2">
-            FKA: {{join person.fkas ", "}}
-          </div>
+          {{join person.fkas ", "}}
+        {{else}}
+          <i>none</i>
         {{/if}}
-
-        <IntakeNotes @type="mentor" @person={{person}} @viewYear={{this.year}} @onSubmit={{this.noteSubmitted}} />
-      </td>
-      <td>
         {{#if person.trained}}
           <div class="text-success">{{fa-icon "check"}} Trained</div>
         {{else}}
           <div class="text-danger">{{fa-icon "times"}} NOT Trained</div>
         {{/if}}
-
+        <b>Training</b>
         <IntakeTraining @trainings={{person.trainings}} @person={{person}} />
+        <b>Personnel Notes</b><br>
+        <IntakeNotes @type="personnel" @person={{person}} @viewYear={{@year}}  />
+        <b>RRN Notes</b><br>
+        <IntakeNotes @type="rrn" @person={{person}} @viewYear={{@year}}  />
+        <b>VC Notes</b><br>
+        <IntakeNotes @type="vc" @person={{person}} @viewYear={{@year}} />
+        <b>Mentor Notes</b><br>
+        <IntakeNotes @type="mentor" @person={{person}} @viewYear={{this.year}} @onSubmit={{this.noteSubmitted}} />
       </td>
     </tr>
   {{else}}

--- a/app/templates/vc/spigot.hbs
+++ b/app/templates/vc/spigot.hbs
@@ -29,7 +29,31 @@
     </tr>
     </thead>
     <tbody>
-    {{#each @model.days as |day|}}
+    <tr>
+      <td><b>Totals</b></td>
+      <td class="text-end">
+        {{this.totals.imported}}
+      </td>
+      <td class="text-end">
+        {{this.totals.photo_approved}}
+      </td>
+      <td class="text-end">
+        {{this.totals.online_trained}}
+      </td>
+      <td class="text-end">
+        {{this.totals.training_signups}}
+      </td>
+      <td class="text-end">
+        {{this.totals.training_passed}}
+      </td>
+      <td class="text-end">
+        {{this.totals.dropped}}
+      </td>
+      <td class="text-end">
+        {{this.totals.alpha_signups}}
+      </td>
+    </tr>
+    {{#each @model.days key="day" as |day|}}
       <tr>
         <td>
           <PresentOrNot @value={{day.day}} @empty="-"/>
@@ -141,30 +165,6 @@
         </td>
       </tr>
     {{/each}}
-    <tr>
-      <td><b>Totals</b></td>
-      <td class="text-end">
-        {{this.totals.imported}}
-      </td>
-      <td class="text-end">
-        {{this.totals.photo_approved}}
-      </td>
-      <td class="text-end">
-        {{this.totals.online_trained}}
-      </td>
-      <td class="text-end">
-        {{this.totals.training_signups}}
-      </td>
-      <td class="text-end">
-        {{this.totals.training_passed}}
-      </td>
-      <td class="text-end">
-        {{this.totals.dropped}}
-      </td>
-      <td class="text-end">
-        {{this.totals.alpha_signups}}
-      </td>
-    </tr>
     </tbody>
   </table>
 </main>


### PR DESCRIPTION
- Added full Personnel, RRN, and VC notes, just not ranks to Potential Alphas.
- Don't bulk select potential alphas with raised Personnel Flag on Convert Prospectives.
- Don't present view UF team notes button if no notes are present and the user is only allowed to view notes, not add a team note.
- Moved VC Spigot totals to the table's top for quick viewing.