### PR TITLE
Search bar improvements.

### DIFF
--- a/app/components/autocomplete-input.hbs
+++ b/app/components/autocomplete-input.hbs
@@ -14,6 +14,9 @@
         </dd.menu>
       </BsDropdown>
     {{/if}}
+    {{#if @appendSearchIcon}}
+      <span class="input-group-text">{{fa-icon "search"}}</span>
+    {{/if}}
     <input type="search"
            placeholder={{@placeholder}}
            value={{@text}}
@@ -27,61 +30,78 @@
            spellcheck="false"
            ...attributes
     />
-    {{#if @appendSearchIcon}}
-      <span class="input-group-text">{{fa-icon "search"}}</span>
-    {{/if}}
   </div>
-  {{#if (and this.isFocused (or this.isSearching this.noResultsFound this.options))}}
-    <div class="autocomplete-results-box autocomplete-results-box-overlay mt-1 border rounded"
-      {{did-insert this.resultsBoxInsertedEvent}}
-      {{will-destroy this.resultsBoxDestroy}}
-    >
-      <div class="autocomplete-list">
-        {{#if this.noResultsFound}}
-          <div class="autocomplete-no-results">{{this.noResultsText}}</div>
-        {{else if this.isSearching}}
-          <div class="autocomplete-searching">
-            Searching
-            <SpinIcon/>
-          </div>
-        {{/if}}
-        {{#if (and this.options this.title)}}
-          <div class="autocomplete-title">
-            {{this.title}}
-          </div>
-        {{/if}}
-        {{#each this.options as |opt idx|}}
-          {{#if opt.isGroup}}
-            <div class="autocomplete-group-header">{{opt.title}}</div>
-            {{#each opt.items as |item|}}
-              <div class="autocomplete-item {{if (eq item.index this.selectionIdx) "autocomplete-option-selected"}}"
-                   data-result-id={{item.index}}
-                   role="link"
-                {{on "click" (fn this.clickSelection item)}}
-                {{!template-lint-disable no-pointer-down-event-binding}}
-                {{on "mousedown" (fn this.clickSelection item)}}
-              >
-                {{yield item opt}}
-              </div>
-            {{/each}}
-          {{else}}
-            <div class="autocomplete-item {{if (eq idx this.selectionIdx) "autocomplete-option-selected"}}"
-                 data-result-id={{idx}}
-                 role="link"
-              {{on "click" (fn this.clickSelection opt)}}
-              {{!template-lint-disable no-pointer-down-event-binding}}
-              {{on "mousedown" (fn this.clickSelection opt)}}
-            >
-              {{yield opt}}
-            </div>
-          {{/if}}
-        {{else}}
-          {{#if (and (not this.noResultsFound) (not this.isSearching))}}
-            <div class="text-muted">Start typing to search</div>
-          {{/if}}
-        {{/each}}
-      </div>
-    </div>
-  {{/if}}
-
 </div>
+
+{{#if (and this.isFocused (or this.isSearching this.noResultsFound this.options))}}
+  <div class="autocomplete-results-box {{unless @renderBelow "autocomplete-results-box-dropdown"}}"
+    {{did-insert this.resultsBoxInsertedEvent}}
+    {{will-destroy this.resultsBoxDestroy}}
+  >
+    {{!template-lint-disable no-pointer-down-event-binding}}
+    {{!template-lint-disable no-invalid-interactive}}
+    <div class="autocomplete-list"
+      {{on "click" this.ignoreClick}}
+      {{on "mousedown" this.ignoreClick}}
+    >
+      {{#if this.noResultsFound}}
+        <div class="autocomplete-no-results">{{this.noResultsText}}</div>
+      {{else if this.isSearching}}
+        <div class="autocomplete-searching">
+          Searching
+          <SpinIcon/>
+        </div>
+      {{else}}
+        {{#if this.banner}}
+          <div class="small mb-1 mx-2">{{this.banner}}</div>
+        {{/if}}
+        {{#if this.sections}}
+          <div class="mx-2 mb-2">
+            {{#each this.sections as |s|}}
+              <button type="button"
+                      class="btn btn-sm mb-1 me-1 {{if (eq this.sectionActive s) "btn-success" "btn-light-gray"}}"
+                {{on "click" (fn this.selectSection s)}}>
+                {{s.sectionTitle}}
+              </button>
+            {{/each}}
+          </div>
+        {{/if}}
+      {{/if}}
+      {{#if (and this.options this.title)}}
+        <div class="autocomplete-title">
+          {{this.title}}
+        </div>
+      {{/if}}
+      {{#each this.options as |opt idx|}}
+        {{#if opt.isGroup}}
+          <div class="autocomplete-group-header">{{opt.title}}</div>
+          {{#each opt.items as |item|}}
+            <div class="autocomplete-item {{if (eq item.index this.selectionIdx) "autocomplete-option-selected"}}"
+                 data-result-id={{item.index}}
+                 role="link"
+              {{on "click" (fn this.clickSelection item)}}
+              {{!template-lint-disable no-pointer-down-event-binding}}
+              {{on "mousedown" (fn this.clickSelection item)}}
+            >
+              {{yield item opt}}
+            </div>
+          {{/each}}
+        {{else}}
+          <div class="autocomplete-item {{if (eq idx this.selectionIdx) "autocomplete-option-selected"}}"
+               data-result-id={{idx}}
+               role="link"
+            {{on "click" (fn this.clickSelection opt)}}
+            {{!template-lint-disable no-pointer-down-event-binding}}
+            {{on "mousedown" (fn this.clickSelection opt)}}
+          >
+            {{yield opt}}
+          </div>
+        {{/if}}
+      {{else}}
+        {{#if (and (not this.noResultsFound) (not this.isSearching))}}
+          <div class="text-muted">Start typing to search</div>
+        {{/if}}
+      {{/each}}
+    </div>
+  </div>
+{{/if}}

--- a/app/components/search-item-bar.hbs
+++ b/app/components/search-item-bar.hbs
@@ -1,92 +1,60 @@
 {{#if this.session.showSearchDialog}}
   <ModalDialog @position="top" @onEscape={{this.hideSearchBoxAction}} as |Modal|>
     <Modal.body>
-      <ChForm @formId="search-bar-form"
-              @formFor={{this.searchForm}}
-              @changeSet={{false}}
-              @onFormChange={{action this.searchFormChange}}
-              autocomplete="off"
-              as |f|>
-        <AutocompleteInput @placeholder={{this.searchPlaceholder}}
-                           @onSearch={{this.searchAction}}
-                           @onSelect={{this.searchSelectAction}}
-                           @onFocus={{this.searchFocusAction}}
-                           @text={{this.searchText}}
-                           @focusBorder={{true}}
-                           @modeOptions={{if this.session.isSmallScreen null this.modeOptions}}
-                           @onModeChange={{this.modeChange}}
-                           @mode={{this.searchForm.mode}}
-                           @appendSearchIcon={{true}}
-                           @autofocus={{true}}
-                           @onEscape={{this.hideSearchBoxAction}}
-                           autocomplete="off"
-                           as |item group|>
-          {{#if (eq this.searchType "asset")}}
-            {{this.searchYear}} Asset #{{item.barcode}} {{item.description}} {{item.type}}
-          {{else if (eq this.searchType "vehicle")}}
-            {{item.name}}: {{item.numbers}}
-            <span class="ms-4 d-block">&bullet; {{item.description}}</span>
-          {{else}}
-            <b>{{item.callsign}}</b>
-            <span class="d-inline-block">&lt;{{item.first_name}} {{item.last_name}}, {{item.status}}&gt;</span>
-            {{#if (eq group.field "fka")}}
-              <span class="ms-4 d-block">&bullet; FKA: {{item.fka_match}}</span>
-            {{else if (eq group.field "email")}}
-              <span class="ms-4 d-block">&bullet;Email match</span>
-            {{else if (eq group.field "email-old")}}
-              <span class="ms-4 d-block">&bullet; OLD email match</span>
+      {{#if (gt this.modeOptions.length 1)}}
+        <FormRow>
+          <label class="col-auto {{if this.session.isSmallScreen "col-form-label"}}">
+            Mode:
+          </label>
+          <div class=" col-sm-12 col-xl-auto">
+            {{#if this.session.isSmallScreen}}
+              <ChForm::Select @options={{this.modeOptions}}
+                              @onChange={{this.modeChange}}
+                              @value={{this.searchMode}}
+                              @fieldSize="sm"
+              />
+            {{else}}
+              <RadioGroup @options={{this.modeOptions}}
+                          @onChange={{this.modeChange}}
+                          @value={{this.searchMode}}
+              />
             {{/if}}
+          </div>
+        </FormRow>
+      {{/if}}
+      <AutocompleteInput @placeholder={{this.searchPlaceholder}}
+                         @onSearch={{this.searchAction}}
+                         @onSelect={{this.searchSelectAction}}
+                         @onFocus={{this.searchFocusAction}}
+                         @text={{this.searchText}}
+                         @focusBorder={{true}}
+                         @onModeChange={{this.modeChange}}
+                         @mode={{this.searchMode}}
+                         @appendSearchIcon={{true}}
+                         @autofocus={{true}}
+                         @onEscape={{this.hideSearchBoxAction}}
+                         @renderBelow={{true}}
+                         @noResultsText={{this.noResultsText}}
+                         autocomplete="off"
+                         as |item group|>
+        {{#if (eq this.searchType "asset")}}
+          {{this.searchYear}} Asset #{{item.barcode}} {{item.description}} {{item.type}}
+        {{else if (eq this.searchType "vehicle")}}
+          {{item.name}}: {{item.numbers}}
+          <span class="ms-4 d-block">&bullet; {{item.description}}</span>
+        {{else}}
+          <b>{{item.callsign}}</b>
+          <span class="d-inline-block">&lt;{{item.first_name}} {{item.last_name}}, {{item.status}}&gt;</span>
+          {{#if (eq group.field "fka")}}
+            <span class="ms-4 d-block">&bullet; FKA: {{item.fka_match}}</span>
+          {{else if (eq group.field "email")}}
+            <span class="ms-4 d-block">&bullet;Email match</span>
+          {{else if (eq group.field "email-old")}}
+            <span class="ms-4 d-block">&bullet; OLD email match</span>
           {{/if}}
-        </AutocompleteInput>
-        <div class="bg-white p-2 pt-2">
-          {{#if this.session.isSmallScreen}}
-            <FormRow>
-              <FormLabel @fixed={{true}} @class="pt-0">Mode:</FormLabel>
-              <div class="col-sm-12 col-xl-auto">
-                <ChForm::Select @name="mode"
-                                @value={{this.searchForm.mode}}
-                                @options={{this.modeOptions}}
-                                @onChange={{this.modeChange}} />
-              </div>
-            </FormRow>
-          {{/if}}
-          {{#if (not-eq this.searchForm.mode "hq")}}
-            <FormRow>
-              <FormLabel @fixed={{true}} @class="pt-0">Search By:</FormLabel>
-              <div class="col-sm-12 col-xl-7">
-                <f.checkbox @name="callsign"
-                            @label="Callsign"
-                            @inline={{true}}
-                />
-                <f.checkbox @name="name"
-                            @label="Name"
-                            @inline={{true}}
-                />
-                <f.checkbox @name="email"
-                            @label="Email"
-                            @inline={{true}}
-                />
-                <f.checkbox @name="fka"
-                            @label="Formerly Known As"
-                            @inline={{true}}
-                />
-              </div>
-            </FormRow>
-            <FormRow>
-              <FormLabel @fixed={{true}}  @class="pt-0">Include:</FormLabel>
-              <div class="col-sm-12 col-xl-7">
-                <f.checkbox @name="auditor"
-                            @label="Auditor"
-                            @inline={{true}}/>
-                <f.checkbox @name="past_prospective"
-                            @label="Past Prospective"
-                            @inline={{true}}/>
-              </div>
-            </FormRow>
-          {{/if}}
-        </div>
-      </ChForm>
-      <div class="border-top pt-2 d-flex justify-content-between small">
+        {{/if}}
+      </AutocompleteInput>
+      <div class="border-top mt-2 pt-2 d-flex justify-content-between small">
         {{#unless this.session.isSmallScreen}}
           <div class="mt-1 ms-2">
             <span class="bg-gray p-1">&uparrow;</span>

--- a/app/styles/autocomplete.scss
+++ b/app/styles/autocomplete.scss
@@ -20,7 +20,6 @@
 
 
 .autocomplete-list {
- // max-height: 14em;
   margin: 0;
   padding: 0;
 }
@@ -30,6 +29,7 @@
   font-size: 0.95em;
   color: #666;
 }
+
 .autocomplete-group-header {
   background-color: #ececec;
   color: #0a3954;
@@ -46,19 +46,21 @@
   background-color: #ffff99;
 }
 
-.autocomplete-results-box-overlay {
+.autocomplete-results-box-dropdown {
   position: absolute;
   z-index: 9500;
-  box-shadow: 0 1px 5px 0 rgb(50 50 50 / 50%); //rgba(0, 0, 0, 0.24) 0px 3px 8px;
+  box-shadow: 0 1px 5px 0 rgb(50 50 50 / 50%);
+  max-height: 20em;
+  overflow-y: auto;
+  background-color: #fafafa;
+  margin-top: 0.25rem;
+  border: 2px solid #ececec;
+  border-radius: 5px;
 }
 
 .autocomplete-results-box {
-  max-height: 20em;
-  overflow-y: auto;
   width: 100%;
-  background-color: #fafafa;
   padding: 5px 0;
-  border: 2px solid #ececec;
 }
 
 .autocomplete-no-results {
@@ -70,6 +72,7 @@
   padding: 5px 10px;
   color: #234d3c;
 }
+
 .autocomplete-option-selected {
   background-color: #d8fbd8;
 }


### PR DESCRIPTION
- Eliminated search options in favor of searching across all status categories (active/current, dismissed/bonked, resigned/retired, etc) with the results grouped into said status categories.
- Render the search results below the input field and inline with the dialog box. The overlay has been removed.
- Added better explanation on what was not found (person, vehicle, assets, etc.)
- Let the user know if they do not have the permissions to search by email when trying to search by email. Don't search by email when no havey permissions, yo!