### PR TITLE
Added timezone support to the slots. New scheduling calendar export feature.

### DIFF
--- a/app/components/admin/slot-form.hbs
+++ b/app/components/admin/slot-form.hbs
@@ -34,10 +34,16 @@
                     @maxlength={{20}} />
       </FormRow>
       <FormRow>
+        <f.select @name="timezone"
+                  @label="Timezone"
+                  @options={{this.timezoneOptions}}
+        />
+      </FormRow>
+      <FormRow>
         <f.number @name="max"
-                @label={{if f.model.trainer_slot_id "Multiplier" "Max Sign Ups"}}
-                @size={{4}}
-                @maxlength={{4}}
+                  @label={{if f.model.trainer_slot_id "Multiplier" "Max Sign Ups"}}
+                  @size={{4}}
+                  @maxlength={{4}}
         />
       </FormRow>
       {{#if f.model.trainer_slot_id}}

--- a/app/components/admin/slot-form.js
+++ b/app/components/admin/slot-form.js
@@ -1,8 +1,11 @@
 import Component from '@glimmer/component';
 import {validatePresence, validateNumber} from 'ember-changeset-validations/validators';
 import validateDateTime from 'clubhouse/validators/datetime';
+import TimezoneOptions from 'clubhouse/constants/timezone-options';
 
 export default class SlotFormComponent extends Component {
+  timezoneOptions = TimezoneOptions;
+
   slotValidations = {
     description: [
       validatePresence({presence: true, message: 'Enter a description.'}),

--- a/app/components/schedule-manage.js
+++ b/app/components/schedule-manage.js
@@ -109,6 +109,7 @@ export default class ScheduleManageComponent extends Component {
   get positions() {
     const slots = this.viewSlots;
     const groups = {};
+
     slots.forEach((slot) => {
       const position_id = slot.position_id;
       const group = groups[position_id];
@@ -116,7 +117,7 @@ export default class ScheduleManageComponent extends Component {
       if (group) {
         group.slots.push(slot);
       } else {
-        groups[position_id] = {title: slot.position_title, position_id, slots: [slot]};
+        groups[position_id] = {title: slot.position_title, type: slot.position_type, position_id, slots: [slot]};
       }
     });
 

--- a/app/components/schedule-position-list.hbs
+++ b/app/components/schedule-position-list.hbs
@@ -6,10 +6,12 @@
         <span class="text-danger">[{{pluralize this.overlappingCount "overlapping signup"}}]</span>
       {{else}}
         <span class="text-success">[
-          {{~pluralize this.nonOverlappingCount "signup"~}}
+          {{pluralize this.nonOverlappingCount "signup"}}
           {{#if this.overlappingCount}}
-            <span class="text-black"> and</span> <span class="text-danger">{{pluralize this.overlappingCount "overlapping signup"}}</span>
-          {{~/if~}}
+            <span class="text-black"> and</span> <span class="text-danger">
+            {{pluralize this.overlappingCount "overlapping signup"}}
+          </span>
+          {{/if}}
           ]</span>
       {{/if}}
     {{/if}}
@@ -44,10 +46,9 @@
       <div class="schedule-table">
         <div class="schedule-row schedule-header">
           <div class="schedule-icon">&nbsp;</div>
-          <div class="schedule-time">Time</div>
+          <div class="schedule-time-description">Time / Description</div>
           <div class="schedule-duration">Duration</div>
           <div class="schedule-credits">Credits</div>
-          <div class="schedule-signup-description">Description</div>
           <div class="schedule-signups">Sign Ups</div>
           <div class="schedule-actions">Actions</div>
         </div>
@@ -65,22 +66,15 @@
                 &nbsp;
               {{/if}}
             </div>
-            <div class="schedule-time">
+            <div class="schedule-time-description">
               {{shift-format slot.slot_begins slot.slot_ends}}
-            </div>
-            <div class="schedule-duration">
-              <span class="schedule-sm-label">Duration:</span>
-              {{#unless slot.position_count_hours}}
-                <span class="me-1"><NoAppreciateIcon/></span>
-              {{/unless}}
-              {{hour-minute-format slot.slot_duration}}
-            </div>
-            <div class="schedule-credits">
-              <span class="schedule-sm-label">Credits:</span> {{credits-format slot.credits}}
-            </div>
-            <div class="schedule-signup-description">
-              <span class="schedule-sm-label">{{@position.title}}</span>
-              <SlotInfoLink @description={{slot.slot_description}} @info={{slot.slot_url}} />
+              {{#if (or this.isTrainingType slot.isNotPacific)}}
+                ({{slot.slot_tz_abbr}})
+              {{/if}}
+              <div class="schedule-sm-label">{{@position.title}}</div>
+              <div>
+                <SlotInfoLink @description={{slot.slot_description}} @info={{slot.slot_url}} />
+              </div>
               {{#if (and slot.trainer_slot_id (eq slot.slot_max 0))}}
                 <div class="text-danger">No trainers signed up yet.<br>Check back later.</div>
               {{/if}}
@@ -92,6 +86,16 @@
                   {{/each}}
                 </div>
               {{/if}}
+            </div>
+            <div class="schedule-duration">
+              <span class="schedule-sm-label">Duration:</span>
+              {{#unless slot.position_count_hours}}
+                <span class="me-1"><NoAppreciateIcon/></span>
+              {{/unless}}
+              {{hour-minute-format slot.slot_duration}}
+            </div>
+            <div class="schedule-credits">
+              <span class="schedule-sm-label">Credits:</span> {{credits-format slot.credits}}
             </div>
             <div class="schedule-signups">
               {{#if (and slot.trainer_slot_id (eq slot.slot_max 0))}}
@@ -114,8 +118,11 @@
               {{#if slot.person_assigned}}
                 {{#if (or @isAdmin (not slot.has_started))}} {{!template-lint-disable "no-negated-condition"}}
                 {{! Only allow admins to remove a sign up that has started}}
-                  <button type="button" {{on "click" (fn @leaveSlot slot)}} class="btn btn-danger btn-sm"
-                          title="Remove from schedule" disabled={{slot.is_submitting}}>
+                  <button type="button"
+                    {{on "click" (fn @leaveSlot slot)}}
+                          class="btn btn-danger btn-sm"
+                          title="Remove from schedule"
+                          disabled={{slot.is_submitting}}>
                     {{#if slot.is_submitting}}
                       <SpinIcon/>
                     {{else}}
@@ -128,8 +135,10 @@
               {{! Only show action buttons for the current year}}
                 {{#if slot.slot_active}}
                   {{#if (or @isAdmin (and (not slot.isFull) (not slot.has_started)))}}
-                    <button type="button" {{on "click" (fn @joinSlot slot)}} class="btn btn-primary btn-sm"
-                            title="Sign up for the shift" disabled={{slot.is_submitting}}>
+                    <button type="button" {{on "click" (fn @joinSlot slot)}}
+                            class="btn btn-primary btn-sm"
+                            title="Sign up for the shift"
+                            disabled={{slot.is_submitting}}>
                       {{#if slot.is_submitting}}
                         <SpinIcon/>
                       {{else}}

--- a/app/components/schedule-position-list.js
+++ b/app/components/schedule-position-list.js
@@ -7,6 +7,7 @@ export default class SchedulePositionListComponent extends Component {
     super(...arguments);
     this.haveNoAppreciationSlots = !!this.args.position.slots.find((s) => !s.position_count_hours);
     this.isTrainingPosition = this.args.position.position_id === TRAINING;
+    this.isTrainingType = this.args.position.type === "Training";
     this.haveShiftWithAdditionalInfo = !!this.args.position.slots.find((s) => s.slot_url?.length);
   }
 

--- a/app/components/schedule-table.hbs
+++ b/app/components/schedule-table.hbs
@@ -14,12 +14,16 @@
     {{/if}}
 
     <p>
+      All shift / training session times are in the Pacific timezone unless otherwise noted.
+    </p>
+    <p>
       <NoAppreciateIcon/>
       = the shift hours do not count towards appreciations.
       <InfoIcon/>
       = More shift information available, click on the icon and/or text.
     </p>
-    <div class="mb-1 d-print-none">
+    <div class="mb-1 d-print-none d-flex justify-content-between">
+      <div>
       {{#if (eq this.viewSchedule "upcoming")}}
         <b>Showing {{pluralize this.upcomingCount "UPCOMING shift"}}</b>
         <UiButton @onClick={{this.showAllAction}}  @size="sm" @type="secondary" @class="ms-2">
@@ -33,14 +37,17 @@
           </UiButton>
         {{/if}}
       {{/if}}
+      </div>
+      <div>
+        <UiButton @onClick={{this.exportCalendarAction}} @type="secondary" @size="sm">Export Calendar</UiButton>
+      </div>
     </div>
     <div class="schedule-table schedule-itinerary">
       <div class="schedule-row schedule-header">
         <div class="schedule-icon">&nbsp;</div>
-        <div class="schedule-time">Time</div>
+        <div class="schedule-time-description">Time / Position / Description</div>
         <div class="schedule-duration">Duration</div>
         <div class="schedule-credits">Credits</div>
-        <div class="schedule-table-description">Position / Description</div>
         <div class="schedule-actions d-print-none">Actions</div>
       </div>
 
@@ -53,8 +60,13 @@
               &nbsp;
             {{/if}}
           </div>
-          <div class="schedule-time">
+          <div class="schedule-time-description">
             {{shift-format slot.slot_begins slot.slot_ends}}
+            {{#if slot.isNotPacific}}
+              ({{slot.slot_tz_abbr}})
+             {{/if}}<br>
+            {{slot.position_title}}<br>
+            <SlotInfoLink @description={{slot.slot_description}} @info={{slot.slot_url}} />
           </div>
           <div class="schedule-duration">
             <span class="schedule-sm-label">Duration:</span>
@@ -66,11 +78,7 @@
           <div class="schedule-credits">
             <span class="schedule-sm-label">Credits:</span>{{credits-format slot.credits}}
           </div>
-          <div class="schedule-table-description">
-            {{slot.position_title}}<br>
-            <SlotInfoLink @description={{slot.slot_description}} @info={{slot.slot_url}} />
-          </div>
-          <div class="schedule-actions d-print-none">
+           <div class="schedule-actions d-print-none">
             <button type="button" {{on "click" (fn @showPeople slot)}} class="btn btn-secondary btn-sm"
                     title="View people signed up" disabled={{slot.is_retrieving_people}}>
               {{#if slot.is_retrieving_people}}

--- a/app/components/schedule-table.js
+++ b/app/components/schedule-table.js
@@ -2,9 +2,12 @@ import Component from '@glimmer/component';
 import {tracked} from '@glimmer/tracking';
 import {service} from '@ember/service';
 import {action} from '@ember/object';
+import ical from 'ical-generator';
+import dayjs from 'dayjs';
 
 export default class ScheduleTableComponent extends Component {
   @service house;
+  @service modal;
   @tracked viewSchedule;
 
   constructor() {
@@ -13,15 +16,29 @@ export default class ScheduleTableComponent extends Component {
     this.viewSchedule = this.isCurrentYear ? 'upcoming' : 'all';
   }
 
+  /**
+   * Show all the slots
+   */
+
   @action
   showAllAction() {
     this.viewSchedule = 'all';
   }
 
+  /**
+   * Show the upcoming slots
+   */
+
   @action
   showUpcomingAction() {
     this.viewSchedule = 'upcoming';
   }
+
+  /**
+   * Filter the slots for viewing.
+   *
+   * @returns {[]}
+   */
 
   get viewSlots() {
     const slots = this.args.slots;
@@ -30,19 +47,57 @@ export default class ScheduleTableComponent extends Component {
       return slots;
     }
 
-    return slots.filter((slot) => !slot.has_started)
+    return slots.filter((slot) => !slot.has_started);
   }
+
+  /**
+   * How many upcoming shifts (i.e., ones not started yet) are there?
+   *
+   * @returns {Number}
+   */
 
   get upcomingCount() {
-    const {slots} = this.args;
-    return slots.reduce(function (upcoming, slot) {
-      return (slot.has_started ? 0 : 1) + upcoming;
-    }, 0);
+    return this.args.slots.reduce((upcoming, slot) => (slot.has_started ? 0 : 1) + upcoming, 0);
   }
 
+  /**
+   * Are there overlapping sign-ups?
+   *
+   * @returns {boolean}
+   */
+
   get hasOverlapping() {
-    return this.viewSlots.reduce(function (total, slot) {
-      return (slot.is_overlapping ? 1 : 0) + total;
-    }, 0);
+    return this.viewSlots.reduce((total, slot) => (slot.is_overlapping ? 1 : 0) + total, 0) > 0;
+  }
+
+  /**
+   * Export the person's schedule to a ICS file.
+   */
+
+  @action
+  exportCalendarAction() {
+    const {slots} = this.args;
+    if (!slots.length) {
+      this.modal.info('No Sign-Ups', "No shifts and/or training sessions are signed up for. There's nothing to export.")
+      return;
+    }
+
+    const calendar = ical({name: 'BRC Ranger Schedule'});
+    calendar.prodId({
+      company: 'Burning Man Project',
+      product: 'Ranger Clubhouse',
+      language: 'EN'
+    });
+
+    slots.forEach((slot) => {
+      calendar.createEvent({
+        start: dayjs.tz(slot.slot_begins, slot.slot_tz).format(),
+        end: dayjs.tz(slot.slot_ends, slot.slot_tz).format(),
+        summary: slot.position_title,
+        detail: `${slot.description} ${slot.url}`,
+      });
+    });
+
+    this.house.downloadFile(`${this.args.year}-ranger-schedule.ics`, calendar.toString(), 'text/calendar');
   }
 }

--- a/app/constants/timezone-options.js
+++ b/app/constants/timezone-options.js
@@ -1,0 +1,486 @@
+/*
+  The timezone values MUST match what PHP supports.
+*/
+
+export default [
+  {
+    "groupName": "United States",
+    "options": [
+      {
+        "id": "America/New_York",
+        "label": "Eastern Time"
+      },
+      /*     {
+             "id": "America/Detroit",
+             "label": "Eastern Time - Michigan - most locations"
+           },
+           {
+             "id": "America/Kentucky/Louisville",
+             "label": "Eastern Time - Kentucky - Louisville area"
+           },
+           {
+             "id": "America/Kentucky/Monticello",
+             "label": "Eastern Time - Kentucky - Wayne County"
+           },
+           {
+             "id": "America/Indiana/Indianapolis",
+             "label": "Eastern Time - Indiana - most locations"
+           },
+           {
+             "id": "America/Indiana/Vincennes",
+             "label": "Eastern Time - Indiana - Daviess, Dubois, Knox & Martin Counties"
+           },
+           {
+             "id": "America/Indiana/Winamac",
+             "label": "Eastern Time - Indiana - Pulaski County"
+           },
+           {
+             "id": "America/Indiana/Marengo",
+             "label": "Eastern Time - Indiana - Crawford County"
+           },
+           {
+             "id": "America/Indiana/Petersburg",
+             "label": "Eastern Time - Indiana - Pike County"
+           },
+           {
+             "id": "America/Indiana/Vevay",
+             "label": "Eastern Time - Indiana - Switzerland County"
+           },
+
+       */
+      {
+        "id": "America/Chicago",
+        "label": "Central Time"
+      },
+      /*
+           {
+             "id": "America/Indiana/Tell_City",
+             "label": "Central Time - Indiana - Perry County"
+           },
+           {
+             "id": "America/Indiana/Knox",
+             "label": "Central Time - Indiana - Starke County"
+           },
+           {
+             "id": "America/Menominee",
+             "label": "Central Time - Michigan - Dickinson, Gogebic, Iron & Menominee Counties"
+           },
+           {
+             "id": "America/North_Dakota/Center",
+             "label": "Central Time - North Dakota - Oliver County"
+           },
+           {
+             "id": "America/North_Dakota/New_Salem",
+             "label": "Central Time - North Dakota - Morton County (except Mandan area)"
+           },
+           {
+             "id": "America/North_Dakota/Beulah",
+             "label": "Central Time - North Dakota - Mercer County"
+           },
+
+       */
+      {
+        "id": "America/Denver",
+        "label": "Mountain Time"
+      },
+      /*     {
+             "id": "America/Boise",
+             "label": "Mountain Time - south Idaho & east Oregon"
+           },
+
+       */
+      {
+        "id": "America/Phoenix",
+        "label": "Arizona Mountain Time (except Navajo)"
+      },
+      {
+        "id": "America/Los_Angeles",
+        "label": "Pacific Time"
+      },
+      /*
+           {
+             "id": "America/Metlakatla",
+             "label": "Pacific Standard Time - Annette Island, Alaska"
+           },
+
+       */
+      {
+        "id": "America/Anchorage",
+        "label": "Alaska Time"
+      },
+      /*
+           {
+             "id": "America/Juneau",
+             "label": "Alaska Time - Alaska panhandle"
+           },
+           {
+             "id": "America/Sitka",
+             "label": "Alaska Time - southeast Alaska panhandle"
+           },
+           {
+             "id": "America/Yakutat",
+             "label": "Alaska Time - Alaska panhandle neck"
+           },
+           {
+             "id": "America/Nome",
+             "label": "Alaska Time - west Alaska"
+           },
+           {
+             "id": "America/Adak",
+             "label": "Aleutian Islands"
+           },
+       */
+      {
+        "id": "Pacific/Honolulu",
+        "label": "Hawaii Time"
+      }
+    ]
+  },
+  {
+    "groupName": "Canada",
+    "options": [
+      {
+        "id": "America/St_Johns",
+        "label": "Newfoundland Time"
+      },
+      {
+        "id": "America/Halifax",
+        "label": "Atlantic Time"
+      },
+      /*
+            {
+              "id": "America/Moncton",
+              "label": "Atlantic Time - New Brunswick"
+            },
+            {
+              "id": "America/Goose_Bay",
+              "label": "Atlantic Time - Labrador - most locations"
+            },
+            {
+              "id": "America/Blanc-Sablon",
+              "label": "Atlantic Standard Time - Quebec - Lower North Shore"
+            },
+
+       */
+      {
+        "id": "America/Toronto",
+        "label": "Eastern Time - Ontario & Quebec"
+      },
+      /*
+            {
+             "id": "America/Thunder_Bay",
+             "label": "Eastern Time - Thunder Bay, Ontario"
+           },
+           {
+             "id": "America/Iqaluit",
+             "label": "Eastern Time - east Nunavut - most locations"
+           },
+           {
+             "id": "America/Pangnirtung",
+             "label": "Eastern Time - Pangnirtung, Nunavut"
+           },
+
+       */
+      /*
+      {
+        "id": "America/Resolute",
+        "label": "Central Time - Resolute, Nunavut"
+      },
+      {
+        "id": "America/Atikokan",
+        "label": "Eastern Standard Time - Atikokan, Ontario and Southampton I, Nunavut"
+      },
+      {
+        "id": "America/Rankin_Inlet",
+        "label": "Central Time - central Nunavut"
+      },
+      {
+        "id": "America/Winnipeg",
+        "label": "Central Time - Manitoba & west Ontario"
+      },
+      {
+        "id": "America/Rainy_River",
+        "label": "Central Time - Rainy River & Fort Frances, Ontario"
+      },
+
+       */
+      {
+        "id": "America/Regina",
+        "label": "Central Standard Time" //- Saskatchewan - most locations
+      },
+      /*
+      {
+        "id": "America/Swift_Current",
+        "label": "Central Standard Time - Saskatchewan - midwest"
+      },
+       */
+      {
+        "id": "America/Edmonton",
+        "label": "Mountain Time" //- Alberta, east British Columbia & west Saskatchewan"
+      },
+      /*
+      {
+        "id": "America/Cambridge_Bay",
+        "label": "Mountain Time - west Nunavut"
+      },
+      {
+        "id": "America/Yellowknife",
+        "label": "Mountain Time - central Northwest Territories"
+      },
+      {
+        "id": "America/Inuvik",
+        "label": "Mountain Time - west Northwest Territories"
+      },
+      {
+        "id": "America/Creston",
+        "label": "Mountain Standard Time - Creston, British Columbia"
+      },
+      {
+        "id": "America/Dawson_Creek",
+        "label": "Mountain Standard Time - Dawson Creek & Fort Saint John, British Columbia"
+      },
+
+       */
+      {
+        "id": "America/Vancouver",
+        "label": "Pacific Time" // - west British Columbia
+      },
+      /*
+      {
+        "id": "America/Whitehorse",
+        "label": "Pacific Time - south Yukon"
+      },
+      {
+        "id": "America/Dawson",
+        "label": "Pacific Time - north Yukon"
+      }*/
+    ]
+  },
+  {
+    "groupName": "Australia",
+    "options": [
+      /*
+            {
+              "id": "Australia/Lord_Howe",
+              "label": "Lord Howe Island"
+            },
+
+
+            {
+              "id": "Antarctica/Macquarie",
+              "label": "Macquarie Island"
+            },
+            {
+              "id": "Australia/Hobart",
+              "label": "Tasmania - most locations"
+            },
+            {
+              "id": "Australia/Currie",
+              "label": "Tasmania - King Island"
+            },
+
+       */
+      {
+        "id": "Australia/Melbourne",
+        "label": "Victoria"
+      },
+      {
+        "id": "Australia/Sydney",
+        "label": "New South Wales" // - most locations
+      },
+      /*
+      {
+        "id": "Australia/Broken_Hill",
+        "label": "New South Wales - Yancowinna"
+      },*/
+      {
+        "id": "Australia/Brisbane",
+        "label": "Queensland" //- most locations
+      },
+      /*
+      {
+        "id": "Australia/Lindeman",
+        "label": "Queensland - Holiday Islands"
+      },*/
+      {
+        "id": "Australia/Adelaide",
+        "label": "South Australia"
+      },
+      {
+        "id": "Australia/Darwin",
+        "label": "Northern Territory"
+      },
+      {
+        "id": "Australia/Perth",
+        "label": "Western Australia" // - most locations
+      },
+      /*
+      {
+        "id": "Australia/Eucla",
+        "label": "Western Australia" //  - Eucla area
+      }*/
+    ]
+  },
+  {
+    "groupName": "New Zealand",
+    "options": [
+      {
+        "id": "Pacific/Auckland",
+        "label": "New Zealand time"
+      },
+      /*
+      {
+        "id": "Pacific/Chatham",
+        "label": "Chatham Islands"
+      }*/
+    ]
+  },
+  {
+    "groupName": "Europe & Africa",
+    "options": [
+      {
+        "id": "Europe/London",
+        "label": "Britain (UK)"
+      },
+      {
+        "id": "Europe/Paris",
+        "label": "France"
+      },
+      /*
+      {
+        "id": "Europe/Zurich",
+        "label": "Germany Swiss time"
+      },*/
+      {
+        "id": "Europe/Berlin",
+        "label": "Germany" //  Berlin time
+      },
+      {
+        "id": "Europe/Rome",
+        "label": "Italy"
+      },
+      {
+        "id": "Europe/Madrid",
+        "label": "Spain" // mainland
+      },
+      /*
+      {
+        "id": "Africa/Ceuta",
+        "label": "Spain Ceuta & Melilla"
+      },
+      {
+        "id": "Atlantic/Canary",
+        "label": "Spain Canary Islands"
+      },*/
+      {
+        "id": "Africa/Johannesburg",
+        "label": "South Africa "
+      }
+    ]
+  },
+  {
+    "groupName": "UTC",
+    "options": [
+      {
+        "id": "Etc/GMT-12",
+        "label": "UTC-12"
+      },
+      {
+        "id": "Etc/GMT-11",
+        "label": "UTC-11"
+      },
+      {
+        "id": "Etc/GMT-10",
+        "label": "UTC-10"
+      },
+      {
+        "id": "Etc/GMT-9",
+        "label": "UTC-9"
+      },
+      {
+        "id": "Etc/GMT-8",
+        "label": "UTC-8"
+      },
+      {
+        "id": "Etc/GMT-7",
+        "label": "UTC-7"
+      },
+      {
+        "id": "Etc/GMT-6",
+        "label": "UTC-6"
+      },
+      {
+        "id": "Etc/GMT-5",
+        "label": "UTC-5"
+      },
+      {
+        "id": "Etc/GMT-4",
+        "label": "UTC-4"
+      },
+      {
+        "id": "Etc/GMT-3",
+        "label": "UTC-3"
+      },
+      {
+        "id": "Etc/GMT-2",
+        "label": "UTC-2"
+      },
+      {
+        "id": "Etc/GMT-1",
+        "label": "UTC-1"
+      },
+      {
+        "id": "Etc/GMT-0",
+        "label": "UTC-0"
+      },
+      {
+        "id": "Etc/GMT+12",
+        "label": "UTC+12"
+      },
+      {
+        "id": "Etc/GMT+11",
+        "label": "UTC+11"
+      },
+      {
+        "id": "Etc/GMT+10",
+        "label": "UTC+10"
+      },
+      {
+        "id": "Etc/GMT+9",
+        "label": "UTC+9"
+      },
+      {
+        "id": "Etc/GMT+8",
+        "label": "UTC+8"
+      },
+      {
+        "id": "Etc/GMT+7",
+        "label": "UTC+7"
+      },
+      {
+        "id": "Etc/GMT+6",
+        "label": "UTC+6"
+      },
+      {
+        "id": "Etc/GMT+5",
+        "label": "UTC+5"
+      },
+      {
+        "id": "Etc/GMT+4",
+        "label": "UTC+4"
+      },
+      {
+        "id": "Etc/GMT+3",
+        "label": "UTC+3"
+      },
+      {
+        "id": "Etc/GMT+2",
+        "label": "UTC+2"
+      },
+      {
+        "id": "Etc/GMT+1",
+        "label": "UTC+1"
+      }
+    ]
+  }
+];

--- a/app/initializers/dayjs-plugins.js
+++ b/app/initializers/dayjs-plugins.js
@@ -1,10 +1,14 @@
 import AdvancedFormat from 'dayjs/plugin/advancedFormat';
 import objectSupport from 'dayjs/plugin/objectSupport';
+import utc from 'dayjs/plugin/utc';
+import timezone from 'dayjs/plugin/timezone';
 import dayjs from 'dayjs';
 
 export function initialize(/* application */) {
   dayjs.extend(AdvancedFormat);
   dayjs.extend(objectSupport);
+  dayjs.extend(utc);
+  dayjs.extend(timezone);
 }
 
 export default {

--- a/app/models/schedule-slot.js
+++ b/app/models/schedule-slot.js
@@ -43,6 +43,10 @@ export default class ScheduleSlotModel {
     return (this.position_type === 'Training');
   }
 
+  get isNotPacific() {
+    return this.slot_tz_abbr !== 'PST' && this.slot_tz_abbr !== 'PDT';
+  }
+
   static hydrate(slots, positions) {
     const positionsById = positions.reduce((hash, row) => {
       hash[row.id] = row;

--- a/app/models/slot.js
+++ b/app/models/slot.js
@@ -21,6 +21,9 @@ export default class SlotModel extends Model {
   @attr('', {readOnly: true}) position;
   @attr('', {readOnly: true}) trainer_slot;
 
+  @attr('string', {defaultValue: 'America/Los_Angeles'}) timezone;
+  @attr('string', {readOnly: true}) timezone_abbr;
+
   @tracked selected; // Used to administer slots
 
   get slotDay() {
@@ -47,5 +50,9 @@ export default class SlotModel extends Model {
   get trainer_slot_title() {
     const trainer = this.trainer_slot;
     return (trainer && trainer.position) ? trainer.position.title : `Position #${this.trainer_slot_id}`;
+  }
+
+  get isNonPacific() {
+    return this.timezone_abbr !== 'PST' && this.timezone_abbr !== 'PDT';
   }
 }

--- a/app/styles/schedule.scss
+++ b/app/styles/schedule.scss
@@ -31,6 +31,7 @@
   > div {
     display: inline-block;
     margin-top: 5px;
+    align-self: center;
   }
 }
 
@@ -59,9 +60,11 @@
   .schedule-icon {
     width: 20px;
     text-align: center;
+    font-size: 1.1rem;
   }
-  .schedule-time {
-    width: 26%;
+
+  .schedule-time-description {
+    width: 40%;
   }
 
   .schedule-duration {
@@ -72,12 +75,7 @@
   .schedule-credits {
     width: 7%;
     text-align: right;
-  }
-
-
-  .schedule-signup-description {
-    width: 24%;
-    margin-left: 5px;
+    margin-right: 5px;
   }
 
   .schedule-table-description {
@@ -104,7 +102,7 @@
 
   .schedule-actions {
     margin-left: 10px;
-    align-self: center;
+    //align-self: center;
   }
 }
 
@@ -126,7 +124,7 @@
       order: 2;
      }
 
-    .schedule-time {
+    .schedule-time-description {
       order: 1;
       width: 90%;
     }
@@ -138,13 +136,9 @@
 
     .schedule-credits {
       order: 4;
-      width: 50%;
+      width: 48%;
       text-align: right;
-    }
-
-    .schedule-description {
-      order: 5;
-      width: 100%;
+      margin-right: 5px;
     }
 
     .schedule-signups {

--- a/app/templates/admin/slots.hbs
+++ b/app/templates/admin/slots.hbs
@@ -75,8 +75,7 @@
             <thead>
             <tr>
               <th>ID</th>
-              <th>From</th>
-              <th>To</th>
+              <th>Time</th>
               <th class="text-end">Max</th>
               <th class="text-end">Count</th>
               <th class="text-end">Credits</th>
@@ -89,8 +88,12 @@
             {{#each position.slots key="id" as |slot|}}
               <tr id="slot-{{slot.id}}">
                 <td>{{slot.id}}</td>
-                <td>{{shift-format slot.begins}}</td>
-                <td>{{shift-format slot.ends}}</td>
+                <td>
+                  {{shift-format slot.begins slot.ends}}
+                  {{#if slot.isNonPacific}}
+                    ({{slot.timezone_abbr}})
+                  {{/if}}
+                </td>
                 <td class="text-end">{{slot.max}}</td>
                 <td class="text-end">{{slot.signed_up}}</td>
                 <td class="text-end">{{credits-format slot.credits}}</td>

--- a/app/templates/training/index.hbs
+++ b/app/templates/training/index.hbs
@@ -7,7 +7,7 @@
 {{#each this.trainingSessions as |session|}}
   <UiSection>
     <:title>
-      {{shift-format session.slot.begins}}
+      {{shift-format session.slot.begins}} ({{session.slot.timezone_abbr}})
       <div class="d-sm-block d-lg-inline-block">{{session.slot.description}}</div>
     </:title>
     <:body>

--- a/app/templates/training/session/index.hbs
+++ b/app/templates/training/session/index.hbs
@@ -1,4 +1,4 @@
-<h1>{{this.year}} {{this.training.title}} - {{shift-format this.slot.begins}}
+<h1>{{this.year}} {{this.training.title}} - {{shift-format this.slot.begins}} ({{this.slot.timezone_abbr}})
   - {{this.slot.description}}</h1>
 <p>
   <LinkTo @route="training.index" @model={{this.training.id}} @query={{hash year=this.year}}>

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -52,6 +52,16 @@ module.exports = function (defaults) {
     'ember-bootstrap': {
       bootstrapVersion: 5,
       importBootstrapCSS: false
+    },
+
+    autoImport: {
+      webpack: {
+        resolve: {
+          fallback: {
+            fs: false
+          }
+        }
+      }
     }
   });
 
@@ -63,6 +73,8 @@ module.exports = function (defaults) {
 
   app.import(`node_modules/dayjs/plugin/advancedFormat.js`);
   app.import(`node_modules/dayjs/plugin/objectSupport.js`);
+  app.import(`node_modules/dayjs/plugin/utc.js`);
+  app.import(`node_modules/dayjs/plugin/timezone.js`);
 
   // If you need to use different assets in different
   // environments, specify an object as the first parameter. That

--- a/mirage/models/schedule.js
+++ b/mirage/models/schedule.js
@@ -4,5 +4,4 @@ import { Model } from 'ember-cli-mirage';
  * Not a real Clubhouse model - used only for testing.
  */
 
-export default Model.extend({
-});
+export default Model;

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,6 +70,7 @@
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-qunit": "^7.3.1",
         "global": "^4.4.0",
+        "ical-generator": "^3.5.1",
         "jscodeshift": "^0.13.1",
         "json-formatter-js": "^2.3.4",
         "libphonenumber-js": "^1.10.13",
@@ -5601,9 +5602,10 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "14.14.35",
-      "dev": true,
-      "license": "MIT"
+      "version": "18.7.18",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.18.tgz",
+      "integrity": "sha512-m+6nTEOadJZuTPkKR/SYK3A2d7FZrgElol9UP1Kae90VVU4a6mxnPuLiIW1m4Cq4gZ/nWb9GrdVXJCoCazDAbg==",
+      "dev": true
     },
     "node_modules/@types/qs": {
       "version": "6.9.7",
@@ -23826,6 +23828,58 @@
         "node": ">=0.4"
       }
     },
+    "node_modules/ical-generator": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/ical-generator/-/ical-generator-3.5.1.tgz",
+      "integrity": "sha512-OLCxRso9ulfkZeFY/aUzSZu9K/7IWnkJpjSG6coaNJXuToAyuBiCq4w1MG0cgSGzHQeY1WTVXez16fLwiZb5yg==",
+      "dev": true,
+      "dependencies": {
+        "uuid-random": "^1.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "@touch4it/ical-timezones": ">=1.6.0",
+        "@types/luxon": ">= 1.26.0",
+        "@types/mocha": ">= 8.2.1",
+        "@types/node": ">= 15.0.0",
+        "dayjs": ">= 1.10.0",
+        "luxon": ">= 1.26.0",
+        "moment": ">= 2.29.0",
+        "moment-timezone": ">= 0.5.33",
+        "rrule": ">= 2.6.8"
+      },
+      "peerDependenciesMeta": {
+        "@touch4it/ical-timezones": {
+          "optional": true
+        },
+        "@types/luxon": {
+          "optional": true
+        },
+        "@types/mocha": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "dayjs": {
+          "optional": true
+        },
+        "luxon": {
+          "optional": true
+        },
+        "moment": {
+          "optional": true
+        },
+        "moment-timezone": {
+          "optional": true
+        },
+        "rrule": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "dev": true,
@@ -39531,6 +39585,12 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/uuid-random": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/uuid-random/-/uuid-random-1.3.2.tgz",
+      "integrity": "sha512-UOzej0Le/UgkbWEO8flm+0y+G+ljUon1QWTEZOq1rnMAsxo2+SckbiZdKzAHHlVh6gJqI1TjC/xwgR50MuCrBQ==",
+      "dev": true
+    },
     "node_modules/v8-compile-cache": {
       "version": "2.3.0",
       "dev": true,
@@ -44655,7 +44715,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.14.35",
+      "version": "18.7.18",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.18.tgz",
+      "integrity": "sha512-m+6nTEOadJZuTPkKR/SYK3A2d7FZrgElol9UP1Kae90VVU4a6mxnPuLiIW1m4Cq4gZ/nWb9GrdVXJCoCazDAbg==",
       "dev": true
     },
     "@types/qs": {
@@ -57507,6 +57569,15 @@
       "integrity": "sha512-FYz4wlXgkQwIPqhzC5TdNMLSE5+GS1IIDJZY/1ZiEPCT2S3COUVZeT5OW4BmW4r5LHLQuOosSwsvnroG9GR59Q==",
       "dev": true
     },
+    "ical-generator": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/ical-generator/-/ical-generator-3.5.1.tgz",
+      "integrity": "sha512-OLCxRso9ulfkZeFY/aUzSZu9K/7IWnkJpjSG6coaNJXuToAyuBiCq4w1MG0cgSGzHQeY1WTVXez16fLwiZb5yg==",
+      "dev": true,
+      "requires": {
+        "uuid-random": "^1.3.2"
+      }
+    },
     "iconv-lite": {
       "version": "0.4.24",
       "dev": true,
@@ -68864,6 +68935,12 @@
     },
     "uuid": {
       "version": "8.3.2",
+      "dev": true
+    },
+    "uuid-random": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/uuid-random/-/uuid-random-1.3.2.tgz",
+      "integrity": "sha512-UOzej0Le/UgkbWEO8flm+0y+G+ljUon1QWTEZOq1rnMAsxo2+SckbiZdKzAHHlVh6gJqI1TjC/xwgR50MuCrBQ==",
       "dev": true
     },
     "v8-compile-cache": {

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-qunit": "^7.3.1",
     "global": "^4.4.0",
+    "ical-generator": "^3.5.1",
     "jscodeshift": "^0.13.1",
     "json-formatter-js": "^2.3.4",
     "libphonenumber-js": "^1.10.13",


### PR DESCRIPTION
- By default, slots are assumed to be in the Pacific timezone.
- Scheduling & training pages will show an abbreviated timezone (e.g., EDT, BST, etc.) suffix for slots not in the Pacific Timezone.