### PR TITLE
Various HQ & UI Tweaks.

### DIFF
--- a/app/components/autocomplete-input.hbs
+++ b/app/components/autocomplete-input.hbs
@@ -54,7 +54,7 @@
           </div>
         {{else}}
           {{#if this.banner}}
-            <div class="small mb-1 mx-2">{{this.banner}}</div>
+            <div class="mb-1 mx-2">{{this.banner}}</div>
           {{/if}}
           {{#if this.sections}}
             <div class="mx-2 mb-2">

--- a/app/components/hq-pogs.hbs
+++ b/app/components/hq-pogs.hbs
@@ -1,8 +1,55 @@
 {{#if this.isLoading}}
   <LoadingIndicator @text="Loading pogs"/>
 {{else}}
-  <div class="mb-1">
-    <UiButton @onClick={{this.newPog}}>Issue Pog</UiButton>
+  {{#if @endedShiftEntry}}
+    <p>
+    <div class="fs-5">
+      Worked shifted ({{@endedShiftEntry.position.title}}) was {{hour-minute-words @endedShiftEntry.duration}}
+      in length.
+    </div>
+    {{#if @endedShiftEntry.isUnverified}}
+      <b class="text-danger">
+        The timesheet entry is unverified. Review the timesheet entry to ensure the worked shift duration is
+        accurate.
+      </b>
+    {{else if @endedShiftEntry.isPending}}
+      <b class="text-danger">
+        The timesheet entry has a pending correction. The worked shift duration might be incorrect.
+      </b>
+    {{/if}}
+    </p>
+  {{/if}}
+  {{#if this.hasMealPass}}
+    <UiNotice @icon="hand-point-right" @type="secondary" @title="Has Meal Pass">
+      {{@person.callsign}} has a BMID Meal Pass for the {{this.currentPeriodLabel}} period.
+    </UiNotice>
+   {{else}}
+    <p>
+      <b>For the current event period, issue a Full Meal Pog for every 6+ hours worked in a shift.</b>
+      {{#if this.config.meal_half_pog_enabled}}
+        <br>
+        1/2 Meal Pogs are available for a shift worked less than 6 hours.
+      {{/if}}
+    </p>
+  {{/if}}
+  <div class="row mb-2">
+    <div class="col-auto">
+      <UiButton @onClick={{this.recordFullMealPog}}>
+        Record Full Meal Pog
+      </UiButton>
+    </div>
+    {{#if this.config.meal_half_pog_enabled}}
+      <div class="col-auto">
+        <UiButton @onClick={{this.recordHalfMealPog}}>
+          Record &half; Meal Pog
+        </UiButton>
+      </div>
+    {{/if}}
+    <div class="col-auto">
+      <UiButton @onClick={{this.recordShowerPog}}>
+        Record Shower Pog
+      </UiButton>
+    </div>
   </div>
   Showing {{pluralize this.pogs.length "pog"}}.
   <table class="table table-width-auto table-hover table-stripped">
@@ -46,68 +93,13 @@
       </tr>
     {{else}}
       <tr>
-        <td colspan="3" class="text-danger">
+        <td colspan="3">
           No pogs have been issued yet.
         </td>
       </tr>
     {{/each}}
     </tbody>
   </table>
-{{/if}}
-
-{{#if this.pog}}
-  <ModalDialog @onEscape={{this.cancelNewPog}} as |Modal|>
-    <ChForm @formId="pog" @formFor={{this.pog}} @onSubmit={{this.savePog}} as |f|>
-      <Modal.title>Issue New Pog</Modal.title>
-      <Modal.body>
-        {{#if @endedShiftEntry}}
-          <p>
-          <div class="fs-5">
-            Worked shifted ({{@endedShiftEntry.position.title}}) was {{hour-minute-words @endedShiftEntry.duration}}
-            in length.
-          </div>
-          {{#if @endedShiftEntry.isUnverified}}
-            <b class="text-danger">
-              The timesheet entry is unverified. Review the timesheet entry to ensure the worked shift duration is
-              accurate.
-            </b>
-          {{else if @endedShiftEntry.isPending}}
-            <b class="text-danger">
-              The timesheet entry has a pending correction. The worked shift duration might be incorrect.
-            </b>
-          {{/if}}
-          </p>
-        {{/if}}
-        {{#if this.hasMealPass}}
-          <div class="fs-5 text-danger">
-            {{@person.callsign}} has a Meal Pass for the {{this.currentPeriodLabel}} period. Do not issue a meal pog.
-          </div>
-        {{else}}
-          {{#if this.config.meal_half_pog_enabled}}
-            <p>
-              &half; Meal Pogs are available for a shift worked less than 6 hours.
-            </p>
-          {{/if}}
-          <b>For the current event period, issue a meal pog for every 6+ hours worked in a shift.</b>
-        {{/if}}
-        <FormRow class="mt-2">
-          <f.radioGroup @name="pog"
-                        @options={{this.pogOptions}}
-                        @label="Pog to issue"
-                        @inline={{true}} />
-        </FormRow>
-        {{#if (eq f.model.pog "half-meal")}}
-          <b class="text-danger">Half-meal pogs are tracked digitally. No physical pog is handed out.</b>
-        {{else}}
-          <b>Don't forget to hand over the physical pog.</b>
-        {{/if}}
-      </Modal.body>
-      <Modal.footer @noAlign={{true}}>
-        <f.submit @label="Issue Pog"/>
-        <UiCancelButton @onClick={{this.cancelNewPog}} />
-      </Modal.footer>
-    </ChForm>
-  </ModalDialog>
 {{/if}}
 
 {{#if this.pogToCancel}}

--- a/app/components/hq-provision-info.hbs
+++ b/app/components/hq-provision-info.hbs
@@ -6,7 +6,7 @@
 
 <div class="d-flex flex-wrap">
   <div class="me-4">
-    <h4><span class="me-2">{{fa-icon "utensils"}}</span> Meals</h4>
+    <h4>{{fa-icon "utensils" right=1 fixed=true}} Meals</h4>
      <table class="table table-width-auto">
       <thead>
       <tr>
@@ -23,10 +23,10 @@
     </table>
   </div>
   <div>
-    <h4>{{fa-icon "shower" right=2}} Showers</h4>
+    <h4>{{fa-icon "shower" right=1 fixed=true}} Showers</h4>
     <p>
       {{#if @showers}}
-        <b class="text-danger">{{fa-icon "ban" right=1}} NO SHOWER POGS</b><br>
+        <b class="text-danger">{{fa-icon "ban" right=1 fixed=true}} NO SHOWER POGS</b><br>
         Has Wet Spot Access BMID
       {{else}}
         <span class="text-success">Pog for every 40 hours worked</span>

--- a/app/components/navbar.hbs
+++ b/app/components/navbar.hbs
@@ -9,7 +9,7 @@
     {{/if}}
   </LinkTo>
 
-  {{#if (and this.session.hasLMOP this.session.isSmallScreen)}}
+  {{#if (and this.session.hasLoginManagement this.session.isSmallScreen)}}
     <button type="button" class="border rounded p-1 bg-white text-muted mx-auto" {{on "click" this.launchSearchDialog}}>
       <span class="mx-1">
         {{fa-icon "search"}}
@@ -75,7 +75,7 @@
       {{/if}}
     </navbar.nav>
   </navbar.content>
-  {{#if (and this.session.hasLMOP (not this.session.isSmallScreen))}}
+  {{#if (and this.session.hasLoginManagement (not this.session.isSmallScreen))}}
     <navbar.content>
       {{! template-lint-disable no-inline-styles}}
       <div role="button"

--- a/app/components/person/simple-form.hbs
+++ b/app/components/person/simple-form.hbs
@@ -69,22 +69,24 @@
       {{mail-to (config "PersonnelEmail")}}
     </dd>
   {{/if}}
-  <dt class="col-sm-12 col-lg-2">On Site</dt>
-  <dd class="col-sm-12 col-lg-9">
-    <ChForm @formId="person" @formFor={{@person}} @onSubmit={{@savePersonAction}} as |f|>
-      <FormRow>
-        <div class="col-auto">
-          <f.radioGroup @name="on_site"
-                        @options={{@onSiteOptions}}
-                        @inline={{true}} />
-        </div>
-      </FormRow>
-      <f.submit @label="Update" @size="sm" @disabled={{@person.isSaving}} />
-      {{#if @person.isSaving}}
-        <LoadingIndicator/>
-      {{/if}}
-    </ChForm>
-  </dd>
+  {{#if (has-role "manage")}}
+    <dt class="col-sm-12 col-lg-2">On Site</dt>
+    <dd class="col-sm-12 col-lg-9">
+      <ChForm @formId="person" @formFor={{@person}} @onSubmit={{@savePersonAction}} as |f|>
+        <FormRow>
+          <div class="col-auto">
+            <f.radioGroup @name="on_site"
+                          @options={{@onSiteOptions}}
+                          @inline={{true}} />
+          </div>
+        </FormRow>
+        <f.submit @label="Update" @size="sm" @disabled={{@person.isSaving}} />
+        {{#if @person.isSaving}}
+          <LoadingIndicator/>
+        {{/if}}
+      </ChForm>
+    </dd>
+  {{/if}}
   <dt class="col-sm-12 col-lg-2">Team/Positions</dt>
   <dd class="col-sm-12 col-lg-9">
     <Person::Positions @personMembership={{@personMembership}}
@@ -94,11 +96,13 @@
                        @editMembershipAction={{@editMembershipAction}}
     />
   </dd>
-  <dt class="col-sm-12 col-lg-2">Permissions</dt>
-  <dd class="col-sm-12 col-lg-9">
-    <Person::Permissions @roles={{@roles}}
-                   @grantedRoles={{@grantedRoles}}
-                   @toggleRoles={{@toggleRoles}}
-                   @showRoles={{@showRoles}} />
-  </dd>
+  {{#if (has-role "manage")}}
+    <dt class="col-sm-12 col-lg-2">Permissions</dt>
+    <dd class="col-sm-12 col-lg-9">
+      <Person::Permissions @roles={{@roles}}
+                           @grantedRoles={{@grantedRoles}}
+                           @toggleRoles={{@toggleRoles}}
+                           @showRoles={{@showRoles}} />
+    </dd>
+  {{/if}}
 </dl>

--- a/app/components/radio-group.hbs
+++ b/app/components/radio-group.hbs
@@ -1,6 +1,12 @@
 {{#each this.options as |opt idx|}}
-  <label class="{{if idx "ms-3"}}">
-    <input type="radio" checked={{opt.isSelected}} {{on "click" (fn this.changeEvent opt)}} />
-    {{opt.label}}
-  </label>
+  <div class="form-check form-check-inline">
+    <input type="radio"
+           id="radio-opt-{{idx}}"
+           class="form-check-input"
+           checked={{opt.isSelected}} {{on "click" (fn this.changeEvent opt)}}
+    />
+    <label class="form-check-label" for="radio-opt-{{idx}}">
+      {{opt.label}}
+    </label>
+  </div>
 {{/each}}

--- a/app/components/search-item-bar.hbs
+++ b/app/components/search-item-bar.hbs
@@ -2,11 +2,13 @@
   <ModalDialog @position="top" @onEscape={{this.hideSearchBoxAction}} as |Modal|>
     <Modal.body>
       {{#if (gt this.modeOptions.length 1)}}
-        <FormRow>
-          <label class="col-auto {{if this.session.isSmallScreen "col-form-label"}}">
-            Mode:
-          </label>
-          <div class=" col-sm-12 col-xl-auto">
+        <FormRow class="align-items-center">
+          <div class="col-auto">
+            <label class="col-form-label">
+              Mode:
+            </label>
+          </div>
+          <div class="col-auto">
             {{#if this.session.isSmallScreen}}
               <ChForm::Select @options={{this.modeOptions}}
                               @onChange={{this.modeChange}}

--- a/app/components/shift-check-in-out.hbs
+++ b/app/components/shift-check-in-out.hbs
@@ -5,12 +5,10 @@
     {{fa-icon "person-walking" right=2}} {{@person.callsign}} is on duty.
   </h4>
   {{#if this.mayNotNeedRadio}}
-    <p>
-      <b class="text-danger">
-        {{fa-icon "arrow-right" right=1}} {{@person.callsign}} is working a Burn Perimeter shift and may not need a
-        radio. Check with the HQ Short or Lead if in doubt.
-      </b>
-    </p>
+    <UiNotice @icon="hand-point-right" @type="secondary" @title="May not need radio">
+      {{@person.callsign}} is working a Burn Perimeter shift and may not need a radio. Check with
+      the HQ Short or Lead if in doubt.
+    </UiNotice>
   {{/if}}
   <table class="table table-width-auto">
     <thead>

--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -23,7 +23,7 @@ export default class ApplicationController extends ClubhouseController {
     const isMac = navigator.userAgent.indexOf("Mac") !== -1;
 
     document.querySelector('body').addEventListener('keydown', (event) => {
-      if (!this.session.user || !this.session.hasLMOP) {
+      if (!this.session.user || !this.session.hasLoginManagement) {
         // Not logged in or does not have LMOP
         return true;
       }

--- a/app/routes/person/schedule.js
+++ b/app/routes/person/schedule.js
@@ -2,8 +2,11 @@ import ClubhouseRoute from 'clubhouse/routes/clubhouse-route';
 import requestYear from 'clubhouse/utils/request-year';
 import RSVP from 'rsvp';
 import ScheduleSlotModel from 'clubhouse/models/schedule-slot';
+import {MANAGE} from "clubhouse/constants/roles";
 
 export default class PersonScheduleRoute extends ClubhouseRoute {
+  roleRequired = MANAGE;
+
   queryParams = {
     year: {refreshModel: true}
   };

--- a/app/services/session.js
+++ b/app/services/session.js
@@ -78,7 +78,7 @@ export default class extends SessionService {
   }
 
 
-  get hasLMOP() {
+  get hasLoginManagement() {
     return this.hasRole(MANAGE);
   }
 

--- a/app/templates/hq/shift.hbs
+++ b/app/templates/hq/shift.hbs
@@ -133,14 +133,13 @@
             {{this.person.callsign}} is authorized for {{pluralize this.eventInfo.radio_max "event radio"}}.
           </p>
         {{else}}
-          {{this.person.callsign}} is only authorized for SHIFT RADIOS.
           {{#if this.mayNotNeedRadio}}
-            <br>
-            <b class="text-danger">
-              {{this.person.callsign}} is working a Burn Perimeter shift and may not need a
-              radio. Check with the HQ Short or Lead if in doubt.
-            </b>
+            <UiNotice @icon="hand-point-right" @type="secondary" @title="May not need radio">
+              {{this.person.callsign}} is working a Burn Perimeter shift and may not need a radio. Check with
+              the HQ Short or Lead if in doubt.
+            </UiNotice>
           {{/if}}
+          {{this.person.callsign}} is only authorized for SHIFT RADIOS.
         {{/if}}
       </div>
 
@@ -166,17 +165,18 @@
     </tab.pane>
 
     <tab.pane @id="pogs">
+      <HqPogs @person={{this.person}}
+              @endedShiftEntry={{this.endedShiftEntry}}
+              @period={{this.eventInfo.event_period}}
+              @eventPeriods={{this.eventPeriods}}
+              @showers={{this.eventInfo.showers}}
+      />
       <HqProvisionInfo @person={{this.person}}
                        @period={{this.eventInfo.event_period}}
                        @eventPeriods={{this.eventPeriods}}
                        @meals={{this.eventInfo.meals}}
                        @showers={{this.eventInfo.showers}}
                        @onDutyEntry={{this.onDutyEntry}} />
-      <HqPogs @person={{this.person}}
-              @endedShiftEntry={{this.endedShiftEntry}}
-              @period={{this.eventInfo.event_period}}
-              @eventPeriods={{this.eventPeriods}}
-      />
     </tab.pane>
 
     <tab.pane @id="offsite">

--- a/app/templates/hq/site-checkin.hbs
+++ b/app/templates/hq/site-checkin.hbs
@@ -14,11 +14,11 @@
   <:body>
     {{#if this.personEvent.asset_authorized}}
       <h4 class="text-success">
-        {{fa-icon "check" fixed=true}} Radio Checkout Agreement has been signed.
+        {{fa-icon "check" right=1 fixed=true}} Radio Checkout Agreement has been signed.
       </h4>
     {{else}}
       <h4 class="text-danger">
-        {{fa-icon "ban" fixed=true}}  Radio Checkout Agreement NOT SIGNED - DO NOT ISSUE RADIOS.
+        {{fa-icon "ban" right=1 fixed=true}} Radio Checkout Agreement NOT SIGNED - DO NOT ISSUE RADIOS.
       </h4>
       <p>
         Direct {{this.person.callsign}} to a kiosk and have them agree to the Radio Checkout Agreement. Only after the
@@ -27,11 +27,11 @@
     {{/if}}
     {{#if this.personEvent.signed_motorpool_agreement}}
       <h4 class="text-success">
-        {{fa-icon "check" fixed=true}} The Motorpool Policy has been signed.
+        {{fa-icon "check" right=1 fixed=true}} The Motorpool Policy has been signed.
       </h4>
     {{else}}
       <h4 class="text-danger">
-        {{fa-icon "ban" fixed=true}} Motorpool Agreement NOT SIGNED - Not authorized to drive Ranger gators, UTVs, or
+        {{fa-icon "ban" right=1 fixed=true}} Motorpool Agreement NOT SIGNED - Not authorized to drive Ranger gators, UTVs, or
         golf carts.
       </h4>
       <p>
@@ -47,17 +47,17 @@
     {{#if this.eventInfo.radio_max}}
       {{#if this.personEvent.asset_authorized}}
         <h4 class="text-success">
-          {{fa-icon "tower-broadcast" fixed=true}} Authorized for {{pluralize this.eventInfo.radio_max "Event Radio"}}
+          {{fa-icon "tower-broadcast" right=1 fixed=true}} Authorized for {{pluralize this.eventInfo.radio_max "Event Radio"}}
         </h4>
       {{else}}
         <h4 class="text-muted">
-          {{fa-icon "ban" fixed=true}} Authorized for {{pluralize this.eventInfo.radio_max "Event Radio"}} &mdash; DO
+          {{fa-icon "ban" right=1 fixed=true}} Authorized for {{pluralize this.eventInfo.radio_max "Event Radio"}} &mdash; DO
           NOT ISSUE UNTIL Radio Checkout Agreement IS SIGNED.
         </h4>
       {{/if}}
     {{else}}
-      <h4 class="text-secondary">
-        {{fa-icon "tower-broadcast" fixed=true}} Shift Radios only
+      <h4>
+        {{fa-icon "tower-broadcast" right=2}} Shift Radios only
       </h4>
     {{/if}}
     <hr>

--- a/app/templates/person.hbs
+++ b/app/templates/person.hbs
@@ -1,24 +1,26 @@
 <UiSidebar @theme="person" @smallTitle="Person Manage" as |s|>
   <s.group @title="PERSON MANAGE">
     <s.link @route="person.index" @title="Account Info" @icon="info" @iconType="s"/>
-    <s.link @route="person.schedule" @title="Schedule / Sign Up" @icon="clipboard"/>
-    <s.link @route="person.event-info" @title="Event/Training Info" @icon="user" @iconType="s"/>
-    <s.link @route="person.timesheet" @title="Timesheets" @icon="clock"/>
-    <s.link @route="person.work-history" @title="Work History" @icon="history" @iconType="s"/>
-    <s.link @route="person.assets" @title="Assets" @icon="broadcast-tower" @iconType="s"/>
-    <s.link @route="person.messages" @title="Messages" @icon="envelope"
-            @badgeText={{this.person.unread_message_count}} />
-    {{#if (has-role "admin" "view-pii")}}
-      <s.link @route="person.personal-info" @title="Personal Info" @icon="home" @iconType="s"/>
+    {{#if this.session.hasLoginManagement}}
+      <s.link @route="person.schedule" @title="Schedule / Sign Up" @icon="clipboard"/>
+      <s.link @route="person.event-info" @title="Event/Training Info" @icon="user" @iconType="s"/>
+      <s.link @route="person.timesheet" @title="Timesheets" @icon="clock"/>
+      <s.link @route="person.work-history" @title="Work History" @icon="history" @iconType="s"/>
+      <s.link @route="person.assets" @title="Assets" @icon="broadcast-tower" @iconType="s"/>
+      <s.link @route="person.messages" @title="Messages" @icon="envelope"
+              @badgeText={{this.person.unread_message_count}} />
+      {{#if (has-role "admin" "view-pii")}}
+        <s.link @route="person.personal-info" @title="Personal Info" @icon="home" @iconType="s"/>
+      {{/if}}
+      {{#if (has-role "admin")}}
+        <s.link @route="person.emergency-contact" @title="Emergency Contact" @icon="comment-medical" @iconType="s"/>
+      {{/if}}
+      {{#if (has-role "admin" "vc" "mentor")}}
+        <s.link @route="person.mentors" @title="Mentors" @icon="users" @iconType="s"/>
+      {{/if}}
+      <s.link @route="person.awards-swag" @title="Awards & Swag" @icon="award" @iconType="s"/>
+      <s.link @route="person.pogs" @title="Pogs" @icon="utensils" @iconType="s"/>
     {{/if}}
-    {{#if (has-role "admin" "manage")}}
-      <s.link @route="person.emergency-contact" @title="Emergency Contact" @icon="comment-medical" @iconType="s"/>
-    {{/if}}
-    {{#if (has-role "admin" "vc" "mentor")}}
-      <s.link @route="person.mentors" @title="Mentors" @icon="users" @iconType="s"/>
-    {{/if}}
-    <s.link @route="person.awards-swag" @title="Awards & Swag" @icon="award" @iconType="s"/>
-    <s.link @route="person.pogs" @title="Pogs" @icon="utensils" @iconType="s"/>
   </s.group>
   {{#if  (has-role "edit-bmids" "edit-access-docs")}}
     <s.group @title="PRE-PLAYA">


### PR DESCRIPTION
- Use buttons instead of a modal dialog to record pogs.
- Show the just ended shift duration on the pog tab
- Minor autocomplete tweak to reduce content shifting when a search is running
- Don't present the on site options if the trainer does not actually have the management role
- Increased may-not-need-a-radio visibility on the radio checkout page if the person is working a Burner Perimeter. -