### PR TITLE
Use the Intersectionality Observer API (if available) to focus an element after DOM insert.

### DIFF
--- a/app/components/asset-checkout-form.hbs
+++ b/app/components/asset-checkout-form.hbs
@@ -4,8 +4,10 @@
         @onSubmit={{this.checkoutAsset}} as |f|>
   <FormRow>
     <f.text @name="barcode"
-             @placeholder="Enter Barcode"
-             @size={{15}} />
+            @placeholder="Enter Barcode"
+            @size={{15}}
+            @autofocus={{true}}
+    />
     <f.select @name="attachment_id"
               @options={{this.attachmentOptions}}/>
     <div class="col-auto">

--- a/app/components/autocomplete-input.js
+++ b/app/components/autocomplete-input.js
@@ -3,6 +3,7 @@ import {action} from '@ember/object';
 import {tracked} from '@glimmer/tracking';
 import {debounce, schedule} from '@ember/runloop';
 import {service} from '@ember/service';
+import focusElement from "clubhouse/utils/focus-element";
 
 const CLICK_DEBOUNCE_MS = 350;
 
@@ -162,9 +163,7 @@ export default class AutocompleteInputComponent extends Component {
     event.stopPropagation();
     this._setupSection(section);
     this.isRefocusing = true;
-    setTimeout(() =>
-        schedule('afterRender', () => this.inputElement.focus()),
-      250);
+    focusElement(this.inputElement);
   }
 
   _setupSection(section) {
@@ -387,9 +386,7 @@ export default class AutocompleteInputComponent extends Component {
   ignoreClick(event) {
     event.stopPropagation();
     this.isRefocusing = true;
-    setTimeout(() =>
-        schedule('afterRender', () => this.inputElement.focus()),
-      250);
+    focusElement(this.inputElement);
     return false;
   }
 
@@ -434,7 +431,7 @@ export default class AutocompleteInputComponent extends Component {
     }
 
     if (this.args.autofocus) {
-      setTimeout(() => schedule('afterRender', () => element.focus()), 100);
+      focusElement(element);
     }
   }
 

--- a/app/components/ch-form.hbs
+++ b/app/components/ch-form.hbs
@@ -2,7 +2,6 @@
       class={{@formClass}}
       autocomplete={{this.autocomplete}}
   {{on "submit" this.submitEvent}}
-  {{did-insert this.insertedFormElement}}
 >
   {{yield (hash
             model=this.model

--- a/app/components/ch-form.js
+++ b/app/components/ch-form.js
@@ -73,21 +73,6 @@ export default class ChFormComponent extends Component {
   }
 
   /**
-   * When the form is inserted into the DOM, find the first element that wants
-   * to be autofocused, and focus it.
-   *
-   * @param element form tag inserted
-   */
-
-  @action
-  insertedFormElement(element) {
-    const field = element.querySelector(`[autofocus]`);
-    if (field) {
-      schedule('afterRender', () => field.focus());
-    }
-  }
-
-  /**
    * Teardown the form - clear the on save callback for the model if it exists.
    */
 

--- a/app/components/ch-form/input-field.js
+++ b/app/components/ch-form/input-field.js
@@ -1,6 +1,6 @@
 import ChFormFieldBaseComponent from './field-base';
-import { action }from '@ember/object';
-import { schedule }from '@ember/runloop';
+import {action} from '@ember/object';
+import focusElement from "clubhouse/utils/focus-element";
 
 /*
    Base class for text, number, and password fields.
@@ -11,8 +11,9 @@ export default class ChFormInputFieldComponent extends ChFormFieldBaseComponent 
 
   @action
   inputInserted(element) {
+    // Delay focusing in case animation fade in/out effects are happening.
     if (this.args.autofocus) {
-      setTimeout(() => schedule('afterRender', () => element.focus()), 100);
+      focusElement(element);
     }
   }
 }

--- a/app/components/ch-form/textarea-field.js
+++ b/app/components/ch-form/textarea-field.js
@@ -1,14 +1,13 @@
 import ChFormFieldBaseComponent from './field-base';
 import {action} from '@ember/object';
-import {schedule} from '@ember/runloop';
-
+import focusElement from "clubhouse/utils/focus-element";
 export default class ChFormTextareaFieldComponent extends ChFormFieldBaseComponent {
   controlClassDefault = 'form-control';
 
   @action
   fieldInserted(element) {
     if (this.args.autofocus) {
-      schedule('afterRender', () => element.focus());
+      focusElement(element);
     }
   }
 }

--- a/app/components/datetime-picker.js
+++ b/app/components/datetime-picker.js
@@ -1,6 +1,5 @@
 import Component from '@glimmer/component';
 import {action} from '@ember/object';
-import { schedule } from '@ember/runloop';
 import focusElement from "clubhouse/utils/focus-element";
 
 export default class DatetimePickerComponent extends Component {

--- a/app/components/datetime-picker.js
+++ b/app/components/datetime-picker.js
@@ -1,6 +1,7 @@
 import Component from '@glimmer/component';
 import {action} from '@ember/object';
 import { schedule } from '@ember/runloop';
+import focusElement from "clubhouse/utils/focus-element";
 
 export default class DatetimePickerComponent extends Component {
   constructor() {
@@ -17,7 +18,7 @@ export default class DatetimePickerComponent extends Component {
   @action
   elementInserted(element) {
      if (this.args.autofocus){
-      schedule('afterRender', () => element.focus());
+       focusElement(element);
     }
   }
 }

--- a/app/utils/focus-element.js
+++ b/app/utils/focus-element.js
@@ -1,0 +1,19 @@
+import {schedule} from '@ember/runloop';
+
+export default function focusElement(element) {
+  if (typeof IntersectionObserver !== "undefined") {
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach(entry => {
+        if (entry.intersectionRatio > 0) {
+          element.focus();
+          observer.unobserve(element);
+        }
+      });
+    }, {root: document.documentElement});
+
+    observer.observe(element)
+  } else {
+    // Delay focusing in case animation fade in/out effects are happening.
+    setTimeout(() => schedule('afterRender', () => element.focus()), 300);
+  }
+}


### PR DESCRIPTION
Fallback to the setTimeout() / afterRender sequence if the API is not available.