### PR TITLE
Radio Eligibility Report adjustments

### DIFF
--- a/app/controllers/admin/radio-eligibility.js
+++ b/app/controllers/admin/radio-eligibility.js
@@ -1,18 +1,26 @@
 import ClubhouseController from 'clubhouse/controllers/clubhouse-controller';
-import { action } from '@ember/object';
+import {action} from '@ember/object';
+import {tracked} from '@glimmer/tracking';
 
 export default class AdminRadioEligibilityController extends ClubhouseController {
-  queryParams = [ 'year' ];
+  queryParams = ['year'];
+
+  @tracked people;
+  @tracked year_1;
+  @tracked year_2;
+  @tracked year_3;
+  @tracked shift_lead_positions;
 
   @action
   exportToCsv() {
     const CSV_COLUMNS = [
-      { title: 'Callsign', key: 'callsign' },
-      { title: `${this.year_last} Hours`, key: 'hours_last_year' },
-      { title: `${this.year_prev} Hours`, key: 'hours_prev_year' },
-      { title: `Radio Hours`, key: 'radio_hours' },
-      { title: 'Shift Lead', key: 'shift_lead' },
-      { title: `${this.year} Signed Up`, key: 'signed_up' }
+      {title: 'Callsign', key: 'callsign'},
+      {title: `${this.year_1} Hours`, key: 'year_1'},
+      {title: `${this.year_2} Hours`, key: 'year_2'},
+      {title: `${this.year_3} Hours`, key: 'year_3'},
+      {title: `Radio Hours`, key: 'radio_hours'},
+      {title: 'Shift Lead', key: 'shift_lead', yesno: true},
+      {title: `${this.year} Signed Up`, key: 'signed_up', yesno: true}
     ];
 
     this.house.downloadCsv(`${this.year}-radio-eligibility.csv`, CSV_COLUMNS, this.people);

--- a/app/routes/admin/radio-eligibility.js
+++ b/app/routes/admin/radio-eligibility.js
@@ -10,30 +10,15 @@ export default class AdminRadioEligibilityRoute extends ClubhouseRoute {
     const year = requestYear(params);
     this.year = year;
 
-    return this.ajax.request('timesheet/radio-eligibility', {data: {year}}).then((results) => results.people);
+    return this.ajax.request('timesheet/radio-eligibility', {data: {year}});
   }
 
-  setupController(controller, model) {
+  setupController(controller, {people, year_1, year_2, year_3, shift_lead_positions}) {
     controller.set('year', this.year);
-
-    let year_last, year_prev;
-    switch (this.year) {
-      case 2022:
-        year_last = 2019;
-        year_prev = 2018;
-        break;
-      case 2023:
-        year_last = 2022;
-        year_prev = 2019;
-        break;
-      default:
-        year_last = this.year - 1;
-        year_prev = this.year - 2;
-        break;
-    }
-    controller.set('year_last', year_last);
-    controller.set('year_prev', year_prev);
-    controller.set('people', model);
+    controller.setProperties({
+      people, year_1, year_2, year_3, pandemicSkipped: (year_1 - year_3) > 2,
+      shift_lead_positions
+    });
   }
 
   resetController(controller, isExiting) {

--- a/app/templates/admin/radio-eligibility.hbs
+++ b/app/templates/admin/radio-eligibility.hbs
@@ -1,9 +1,19 @@
 <main>
-  <YearSelect @title="Radio Eligibility Report" @year={{this.year}} @onChange={{action (mut this.year)}}  />
+  <YearSelect @title="Radio Eligibility Report"
+              @year={{this.year}}
+              @minYear={{2010}}
+              @onChange={{action (mut this.year)}}
+              @skipPandemic={{true}}
+  />
   <p>
     The report will list all active, inactive, inactive extension, and retired
-    Rangers with their last year, and previous to last year hours. The Alpha
-    and Training shifts are not included.
+    Rangers with the last 3 event hours. The Alpha and Training shifts are not included.
+  </p>
+  <p>
+    A person is considered a Shift Lead is they currently hold one of the following positions:
+    {{#each this.shift_lead_positions as |position idx|}}
+      {{if idx ", "}}{{position.title}}
+    {{/each}}
   </p>
   <p>
     "Shift Lead" indicates if the person is shift lead.<br>
@@ -12,10 +22,9 @@
   <p>
     <UiButton @onClick={{this.exportToCsv}}>Export To CSV</UiButton>
   </p>
-  {{#if (or (eq this.year 2023) (eq this.year 2022))}}
-    <p>
-      <b class="text-danger">Because 2020 & 2021 were canceled, years {{this.year_last}} & {{this.year_prev}} are
-        shown.</b>
+  {{#if this.pandemicSkipped}}
+    <p class="text-danger">
+      Note: 2020 & 2021 are skipped over.
     </p>
   {{/if}}
   Showing {{pluralize this.people.length "person"}}
@@ -23,11 +32,12 @@
     <thead>
     <tr>
       <th>Callsign</th>
-      <th class="text-end">{{this.year_last}} Hours</th>
-      <th class="text-end">{{this.year_prev}} Hours</th>
+      <th class="text-end">{{this.year_1}} Hours</th>
+      <th class="text-end">{{this.year_2}} Hours</th>
+      <th class="text-end">{{this.year_3}} Hours</th>
       <th class="text-end">Eligibility Hours</th>
-      <th>Shift Lead</th>
-      <th>{{this.year}} Signup</th>
+      <th>Shift Lead?</th>
+      <th>{{this.year}} Signups?</th>
     </tr>
     </thead>
 
@@ -37,11 +47,12 @@
         <td>
           <PersonLink @person={{person}} />
         </td>
-        <td class="text-end">{{person.hours_last_year}}</td>
-        <td class="text-end">{{person.hours_prev_year}}</td>
+        <td class="text-end">{{person.year_1}}</td>
+        <td class="text-end">{{person.year_2}}</td>
+        <td class="text-end">{{person.year_3}}</td>
         <td class="text-end">{{person.radio_hours}}</td>
-        <td>{{yesno person.shift_lead}}</td>
-        <td>{{yesno person.signed_up}}</td>
+        <td class="text-center">{{yesno person.shift_lead}}</td>
+        <td class="text-center">{{yesno person.signed_up}}</td>
       </tr>
     {{else}}
       <tr>


### PR DESCRIPTION
- Report on the last 3 events as per policy, not just the last 2.
- Use the API result to show the years being reported on
- Indicate what Shift Lead positions are being considered.