### PR TITLE
Various tweaks.

### DIFF
--- a/app/components/person/timesheet-manage.hbs
+++ b/app/components/person/timesheet-manage.hbs
@@ -35,10 +35,10 @@
       </thead>
       <tbody>
       {{#each @timesheets key="id" as |ts|}}
-        <tr>
+        <tr class="align-middle">
           <td>
             {{#if (is-empty ts.off_duty)}}
-              {{fa-icon "person-walking" color="danger"}}
+              {{fa-icon "person-walking"}}
             {{else if ts.isVerified}}
               {{fa-icon "check" color="success"}}
             {{else if ts.isUnverified}}
@@ -89,18 +89,18 @@
           </td>
           <td>
             {{#if (is-empty ts.off_duty)}}
-              <i class="text-danger">Still On Duty</i>
+              {{badge "warning" "Still On Duty"}}
             {{else if ts.isVerified}}
-              <span class="text-success">Verified</span>
+              {{badge "success" "Verfied"}}
             {{else if ts.isUnverified}}
-              Unverified
+              {{badge "secondary" "Unverified"}}
             {{else if ts.isPending}}
-              <b class="text-danger">Correction Requested</b>
+              {{badge "danger" "Correction Requested"}}
             {{else if ts.isRejected}}
-              Correction Rejected
+              {{badge "warning" "Correction Rejected"}}
             {{else if ts.isApproved}}
-              Correction Approved<br>
-              Verification needed.
+              {{badge "success" "Correction Approved"}}<br>
+              {{badge "secondary" "Verification still needed"}}
             {{else}}
               &nbsp;
             {{/if}}
@@ -199,13 +199,13 @@
           <br>
           <div class="text-muted mb-1">
             {{#if this.editEntry.slot}}
-              <span class="me-2">Scheduled Shift</span> {{hour-minute-words this.editEntry.slot.duration}}
+              <span class="me-2">Scheduled Signup</span> {{hour-minute-words this.editEntry.slot.duration}}
               {{shift-format this.editEntry.slot.begins this.editEntry.slot.ends}}
               Slot #{{this.editEntry.slot.id}}<br>
-              The scheduled shift is shown for reference. The actual time worked might be longer or shorter than
-              the scheduled shift.
+              The scheduled sign-up is shown for reference. The actual time worked might be longer or shorter than
+              the scheduled sign-up.
             {{else}}
-              No scheduled shift found.
+              Entry does not appear to be associated with a scheduled signed-up.
             {{/if}}
           </div>
 

--- a/app/components/person/timesheet-manage.js
+++ b/app/components/person/timesheet-manage.js
@@ -25,7 +25,7 @@ export default class PersonTimesheetManageComponent extends Component {
   reviewOptions = [
     ['Correction approved', 'approved'],
     ['Correction rejected', 'rejected'],
-    ['Review requested', 'pending'],
+    ['Correction requested', 'pending'],
     ['Entry verified', 'verified'],
     ['Entry unverified', 'unverified']
   ];

--- a/app/components/search-item-bar.js
+++ b/app/components/search-item-bar.js
@@ -43,6 +43,16 @@ const LiveStatuses = [
   SUSPENDED,
 ].join(',');
 
+const HqStatuses = [
+  ACTIVE,
+  ALPHA,
+  INACTIVE,
+  INACTIVE_EXTENSION,
+  NON_RANGER,
+  PROSPECTIVE,
+  'cheetahcub'   // pseudo-status, find anyone who is signed up for a Cheetah Cub shift.
+].join(',');
+
 // What page to route to based on the search mode selected
 const MODE_ROUTES = {
   'account': 'person.index',
@@ -427,10 +437,10 @@ export default class SearchItemBarComponent extends Component {
       // restrict search to callsign and a handful of active-like statuses
       params = {
         search_fields: 'callsign',
-        statuses: LiveStatuses
+        statuses: HqStatuses
       };
     } else if (query.startsWith('+')) {
-      params = { search_fields: 'id' };
+      params = {search_fields: 'id'};
     } else {
       const match = query.match(/^(callsign|name|fka|last)\s*:\s*(.*)$/i);
       if (match) {

--- a/app/components/search-item-bar.js
+++ b/app/components/search-item-bar.js
@@ -6,7 +6,7 @@ import {
   ACTIVE,
   ALPHA,
   INACTIVE, INACTIVE_EXTENSION,
-  NON_RANGER, PROSPECTIVE, SUSPENDED,
+  NON_RANGER, PROSPECTIVE,
 } from 'clubhouse/constants/person_status';
 import {debounce} from '@ember/runloop';
 import {service} from '@ember/service';
@@ -32,16 +32,6 @@ const SearchGroupTitles = {
   'name': 'real name',
   'old-email': 'old email',
 };
-
-const LiveStatuses = [
-  ACTIVE,
-  ALPHA,
-  INACTIVE,
-  INACTIVE_EXTENSION,
-  NON_RANGER,
-  PROSPECTIVE,
-  SUSPENDED,
-].join(',');
 
 const HqStatuses = [
   ACTIVE,

--- a/app/helpers/badge.js
+++ b/app/helpers/badge.js
@@ -2,7 +2,7 @@ import { helper } from '@ember/component/helper';
 import { htmlSafe } from '@ember/template';
 
 export function badge([ badgeType, text ]) {
-  return htmlSafe(`<span class="badge bg-${badgeType}">${text}</span>`)
+  return htmlSafe(`<span class="badge text-bg-${badgeType}">${text}</span>`)
 }
 
 export default helper(badge);

--- a/tests/integration/helpers/badge-test.js
+++ b/tests/integration/helpers/badge-test.js
@@ -11,7 +11,7 @@ module('helper:badge', function(hooks) {
   test('it renders type', async function(assert) {
     await render(hbs`{{badge "danger" "badge text" }}`);
 
-    assert.dom('span.badge.bg-danger').exists();
+    assert.dom('span.badge.text-bg-danger').exists();
     assert.dom('span.badge').hasText('badge text');
   });
 });


### PR DESCRIPTION
- Use badge indicators on timesheet management
- Use text-bg-* css selectors for badges
- Have search bar locate retired/resigned Rangers who are signed up for Cheetah Cub shifts. The statuses were previously excluded for HQ Window mode.