### PR TITLE
Added person off site indicator to Shift Lead Report (scheduled signups)

### DIFF
--- a/app/components/shift-lead-table.hbs
+++ b/app/components/shift-lead-table.hbs
@@ -31,6 +31,9 @@
             {{if person.position.short_title person.position.short_title person.position.title}}
           </td>
           <td class="w-15">
+            {{#unless person.on_site}}
+              {{fa-icon "ban" color="danger"}}
+            {{/unless}}
             <PersonLink @person={{person}} />
           </td>
           <td class="w-5">

--- a/app/templates/reports/shift-lead.hbs
+++ b/app/templates/reports/shift-lead.hbs
@@ -101,8 +101,9 @@
   </div>
   <p>
     Gender = F: Female, M: Male, NB: Non-binary, Q: Queer (unspecified), GF: Gender Fluid, - (dash): not stated<br>
-    GTR? = Indicates person signed the Motorpool Vehicle Agreement<br>
-    Veh? = Indicates person has BM Org insurance<br>
+    GTR? = Indicates person signed the Motorpool Vehicle Agreement. Veh? = Indicates person has BM Org insurance.<br>
+    {{fa-icon "ban" color="danger"}} = Person not marked as being on site. <b>Note</b>: person could be on playa however
+    has not visited HQ Window yet for a site check-in.
   </p>
   <ShiftLeadTable @title="DIRT/GREEN DOTS" @people={{this.dirt_signups}} @isOnDuty={{this.isOnDuty}}/>
   <ShiftLeadTable @title="COMMAND STAFF" @people={{this.command_staff_signups}} @isOnDuty={{this.isOnDuty}}/>


### PR DESCRIPTION
On going pandemic concerns. The worry is a person may have to bail during the event, and forget to remove their pending signups.