### PR TITLE
handle-reservations: hide expired reservations by default

### DIFF
--- a/app/controllers/admin/handle-reservations.js
+++ b/app/controllers/admin/handle-reservations.js
@@ -1,3 +1,4 @@
+import dayjs from 'dayjs';
 import ClubhouseController from 'clubhouse/controllers/clubhouse-controller';
 import {action} from '@ember/object';
 import {tracked} from '@glimmer/tracking';
@@ -17,6 +18,8 @@ export default class HandleReservationController extends ClubhouseController {
 
   @tracked handleReservations;
 
+  @tracked showExpired = false;
+
   @tracked entry = null;
 
   typeOptions = [
@@ -32,6 +35,15 @@ export default class HandleReservationController extends ClubhouseController {
 
   typeLabel(type) {
     return TypeLabels[type] ?? type;
+  }
+
+  get reservations() {
+    let results = this.handleReservations;
+    if (!this.showExpired) {
+      const today = dayjs();
+      results = results.filter((h) => h.end_date === null || today.isBefore(h.end_date));
+    }
+    return results;
   }
 
   @action
@@ -69,5 +81,10 @@ export default class HandleReservationController extends ClubhouseController {
   @action
   cancelHandleReservation() {
     this.entry = null;
+  }
+
+  @action
+  toggleShowExpired() {
+    this.showExpired = !this.showExpired;
   }
 }

--- a/app/templates/admin/handle-reservations.hbs
+++ b/app/templates/admin/handle-reservations.hbs
@@ -10,6 +10,10 @@
   <p>
     {{! TODO(srabraham): maybe add a "delete all expired button"? }}
     <button type="button" class="btn btn-primary" {{action this.newHandleReservation}}>New Handle Reservation</button>
+    <div class="form-check form-check-inline">
+      <Input @type="checkbox" @checked={{this.showExpired}} class="form-check-input" id="show-expired" onclick="{{action this.toggleShowExpired}}" />
+      <label class="form-check-label" for="show-expired">Show Expired</label>
+    </div>
   </p>
   {{! TODO(srabraham): maybe add filtering? Bulk deleting? }}
   <table class="table table-sm table-hover table-striped table-width-auto">
@@ -24,7 +28,7 @@
     </tr>
     </thead>
     <tbody>
-    {{#each this.handleReservations as |hr|}}
+    {{#each this.reservations as |hr|}}
       <tr>
         <td>{{hr.handle}}</td>
         <td>{{this.typeLabel hr.reservation_type}}</td>

--- a/app/utils/handle-rules.js
+++ b/app/utils/handle-rules.js
@@ -132,11 +132,15 @@ export class SubstringRule {
         }
       } else if (name.length < targetName.length) {
         if (targetName.indexOf(name) >= 0) {
-          result.push(new HandleConflict(rawName, `${handle.name} contains ${rawName}`, 'medium', this.id, handle));
+          // TODO(srabraham): improve priority handling; other types should be high priority as well
+          const priority = handle.entityType === 'slur' ? 'high' : 'medium';
+          result.push(new HandleConflict(rawName, `${handle.name} contains ${rawName}`, priority, this.id, handle));
         }
       } else {
         if (name.indexOf(targetName) >= 0) {
-          result.push(new HandleConflict(rawName, `${rawName} contains ${handle.name}`, 'medium', this.id, handle));
+          // TODO(srabraham): improve priority handling; other types should be high priority as well
+          const priority = handle.entityType === 'slur' ? 'high' : 'medium';
+          result.push(new HandleConflict(rawName, `${rawName} contains ${handle.name}`, priority, this.id, handle));
         }
       }
     }


### PR DESCRIPTION
VCs ought to usually just care about active reservations, but it'll be nice to still be able to edit expired ones, e.g. to extend their end dates.

This also adds a relevant tweak and TODO to the handle checker tool. We'll need to deal with priorities a bit better when processing reservations from the backend.