### PR TITLE
Action log & Show Role tweaks.

### DIFF
--- a/app/components/person/roles.hbs
+++ b/app/components/person/roles.hbs
@@ -19,7 +19,7 @@
             Inspect Cache
           </a>
         </ddm.item>
-        <ddm.divider />
+        <ddm.divider/>
         <ddm.item>
           <a href {{action this.clearRoleCacheAction}}>
             Clear Cache
@@ -44,20 +44,26 @@
     <thead>
     <tr>
       <th>Role</th>
-      <th class="text-center">Manually Assigned?</th>
-      <th>Thru Teams</th>
-      <th>Thru Positions</th>
+      <th>Active?</th>
+      <th class="text-center">Manually<br>Assigned?</th>
+      <th>Thru<br>Teams</th>
+      <th>Thru<br>Positions</th>
     </tr>
     </thead>
     <tbody>
     {{#each this.combinedRoles as |role| }}
       <tr>
         <td class="text-nowrap">
-          {{#if role.notGranted}}
-            {{fa-icon "ban"}} {{role.title}}
-            <div class="text-danger small">NOT ASSIGNED</div>
+          {{#unless role.active}}
+            {{fa-icon "ban"}}
+          {{/unless}}
+          {{role.title}}
+        </td>
+        <td class="text-center">
+          {{#if role.active}}
+            Y
           {{else}}
-            {{role.title}}
+            <b class="text-danger">N</b>
           {{/if}}
         </td>
         <td class="text-center">
@@ -72,11 +78,11 @@
           {{/each}}
         </td>
         <td>
-          {{#if role.notGranted}}
+          {{#unless role.active}}
             <div class="text-danger small">
               Since the appropriate ART training(s) have not been passed for the year, the role has not been assigned.
             </div>
-          {{/if}}
+          {{/unless}}
           {{#each role.positions as |position idx|}}
             {{#if idx}}<br>{{/if}}
             {{position.title}}

--- a/app/components/person/roles.js
+++ b/app/components/person/roles.js
@@ -35,7 +35,7 @@ export default class PersonRolesComponent extends Component {
         return;
       }
 
-      let notGranted = false;
+      let active = true;
 
       // See if the role is only granted thru the positions, said positions require training before the roles
       // are granted, and the person is not (ART) trained.
@@ -43,7 +43,7 @@ export default class PersonRolesComponent extends Component {
         && !teams.length
         && positions.filter((p) => p.require_training_for_roles).length === positions.length
         && !positions.some((p) => p.is_trained)) {
-        notGranted = true;
+        active = false;
       }
 
       foundRoles.push({
@@ -52,7 +52,7 @@ export default class PersonRolesComponent extends Component {
         granted,
         positions,
         teams,
-        notGranted,
+        active,
       });
     });
 

--- a/app/templates/admin/action-log.hbs
+++ b/app/templates/admin/action-log.hbs
@@ -101,7 +101,7 @@
           </td>
         </tr>
 
-        {{#if (or log.positions log.position log.roles log.slot)}}
+        {{#if (or log.positions log.position log.roles log.slot log.role log.team)}}
           <tr class="tr-no-border">
             <td colspan="5">
               {{#if log.positions}}
@@ -120,6 +120,10 @@
                 {{/each}}<br>
               {{/if}}
 
+              {{#if log.role}}
+                Role: {{log.role.title}}<br>
+              {{/if}}
+
               {{#if log.slot}}
                 Slot #{{log.slot.id}} {{log.slot.position.title}} - {{log.slot.description}}
                 {{shift-format log.slot.begins}}<br>
@@ -130,6 +134,10 @@
                   Previously Enrolled #{{slot.id}} {{slot.position.title}} - {{slot.description}}
                   {{shift-format slot.begins}}<br>
                 {{/each}}
+              {{/if}}
+
+              {{#if log.team}}
+                Team: {{log.team.title}}<br>
               {{/if}}
             </td>
           </tr>


### PR DESCRIPTION
- Include team and role titles on the action log for team/position updates.
- Indicate if the role is active on Show Roles.