### PR TITLE
Various tweaks.

### DIFF
--- a/app/components/dashboard-pnv.js
+++ b/app/components/dashboard-pnv.js
@@ -70,7 +70,7 @@ const ALPHA_STEPS = [{
 },
 
   {
-    name: 'Walk your Alpha shift',
+    name: 'Attend your Alpha shift',
     check({milestones, person}) {
       if (person.status === 'bonked') {
         return {
@@ -85,7 +85,7 @@ const ALPHA_STEPS = [{
             result: ACTION_NEEDED,
             message: htmlSafe(`<p>Please read "<a href="${milestones.alpha_shift_prep_link}" target="_blank" rel="noopener noreferrer">Becoming a Ranger: On-playa Alpha Shifts</a>"`
                 +` on the Ranger website.</p>Your Alpha shift starts ${dayjs(milestones.alpha_shift.begins).format('ddd MMM DD [@] HH:mm')}.`
-                +`<p><b class="text-danger">ARRIVE 30 MINUTES EARLY. Late arrivals will NOT be allowed to walk.</b></p>`
+                +`<p><b class="text-danger">ARRIVE 30 MINUTES EARLY. Late arrivals will be turned away.</b></p>`
                 +`<p>Check-in at the Hat Rack located at Ranger HQ, 5:45 &amp; the Esplanda close to Center Camp.</p>`
                 +`If you know you won't be able to make your Alpha shift please email the Mentor Cadre or stop by Ranger HQ on playa.`),
             email: 'MentorEmail'
@@ -111,7 +111,7 @@ const ALPHA_STEPS = [{
 const STEP_GROUPS = [
   {title: 'Setup Your Clubhouse Account', steps: SETUP_ACCOUNT_STEPS},
   {title: 'Train to be a Ranger ', steps: TRAINING_STEPS},
-  {title: 'Walk your Alpha shift', steps: ALPHA_STEPS}
+  {title: 'Attend your Alpha shift', steps: ALPHA_STEPS}
 ];
 
 export default class DashboardPNVComponent extends Component {

--- a/app/components/dashboard-ranger.js
+++ b/app/components/dashboard-ranger.js
@@ -73,7 +73,7 @@ const STEPS = [
 
       return {
         result: ACTION_NEEDED,
-        message: 'Besides attending Green Dot Training, you must sign up for, walk, and pass a Green Dot Mentee shift in order to become a Green Dot.',
+        message: 'Besides attending Green Dot Training, you must sign up for, attend, and pass a Green Dot Mentee shift in order to become a Green Dot.',
         linkedMessage: {
           route: 'me.schedule',
           prefix: 'Visit',
@@ -85,7 +85,7 @@ const STEPS = [
   },
 
   {
-    name: 'Walk and pass a Green Dot Mentee shift',
+    name: 'Attend & Pass a Green Dot Mentee shift',
     skipPeriod: AFTER_EVENT,
     check({milestones}) {
       const {art_trainings: arts} = milestones;
@@ -208,14 +208,14 @@ const STEPS = [
 
       return {
         result: milestones.online_training_passed ? URGENT : ACTION_NEEDED,
-        message: 'Since you have not Rangered in a while, you will need to walk a Cheetah Cub shift before returning to Active status. Email the Mentor Cadre to sign up for one.',
+        message: 'Since you have not Rangered in a while, you will need to attend a Cheetah Cub shift before returning to Active status. Email the Mentor Cadre to sign up for one.',
         email: 'MentorEmail'
       };
     }
   },
 
   {
-    name: 'Walk your Cheetah Cub shift',
+    name: 'Attend your Cheetah Cub shift',
     skipPeriod: AFTER_EVENT,
     check({milestones}) {
       if (!milestones.is_cheetah_cub) {

--- a/app/components/ticket-open-applicant.hbs
+++ b/app/components/ticket-open-applicant.hbs
@@ -1,5 +1,5 @@
 <p>
-  A Work Access Pass (WAP) is good <b class="text-danger">for YOU (the Ranger Applicant) ONLY and IS *NOT* AN EVENT
+  A Work Access Pass (WAP) is <b class="text-danger">good for YOU (the Ranger Applicant) ONLY and IS *NOT* AN EVENT
   TICKET</b>.
 </p>
 <p>
@@ -9,7 +9,7 @@
   <b class="text-danger">All Ranger Applicants must provide their own event ticket.</b>
 </p>
 <p>
-  Ranger Applicants who have signed up for or completed training and intend to walk an Alpha shift
+  Ranger Applicants who have signed up for or completed training and intend to attend an Alpha shift
   on playa are eligible for a WAP that allows them to enter the event on or after
   {{mdy-format @ticketingInfo.wap_alpha_default_date full=true}} at 00:01 (one minute after midnight).
 </p>

--- a/app/components/ticketing-closed.hbs
+++ b/app/components/ticketing-closed.hbs
@@ -4,7 +4,7 @@
     <:body>
       <p>
         Alphas and Prospective Rangers who have signed up for or completed
-        training and intend to walk an Alpha shift on playa are eligible for a
+        training and intend to attend an Alpha shift on playa are eligible for a
         Work Access Pass (WAP) that allows them to enter the event on or any day after
         {{mdy-format @ticketingInfo.wap_alpha_default_date full=true}}
         at 00:01 (one minute after midnight).

--- a/app/constants/dashboard-steps.js
+++ b/app/constants/dashboard-steps.js
@@ -370,7 +370,7 @@ export const ATTEND_TRAINING = {
         if (milestones.is_cheetah_cub) {
           return {
             result: COMPLETED,
-            message: 'You still have to walk a Cheetah Cub shift before being allowed to work on playa.'
+            message: 'You still have to attend a Cheetah Cub shift before being allowed to work on playa.'
           }
         } else {
           if (isPNV || isAuditor) {

--- a/app/controllers/mentor/pod/manage.js
+++ b/app/controllers/mentor/pod/manage.js
@@ -20,6 +20,7 @@ export default class MentorPodManageController extends ClubhouseController {
   @tracked callsignForm;
 
   @tracked showSortControls = false;
+  @tracked showOffDuty = false;
 
   @tracked isLead;
 
@@ -221,6 +222,7 @@ export default class MentorPodManageController extends ClubhouseController {
     this.addPod = pod;
     this.addType = type;
     this.showAddDialog = true;
+    this.showOffDuty = false;
     this.callsignForm = EmberObject.create({
       is_lead: false,
       onduty: [],
@@ -230,6 +232,11 @@ export default class MentorPodManageController extends ClubhouseController {
     this.onDutyOptions = options[0];
     this.offDutyOptions = options[1];
     this.isLead = false;
+  }
+
+  @action
+  toggleOffDuty() {
+    this.showOffDuty = !this.showOffDuty;
   }
 
   @action

--- a/app/controllers/mentor/post-season-summary.js
+++ b/app/controllers/mentor/post-season-summary.js
@@ -16,7 +16,7 @@ export default class MentorPostSeasonSummaryController extends ClubhouseControll
     {id: 'bonked', title: 'Bonked'},
     {id: 'self-bonked', title: 'Self Bonked'},
     {id: 'uberbonked', title: 'Uber Bonked'},
-    {id: 'no-walk', title: 'Did not walk'},
+    {id: 'no-walk', title: 'Did Not Attend'},
     {id: 'no-shift', title: 'No Alpha shift'},
   ];
 

--- a/app/controllers/person/index.js
+++ b/app/controllers/person/index.js
@@ -190,7 +190,7 @@ export default class PersonIndexController extends ClubhouseController {
           case RESIGNED:
           case RETIRED:
           case INACTIVE_EXTENSION:
-            walkCC = '<li>Walk and PASS a Cheetah Cub shift</li>';
+            walkCC = '<li>Attend &amp; PASS a Cheetah Cub shift</li>';
           // eslint-disable-next-line no-fallthrough
           case INACTIVE:
             this.modal.confirm('Confirm updating status to active',

--- a/app/controllers/reports/cruise-direction.js
+++ b/app/controllers/reports/cruise-direction.js
@@ -27,6 +27,8 @@ export default class ReportsCruiseDirectionController extends ClubhouseControlle
 
   @tracked editPod;
 
+  @tracked isNewPod = false;
+
   transportOptions = TransportOptions;
 
   constructor() {
@@ -129,6 +131,7 @@ export default class ReportsCruiseDirectionController extends ClubhouseControlle
   @action
   async savePod(model) {
     const {isNew} = this.editPod;
+    const pod = this.editPod;
     this.isSubmitting = true;
     try {
       await model.save();
@@ -139,8 +142,14 @@ export default class ReportsCruiseDirectionController extends ClubhouseControlle
       this.toast.success('Pod successfully saved.');
     } catch (response) {
       this.house.handleErrorResponse(response);
+      return;
     } finally {
       this.isSubmitting = false;
+    }
+
+    if (isNew) {
+      this.isNewPod = true;
+      this.setupToAdd(pod);
     }
   }
 
@@ -190,7 +199,7 @@ export default class ReportsCruiseDirectionController extends ClubhouseControlle
   }
 
   /**
-   * Setup to select and add Alphas to a pod
+   * Setup to select and add folks to a pod
    *
    * @param pod
    * @returns {Promise<void>}

--- a/app/templates/me/event-info.hbs
+++ b/app/templates/me/event-info.hbs
@@ -41,7 +41,7 @@
             Passed training on {{mdy-format this.dirtTraining.date}} at {{this.dirtTraining.location}}
             {{#if this.person.isAlpha}}
               <br>
-              <b class="text-danger">{{fa-icon "hand-point-right"}} You still need to walk your Alpha shift on playa in
+              <b class="text-danger">{{fa-icon "hand-point-right"}} You still need to attend your Alpha shift on playa in
                 order to become a Ranger.</b>
             {{/if}}
           {{else if (eq this.dirtTraining.status "no-show")}}

--- a/app/templates/mentor/pod/manage.hbs
+++ b/app/templates/mentor/pod/manage.hbs
@@ -255,7 +255,13 @@
             <FormRow>
               <div class="col-auto">
                 {{#if this.offDutyOptions}}
-                  <f.checkboxGroup @name="offduty" @options={{this.offDutyOptions}} @cols={{4}} />
+                  <a href {{action this.toggleOffDuty}} class="d-block mb-2">
+                    {{if this.showOffDuty "Hide" "Show" }} {{pluralize this.offDutyOptions.length (concat "Off Duty " this.addType)}}
+                  </a>
+
+                  {{#if this.showOffDuty}}
+                    <f.checkboxGroup @name="offduty" @options={{this.offDutyOptions}} @cols={{4}} />
+                  {{/if}}
                 {{else}}
                   No off duty {{this.addType}}s were found.
                 {{/if}}

--- a/app/templates/mentor/post-season-summary.hbs
+++ b/app/templates/mentor/post-season-summary.hbs
@@ -66,7 +66,7 @@ bonked.
           {{#if (eq mentee.mentor_status "pass")}}
             <span class="text-success">{{fa-icon "check"}} Passed</span>
           {{else if (eq mentee.mentor_status "pending")}}
-            <span class="text-danger">{{fa-icon "shoe-prints"}} Didn't Walk</span>
+            <span class="text-danger">{{fa-icon "shoe-prints"}} Didn't Attend</span>
           {{else if (eq mentee.mentor_status "bonk")}}
             <span class="text-danger">{{fa-icon "ban"}} Bonked</span>
           {{else if (eq mentee.mentor_status "self-bonk")}}

--- a/app/templates/reports/cruise-direction.hbs
+++ b/app/templates/reports/cruise-direction.hbs
@@ -148,7 +148,15 @@
 
 {{#if this.showAddDialog}}
   <ModalDialog @onEscape={{this.closeAddDialog}} @position="top" @size="xl" as |Modal|>
-    <Modal.title>Add People to Pod #{{this.addPod.sort_index}}</Modal.title>
+    <Modal.title>
+      Pod #{{this.addPod.sort_index}} {{this.addPod.transportLabel}}.
+      {{#if this.addPod.location}}
+        Location {{this.addPod.location}}.
+      {{else}}
+        No location set.
+      {{/if}}
+    </Modal.title>
+
     <ChForm @formId="people" @formFor={{this.peopleForm}} @onSubmit={{this.addPerson}} as |f|>
       <Modal.body>
         <p>


### PR DESCRIPTION
- Updated "Walk Your Alpha Shift" language to "Attend Your Alpha Shift" in response to recent policy change.
- Do not show, by default, off duty mentors and mittens on add people to a mentor/alpoha pod dialog.
- Immediately open the add people dialog after creating a new Cruise Direction pod.