### PR TITLE
Support for (ART) training required for assoc. roles to take effect.

### DIFF
--- a/app/components/person/full-form.hbs
+++ b/app/components/person/full-form.hbs
@@ -151,7 +151,6 @@ Everyone else will see person/simple-form
     </div>
   </FormRow>
 
-
   <FormRow>
     <FormLabel @fixed={{true}}>Agreements</FormLabel>
     <div class="col-sm-12 col-xl-auto mt-2">
@@ -207,6 +206,7 @@ Everyone else will see person/simple-form
         </UiButton>
       </div>
     {{/if}}
+
     {{#if (has-role "admin")}}
       <div class="col-sm-12 col-xl-auto mb-4">
         <UiButton @type="secondary" @class="btn-responsive" @onClick={{@showPasswordDialogAction}}>
@@ -214,6 +214,15 @@ Everyone else will see person/simple-form
         </UiButton>
       </div>
     {{/if}}
+
+    {{#if (has-role "tech-ninja")}}
+      <div class="col-sm-12 col-xl-auto mb-4">
+        <UiButton @type="secondary" @class="btn-responsive" @onClick={{@clearRoleCacheAction}}>
+          Clear Cached Roles
+        </UiButton>
+      </div>
+    {{/if}}
+
     <div class="col-sm-12 col-xl-auto mb-4">
       {{#if @person.isSaving}}
         <LoadingIndicator/>

--- a/app/components/person/role-form.hbs
+++ b/app/components/person/role-form.hbs
@@ -17,7 +17,7 @@
               <label for="role-{{role.id}}" class="form-check-label">
                 {{role.title}}
                 {{#if role.disabled}}
-                  <div class="text-muted small">Contact Tech Team to grant/revoke</div>
+                  <div class="text-muted small">Contact Tech Team to assign/remove</div>
                 {{/if}}
               </label>
 
@@ -27,6 +27,16 @@
                   <ul>
                     {{#each role.positions as |position|}}
                       <li>{{position.title}}</li>
+                    {{/each}}
+                  </ul>
+                </div>
+              {{/if}}
+              {{#if role.teams}}
+                <div class="ms-1">
+                  <div class="text-danger">Granted thru {{pluralize role.teams.length "team"}}:</div>
+                  <ul>
+                    {{#each role.teams as |team|}}
+                      <li>{{team.title}}</li>
                     {{/each}}
                   </ul>
                 </div>

--- a/app/components/person/role-form.js
+++ b/app/components/person/role-form.js
@@ -19,15 +19,14 @@ export default class PersonRoleFormComponent extends Component {
     this.roleIds = grantedRoles.roles.map((r) => r.id);
     this.roleForm = {roleIds: this.roleIds};
 
-    this.roles = roles.map((role) => {
-      return {
-        id: role.id,
-        title: role.title,
-        selected: this.roleIds.includes(role.id),
-        positions: grantedRoles.position_roles.filter((p) => p.role_id === role.id),
-        disabled: ((role.id === TECH_NINJA || role.id === ADMIN) && !isTechNinja),
-      }
-    });
+    this.roles = roles.map((role) => ({
+      id: role.id,
+      title: role.title,
+      selected: this.roleIds.includes(role.id),
+      positions: grantedRoles.position_roles.filter((p) => p.role_id === role.id),
+      teams: grantedRoles.team_roles.filter((p) => p.role_id === role.id),
+      disabled: ((role.id === TECH_NINJA || role.id === ADMIN) && !isTechNinja),
+    }));
 
     this.roleGroups = inGroups(this.roles, 3);
   }

--- a/app/components/person/roles.hbs
+++ b/app/components/person/roles.hbs
@@ -9,46 +9,68 @@
   {{/if}}
 </div>
 {{#unless this.combinedRoles}}
-  <div class="mt-2 text-danger">
-    <b>No roles granted.</b>
+  <div class="mt-2">
+    <b>No additional roles granted.</b>
   </div>
 {{/unless}}
 {{#if @showRoles}}
-  <div class="masonry-container masonry-border masonry-col-2 mt-2">
+  <p class="mt-2">
+    Effective roles are a union of manual assignment, team membership with associated roles, and position assignments with
+    associated roles.
+  </p>
+  <table class="table table-width-auto table-sm table-striped table-hover">
+    <thead>
+    <tr>
+      <th>Role</th>
+      <th class="text-center">Manually Assigned?</th>
+      <th>Thru Teams</th>
+      <th>Thru Positions</th>
+    </tr>
+    </thead>
+    <tbody>
     {{#each this.combinedRoles as |role| }}
-      <div class="masonry-item">
-        {{role.title}}
-        {{#if role.granted}}
-          {{#if (or role.teams role.positions)}}
-            <div class="small text-muted">
-              Manually assigned and granted thru:
+      <tr>
+        <td class="text-nowrap">
+          {{#if role.notGranted}}
+            {{fa-icon "ban"}} {{role.title}}
+            <div class="text-danger small">NOT ASSIGNED</div>
+          {{else}}
+            {{role.title}}
+          {{/if}}
+        </td>
+        <td class="text-center">
+          {{yesno role.granted}}
+        </td>
+        <td>
+          {{#each role.teams as |team idx|}}
+            {{#if idx}}<br>{{/if}}
+            {{team.title}}
+          {{else}}
+            <i class="text-muted">none</i>
+          {{/each}}
+        </td>
+        <td>
+          {{#if role.notGranted}}
+            <div class="text-danger small">
+              Since the appropriate ART training(s) have not been passed for the year, the role has not been assigned.
             </div>
           {{/if}}
-        {{else}}
-          <div class="small text-muted">
-            Only granted thru:
-          </div>
-        {{/if}}
-        {{#if role.teams}}
-          <div class="mt-1">
-            <Popover @text="[{{pluralize role.teams.length "team"}}]" @placement="bottom">
-              {{#each role.teams as |team|}}
-                {{team.title}}<br>
-              {{/each}}
-            </Popover>
-          </div>
-        {{/if}}
-
-        {{#if role.positions}}
-          <div class="mt-1">
-            <Popover @text="[{{pluralize role.positions.length "position"}}]" @placement="bottom">
-              {{#each role.positions as |position|}}
-                {{position.title}}<br>
-              {{/each}}
-            </Popover>
-          </div>
-        {{/if}}
-      </div>
+          {{#each role.positions as |position idx|}}
+            {{#if idx}}<br>{{/if}}
+            {{position.title}}
+            {{#if position.require_training_for_roles}}
+              {{#if position.is_trained}}
+                (trained)
+              {{else}}
+                <span class="text-danger">(NOT TRAINED)</span>
+              {{/if}}
+            {{/if}}
+          {{else}}
+            <i class="text-muted">none</i>
+          {{/each}}
+        </td>
+      </tr>
     {{/each}}
-  </div>
+    </tbody>
+  </table>
 {{/if}}

--- a/app/components/person/roles.js
+++ b/app/components/person/roles.js
@@ -9,17 +9,31 @@ export default class PersonRolesComponent extends Component {
 
     this.args.roles.forEach((role) => {
       const granted = !!roles.find((r) => role.id === r.id);
+      const teams = team_roles.filter((t) => t.role_id === role.id).sort((a, b) => a.title.localeCompare(b.title));
+      const positions = position_roles.filter((p) => p.role_id === role.id).sort((a, b) => a.title.localeCompare(b.title));
 
-      if (!granted && !position_roles.find((p) => p.role_id === role.id)) {
+      if (!granted && !positions.length && !teams.length) {
         return;
+      }
+
+       let notGranted = false;
+
+      // See if the role is only granted thru the positions, said positions require training before the roles
+      // are granted, and the person is not (ART) trained.
+      if (!granted
+        && !teams.length
+        && positions.filter((p) => p.require_training_for_roles).length === positions.length
+        && !positions.some((p) => p.is_trained)) {
+        notGranted = true;
       }
 
       foundRoles.push({
         id: role.id,
         title: role.title,
         granted,
-        positions: position_roles.filter((p) => p.role_id === role.id).sort((a, b) => a.title.localeCompare(b.title)),
-        teams: team_roles.filter((t) => t.role_id === role.id).sort((a, b) => a.title.localeCompare(b.title)),
+        positions,
+        teams,
+        notGranted,
       });
     });
 

--- a/app/components/position-table.hbs
+++ b/app/components/position-table.hbs
@@ -24,7 +24,7 @@
       <td>
         {{position.title}}
       </td>
-       <td>
+      <td>
         <PresentOrNot @value={{position.short_title}} @empty="-"/>
       </td>
       <td>
@@ -37,23 +37,26 @@
           Training position:
           <div class="ms-3">{{pluck position.training_position_id @positions "title" "-"}}</div>
         {{/if}}
+        {{#if position.require_training_for_roles}}
+          {{fa-icon "user-graduate" fixed=true}} Requires ART to be passed before roles are granted.<br>
+        {{/if}}
         {{#if position.new_user_eligible}}
-          {{fa-icon "globe"}} Grant to New Accounts<br>
+          {{fa-icon "globe" fixed=true}} Grant to New Accounts<br>
         {{/if}}
         {{#if position.all_rangers}}
-          {{fa-icon "universal-access"}} Grant To All Rangers<br>
+          {{fa-icon "universal-access" fixed=true}} Grant To All Rangers<br>
         {{/if}}
         {{#if position.count_hours}}
-          {{fa-icon "clock"}} Hours count towards appreciations<br>
+          {{fa-icon "clock" fixed=true}} Hours count towards appreciations<br>
         {{/if}}
         {{#if position.on_sl_report}}
-          {{fa-icon "list"}} On Shift Lead Report<br>
+          {{fa-icon "list fixed=true"}} On Shift Lead Report<br>
         {{/if}}
         {{#if position.on_trainer_report}}
-          {{fa-icon "rectangle-list"}} On Trainer's Report<br>
+          {{fa-icon "rectangle-list" fixed=true}} On Trainer's Report<br>
         {{/if}}
         {{#if position.prevent_multiple_enrollments}}
-          {{fa-icon "ban"}} Multiple Enrollments Prevented<br>
+          {{fa-icon "ban" fixed=true}} Multiple Enrollments Prevented<br>
         {{/if}}
         {{#if position.contact_email}}
           {{mail-to position.contact_email}}

--- a/app/controllers/person/index.js
+++ b/app/controllers/person/index.js
@@ -204,7 +204,7 @@ export default class PersonIndexController extends ClubhouseController {
 
     return this.ajax.request(`person/${personId}/membership`)
       .then(({membership}) => {
-        this.personMembership =membership;
+        this.personMembership = membership;
 
         // Reload the roles because team and positions may have added or removed roles
         this.ajax.request(`person/${personId}/roles`, {data: {include_memberships: 1}})
@@ -296,5 +296,16 @@ export default class PersonIndexController extends ClubhouseController {
   @action
   closePasswordDialogAction() {
     this.showPasswordDialog = false;
+  }
+
+  /**
+   * Clear any cached roles - just in case the cache got f**ked up.
+   */
+
+  @action
+  clearRoleCacheAction() {
+    this.ajax.request('role/clear-cache', {method: 'POST', data: {person_id: this.person.id}}).then(() => {
+      this.toast.success('Role cache has been cleared.');
+    }).catch((response) => this.house.handleErrorResponse(response));
   }
 }

--- a/app/controllers/reports/people-by-role.js
+++ b/app/controllers/reports/people-by-role.js
@@ -3,6 +3,14 @@ import {tracked} from '@glimmer/tracking';
 import {action} from '@ember/object';
 import {cached} from '@glimmer/tracking';
 
+const CSV_COLUMNS = [
+  {title: 'ID', key: 'id'},
+  {title: 'Callsign', key: 'callsign'},
+  {title: 'Explicit Grant?', key: 'granted', yesno: true },
+  {title: 'Teams', key: 'teams' },
+  {title: 'Positions', key: 'positions'}
+];
+
 export default class ReportsPeopleByRoleController extends ClubhouseController {
   @tracked showPerson = null;
   @tracked filter;
@@ -44,4 +52,54 @@ export default class ReportsPeopleByRoleController extends ClubhouseController {
     this.showPerson = null;
   }
 
+  @action
+  exportToCSV(role) {
+    const rows = role.people.map((p) => {
+      return {
+        id: p.id,
+        callsign: p.callsign,
+        granted: p.granted,
+        teams: p.teams.map((t) => t.title).join("\n"),
+        positions: p.positions.map((p) => p.title).join("\n"),
+        positions_granted: p.positions.map((p) => {
+          if (!p.require_training_for_roles) {
+            return 'Granted - Training not required';
+          } else if (p.is_trained) {
+            return 'Granted - Training passed';
+          } else {
+            return 'NOT GRANTED - Training not passed';
+          }
+        }).join("\n")
+      }
+    })
+
+    this.house.downloadCsv(`${this.house.currentYear()}-${role.title}-grants.csv`, CSV_COLUMNS, rows);
+  }
+
+  grantedHow(person) {
+    const grants = [];
+
+    if (!person.granted && !person.teams.length) {
+      // See if the position is only granted thru positions which requires training
+      if (person.positions.filter((p) => p.require_training_for_roles).length === person.positions.length) {
+        if (!person.positions.find((p) => p.is_trained)) {
+          return 'untrained position';
+        }
+      }
+    }
+
+    if (person.granted) {
+      grants.push('role');
+    }
+
+    if (person.positions.length) {
+      grants.push('position');
+    }
+
+    if (person.teams.length) {
+      grants.push('team');
+    }
+
+    return grants.join(', ');
+  }
 }

--- a/app/models/position.js
+++ b/app/models/position.js
@@ -19,6 +19,8 @@ export default class PositionModel extends Model {
   @attr('boolean', { defaultValue: false }) all_team_members;
   @attr('boolean', { defaultValue: false }) public_team_position;
 
+  @attr('boolean', { defaultValue: false }) require_training_for_roles;
+
   @attr('') role_ids;
 
   @attr('number') min;

--- a/app/routes/reports/people-by-role.js
+++ b/app/routes/reports/people-by-role.js
@@ -2,11 +2,12 @@ import ClubhouseRoute from 'clubhouse/routes/clubhouse-route';
 
 export default class ReportsPeopleByRoleRoute extends ClubhouseRoute {
   model() {
-    return this.ajax.request('person/by-role');
+    return this.ajax.request('role/people-by-role');
   }
 
   setupController(controller, {roles}) {
     controller.roles = roles;
     controller.filter = 'all';
+    controller.showPerson = null;
   }
 }

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -549,8 +549,11 @@ legend {
 }
 
 .callsign-list {
-  column-count: auto;
-  column-width: 16ch;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(8em, 10em));
+
+  /* column-count: auto;
+   column-width: 18ch;*/
 
   > a {
     display: block;

--- a/app/templates/admin/positions.hbs
+++ b/app/templates/admin/positions.hbs
@@ -1,8 +1,11 @@
 <main>
   <h1>Clubhouse Positions</h1>
-  <p>
-    <b class="text-danger">Contact the Scheduling Gnome or Tech Team about position creation and/or adjustments.</b>
-  </p>
+  {{#if this.canManagePositions}}
+    <UiNotice @type="secondary" @icon="hand-point-right" @title="Need Position Help?">
+      Contact the Tech Team about creating new positions or adjusting existing ones.<br>
+      {{admin-email}}
+    </UiNotice>
+  {{/if}}
   <FormRow>
     <FormLabel @auto={{true}}>Type filter</FormLabel>
     <div class="col-auto">
@@ -184,16 +187,22 @@
           <fieldset>
             <legend>Position Role Grants</legend>
             <FormRow>
-              <f.checkboxGroup @name="role_ids" @options={{this.roleOptions}} />
+              <div class="col-12">
+                <f.checkbox @name="require_training_for_roles"
+                            @label="ART must be passed before roles are granted"/>
+              </div>
+            </FormRow>
+            <FormRow>
+              <f.checkboxGroup @label="Roles To Grant When Position is Granted" @name="role_ids" @options={{this.roleOptions}} />
             </FormRow>
           </fieldset>
 
-          {{#if (eq f.model.type "Training")}}
+          {{#unless (eq f.model.type "Training")}}
             <fieldset>
               <legend>Training</legend>
               <p>
-                This section is relevant when type is "Training". The Training Position is the position
-                the person has to have passed in the current year to be allowed to work this position during the event.
+                The Training Position is the position the person has to have passed in the current year to
+                be allowed to work this position during the event.
               </p>
               <FormRow>
                 <f.select @name="training_position_id"
@@ -202,10 +211,9 @@
                 />
               </FormRow>
             </fieldset>
-          {{/if}}
+          {{/unless}}
           <fieldset>
             <legend>Notifications</legend>
-
             <FormRow>
               <div class="col-12">
                 <f.checkbox @name="alert_when_empty"

--- a/app/templates/person/index.hbs
+++ b/app/templates/person/index.hbs
@@ -17,12 +17,14 @@
 {{#if this.person.is_bouncing}}
   <UiNotice @title="Email Bouncing" @type="danger" @icon="envelope">
     <p>
-      The email address has been reported as bouncing. The inbox might be full, the person's email server is experiencing
+      The email address has been reported as bouncing. The inbox might be full, the person's email server is
+      experiencing
       issues, or the address is no longer valid.
     </p>
     Contact the Ranger Tech Ninjas at {{admin-email}} for assistance.
   </UiNotice>
 {{/if}}
+
 {{#if this.person.unread_message_count}}
   <p>
     <LinkTo @route="person.messages">
@@ -63,6 +65,8 @@
                             @sendWelcomeMailAction={{this.sendWelcomeMailAction}}
 
                             @showPasswordDialogAction={{this.showPasswordDialogAction}}
+
+                            @clearRoleCacheAction={{this.clearRoleCacheAction}}
           />
         {{else}}
           <Person::SimpleForm @person={{this.person}}

--- a/app/templates/reports/people-by-role.hbs
+++ b/app/templates/reports/people-by-role.hbs
@@ -1,9 +1,5 @@
 <h1>People By Role Report</h1>
 <p>
-  {{fa-icon "user-plus" color="danger"}} = Role is explicitly granted.<br>
-  {{fa-icon "sitemap"}} = Role granted via a team and/or position.
-</p>
-<p>
   Click on the callsign to see how the role is granted.
 </p>
 <p>
@@ -17,16 +13,14 @@
     <accordion.body>
       {{#if accordion.isOpen}}
         {{#if role.people}}
-          <div class="callsign-list">
+          <UiButton @onClick={{fn this.exportToCSV role}}>Export To CSV</UiButton>
+          <div class="callsign-list mt-2">
             {{#each role.people key="id" as |person|}}
               <div>
                 <a href {{action this.showPersonAction person}}>{{person.callsign}}</a>
-                {{#if person.granted}}
-                  {{fa-icon "user-plus"}}
-                {{/if}}
-                {{#if (or person.teams person.positions)}}
-                  {{fa-icon "sitemap"}}
-                {{/if}}
+                <div class="text-muted small">
+                  via {{this.grantedHow person}}
+                </div>
               </div>
             {{/each}}
           </div>
@@ -41,44 +35,63 @@
 {{#if this.showPerson}}
   <ModalDialog @title="{{this.showPerson.callsign}} information" as |Modal|>
     <Modal.body>
-      <p>
-        {{#if this.showPerson.granted}}
-          <b class="text-danger">Role has been granted explicitly.</b>
-        {{else}}
-          Role has NOT been granted explicitly.
-        {{/if}}
-      </p>
-      {{#if (or this.showPerson.teams this.showPerson.positions)}}
-        Role is granted thru {{pluralize this.showPerson.teams.length "team"}} and
-        {{pluralize this.showPerson.positions.length "position"}}.
-        <dl class="mt-2">
-          <dt>Teams:</dt>
-          <dd>
+      <table class="table table-sm table-width-auto mb-2">
+        <thead>
+        <tr>
+          <th>Explicit Grant</th>
+          <th>Teams</th>
+          <th>Positions</th>
+          <th>&nbsp;</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr>
+          <td>
+            {{#if this.showPerson.granted}}
+              <span class="text-danger">Explicit Grant?</span>
+            {{else}}
+              <span class="text-muted">None</span>
+            {{/if}}
+          </td>
+          <td>
             {{#each this.showPerson.teams as |team|}}
               {{team.title}}<br>
             {{else}}
-              <i>none</i>
+              <span class="text-muted">None</span>
             {{/each}}
-          </dd>
-          <dt>Positions:</dt>
-          <dd>
-            {{#each this.showPerson.positions as |position|}}
-              {{position.title}}<br>
-            {{else}}
-              <i>none</i>
+          </td>
+          <td>
+            {{#each this.showPerson.positions as |position idx|}}
+              {{#if idx}}
+                <br>
+              {{/if}}
+              {{position.title}}
             {{/each}}
-          </dd>
-        </dl>
-      {{else}}
-        <p>
-          Role is not granted through any team or position assignment.
-        </p>
-      {{/if}}
-      <p>
-        Visit
-        <PersonLink @person={{this.showPerson}} />
-        person management page.
-      </p>
+          </td>
+          <td>
+            {{#each this.showPerson.positions as |position idx|}}
+              {{#if position.require_training_for_roles}}
+                {{#if idx}}
+                  <br>
+                {{/if}}
+                {{#if position.is_trained}}
+                  <span class="text-success">{{fa-icon "check"}} Trained - Role granted</span>
+                {{else}}
+                  <span class="text-danger small">
+                    {{fa-icon "ban"}} Untrained - Will not be granted until ART is passed.
+                  </span>
+                {{/if}}
+              {{else}}
+                <span class="text-muted">Role granted (training not required)</span>
+              {{/if}}
+            {{/each}}
+          </td>
+        </tr>
+        </tbody>
+      </table>
+      <LinkTo @route="person.index" @model={{this.showPerson.id}}>
+        Go to {{this.showPerson.callsign}}'s Person Manage page.
+      </LinkTo>
     </Modal.body>
     <Modal.footer>
       <UiCloseButton @onClick={{this.closePerson}} />


### PR DESCRIPTION
- People By Status report indicates if the person passed (ART) training or not.
- Export To CSV added to People By Status report
- Edit Roles dialog was not showing team membership role associations.
- Show Roles redesigned to list the roles as a table.