### PR TITLE
Implemented browser window to browser window signalling. sendBeacon detection.

### DIFF
--- a/app/controllers/admin/settings.js
+++ b/app/controllers/admin/settings.js
@@ -2,7 +2,6 @@ import ClubhouseController from 'clubhouse/controllers/clubhouse-controller';
 import { isEmpty } from '@ember/utils';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import ENV from 'clubhouse/config/environment';
 import {TECH_NINJA} from 'clubhouse/constants/roles';
 
 export default class AdminSettingsController extends ClubhouseController {
@@ -55,7 +54,7 @@ export default class AdminSettingsController extends ClubhouseController {
   }
 
   @action
-  save(model, isValid) {
+  async save(model, isValid) {
     if (!isValid)
       return;
 
@@ -64,11 +63,14 @@ export default class AdminSettingsController extends ClubhouseController {
       return;
     }
 
-    model.save().then(() => {
+    try {
+      await model.save();
       this.editSetting = null;
       this.toast.success(`The setting value has been successfully update.`);
-      return this.ajax.request('config').then((config) => ENV['clientConfig'] = config);
-    }).catch((response) => this.house.handleErrorResponse(response, model));
+      this.session.loadConfig(true);
+    } catch (response) {
+      this.house.handleErrorResponse(response, model);
+    }
   }
 
   @action

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -51,6 +51,11 @@ export default class ApplicationRoute extends ClubhouseRoute {
       return;
     }
 
+    if (!('sendBeacon' in navigator)) {
+      // Too old of browser, or api is blocked by a "security" browser extension.
+      return;
+    }
+
     try {
       const analytics = new FormData;
       let pathname = window.location.pathname;
@@ -126,7 +131,7 @@ export default class ApplicationRoute extends ClubhouseRoute {
 
       const results = await RSVP.hash({
         config: this.ajax.request('config'),
-        user: this.session.loadUser()
+        user: this.session.loadUser(true)
       });
 
       ENV['clientConfig'] = results.config;

--- a/app/services/house.js
+++ b/app/services/house.js
@@ -439,6 +439,11 @@ export default class HouseService extends Service {
    */
 
   actionRecord(event, data = null, message = null) {
+    if (!('sendBeacon' in navigator)) {
+      // Too old of browser, or api is blocked by a "security" browser extension.
+      return;
+    }
+
     const record = new FormData;
 
     record.append('event', event);


### PR DESCRIPTION
- When the user permissions', checked-in position, or settings are updated, signal the other browser windows to update as well.
- Detect is navigator.sendBeacon is available. May not be available on older browsers, or an adblock or analytics blocking extension might restrict the api.