### PR TITLE
handle-rules: look for substrings that are inappropriate

### DIFF
--- a/app/utils/handle-rules.js
+++ b/app/utils/handle-rules.js
@@ -66,9 +66,9 @@ export class InappropriateRule {
 
   check(name) {
     const result = [];
-    for (const word of name.toLowerCase().split(/[^a-z]+/)) {
-      const reason = this.inappropriateWords[word];
-      if (reason) {
+    // See if any inappropriate word is a substring of the proposed name
+    for (const [word, reason] of Object.entries(this.inappropriateWords)) {
+      if (name.toLowerCase().indexOf(word) >= 0) {
         result.push(new HandleConflict(name, `${word} ${reason}`, 'high', this.id));
       }
     }

--- a/tests/unit/utils/handle-rules-test.js
+++ b/tests/unit/utils/handle-rules-test.js
@@ -153,34 +153,34 @@ module('Unit | Utility | handle-rules', function(hooks) {
   // eslint-disable-next-line qunit/require-expect
   test('inappropriate rejects the Carlin 7', function(assert) {
     const rule = new InappropriateRule();
-    let checkit = (name) => {
+    let checkit = (name, matchCount) => {
       let conflicts = rule.check(name);
-      assert.strictEqual(conflicts.length, 1, `${JSON.stringify(conflicts.length)} conflicts for ${name}`);
+      assert.strictEqual(conflicts.length, matchCount, `${JSON.stringify(conflicts.length)} conflicts for ${name}`);
       assert.strictEqual(conflicts[0].candidateName, name);
       assert.ok(conflicts[0].description.match(/FCC/));
     };
-    checkit('Hot shit handle');
-    checkit('Piss-ant');
-    checkit('Fuck Censorship');
-    checkit('Why Cunt?');
-    checkit('CockSucker');
-    checkit('Charismatic Motherfucker');
-    checkit('2Tits');
+    checkit('Hot shit handle', 1);
+    checkit('Piss-ant', 1);
+    checkit('Fuck Censorship', 1);
+    checkit('Why Cunt?', 1);
+    checkit('CockSucker', 1);
+    checkit('Charismatic Motherfucker', 2);
+    checkit('2Tits', 1);
   });
 
   // eslint-disable-next-line qunit/require-expect
   test('inappropriate rejects the Roma slurs', function(assert) {
     const rule = new InappropriateRule();
-    let checkit = (name) => {
+    let checkit = (name, matchCount) => {
       let conflicts = rule.check(name);
-      assert.strictEqual(conflicts.length, 1, `${JSON.stringify(conflicts.length)} conflicts for ${name}`);
+      assert.strictEqual(conflicts.length, matchCount, `${JSON.stringify(conflicts.length)} conflicts for ${name}`);
       assert.strictEqual(conflicts[0].candidateName, name);
       assert.ok(conflicts[0].description.match(/Roma/));
     };
-    checkit('Gypsy Child');
-    checkit('Band of Gypsies');
-    checkit('Zingara');
-    checkit('Big-Gitan');
+    checkit('Gypsy Child', 1);
+    checkit('Band of Gypsies', 2);
+    checkit('Zingara', 1);
+    checkit('Big-Gitan', 1);
   });
 
   // === PhoneticAlphabetRule tests ===


### PR DESCRIPTION
Without this change, the checker is only looking for exact words that exist in a proposed handle. Example cases:

Triggered before and after this change:
Shit
Dog Shit

Triggers only after this change, not before:
PissShit
GypsyMan
BassHitter

"BassHitter" is given as an example of one that's probably OK. All of the inappropriate words are long enough that I wouldn't expect all that many false positive hits.

I'm not sure if this change is desirable or not. It was just so easy to do that I thought I'd make a PR rather than an email thread.