### PR TITLE
Fixes for dealing with errant pre-2008 timesheet entries.

### DIFF
--- a/app/components/person/timesheet-manage.hbs
+++ b/app/components/person/timesheet-manage.hbs
@@ -184,7 +184,7 @@
 
               <dt class="col-2">Time:</dt>
               <dd class="col-10">
-                {{shift-format this.editEntry.on_duty}} to {{shift-format this.editEntry.off_duty}}
+                {{shift-format this.editEntry.on_duty this.editEntry.off_duty}}
               </dd>
 
               <dt class="col-2">Duration:</dt>

--- a/app/components/person/timesheet-manage.js
+++ b/app/components/person/timesheet-manage.js
@@ -3,8 +3,11 @@ import {action} from '@ember/object';
 import {Role} from 'clubhouse/constants/roles';
 import {validatePresence} from 'ember-changeset-validations/validators';
 import validateDateTime from 'clubhouse/validators/datetime';
-import {tracked} from '@glimmer/tracking';
+import {cached,tracked} from '@glimmer/tracking';
 import {service} from '@ember/service';
+import { isEmpty } from '@ember/utils';
+import dayjs from 'dayjs';
+
 
 export default class PersonTimesheetManageComponent extends Component {
   @service ajax;
@@ -43,6 +46,12 @@ export default class PersonTimesheetManageComponent extends Component {
 
     this._markOverlapping();
   }
+
+  /**
+   * Run through all the entries and mark those which overlap in time.
+   *
+   * @private
+   */
 
   _markOverlapping() {
     const {timesheets} = this.args;
@@ -90,17 +99,54 @@ export default class PersonTimesheetManageComponent extends Component {
     }).catch((response) => this.house.handleErrorResponse(response));
   }
 
-  get minDate() {
-    return `${this.args.year}-08-01`;
+  /**
+   * Check if the entry has abnormal on duty or off duty times.
+   * Allow an unrestricted date range if the years don't match, or the months
+   * are not August or September.
+   *
+   * @param {string} restrictTime
+   * @returns {undefined|string}
+   * @private
+   */
+
+  _restrictCheck(restrictTime) {
+    if (!isEmpty(this.editEntry.on_duty) && !isEmpty(this.editEntry.off_duty)) {
+      const onDuty = dayjs(this.editEntry.on_duty), offDuty = dayjs(this.editEntry.off_duty);
+      if (onDuty.year() !== offDuty.year()
+        || onDuty.month() < 7 || onDuty.month() > 9
+        || offDuty.month() < 7 || offDuty.month() > 9) {
+        return undefined;
+      }
+    }
+    return restrictTime;
   }
 
+  /**
+   * Return the earliest on duty date allowed
+   *
+   * @returns {string|undefined}
+   */
+
+  @cached
+  get minDate() {
+     return this._restrictCheck(`${this.args.year}-08-01`);
+  }
+
+  /**
+   * Return the latest off duty date allowed
+   *
+   * @returns {string|undefined}
+   */
+
+  @cached
   get maxDate() {
-    return `${this.args.year}-09-15`;
+     return this._restrictCheck(`${this.args.year}-09-30`);
   }
 
   /**
    * Cancel an entry edit - i.e. hide the form dialog
    */
+
   @action
   cancelEntryAction() {
     this.editEntry = null;
@@ -112,6 +158,7 @@ export default class PersonTimesheetManageComponent extends Component {
    * @param model
    * @param {boolean} isValid
    */
+
   @action
   saveEntryAction(model, isValid) {
     if (!isValid) {
@@ -195,6 +242,12 @@ export default class PersonTimesheetManageComponent extends Component {
   cancelDeleteDialogAction() {
     this.deleteEntry = false;
   }
+
+  /**
+   * Do any of the entries overlap?
+   *
+   * @returns {boolean}
+   */
 
   get hasOverlapping() {
     return this.args.timesheets.find((ts) => ts.isOverlapping) !== undefined;

--- a/app/helpers/shift-format.js
+++ b/app/helpers/shift-format.js
@@ -34,9 +34,12 @@ export function shiftFormat([shiftDate, endDate], hash) {
   }
 
   const startDay = datetime.date(), endDay = endDatetime.date();
+
   let endFormat = null;
 
-  if ((startDay === endDay)) {
+  if (datetime.year() !== endDatetime.year()) {
+    return htmlSafe(`${datetime.format(MONTH_DAY_TIME_YEAR)} to <span class="d-inline-block">${endDatetime.format(MONTH_DAY_TIME_YEAR)}</span>`);
+  } else if (startDay === endDay) {
     // Don't bother with added the day on the end time if its only to midnight
     endFormat = endDatetime.format(HOUR_MINS);
   } else if ((endDatetime.dayOfYear() - datetime.dayOfYear()) > 1) {


### PR DESCRIPTION
- shift-format helper will show the full datetime w/year if the range spans years.
- Do not restrict the calendar date range when editing an existing timesheet and the date ranges crosses years, or the months are not August or September.