### PR TITLE
Pass in the dayjs object, not formatted string, to ical-generator.

### DIFF
--- a/app/components/schedule-table.js
+++ b/app/components/schedule-table.js
@@ -84,17 +84,19 @@ export default class ScheduleTableComponent extends Component {
       return;
     }
 
-    const calendar = ical({name: 'BRC Ranger Schedule'});
+    const calendar = ical({
+      name: `${this.args.year} BRC Ranger Schedule`,
+    });
     calendar.prodId({
       company: 'Burning Man Project',
       product: 'Ranger Clubhouse',
-      language: 'EN'
+      language: 'EN',
     });
 
     slots.forEach((slot) => {
       calendar.createEvent({
-        start: dayjs.tz(slot.slot_begins, slot.slot_tz).format(),
-        end: dayjs.tz(slot.slot_ends, slot.slot_tz).format(),
+        start: dayjs.tz(slot.slot_begins, slot.slot_tz),
+        end: dayjs.tz(slot.slot_ends, slot.slot_tz),
         summary: slot.position_title,
         detail: `${slot.description} ${slot.url}`,
         timezone: slot.slot_tz,


### PR DESCRIPTION
A timezone bug exists if an entry is created with a formatted datetime string and not a dayjs/momentjs/luxon object. With a string, the datetime will be non-consensually adjusted using the browser's datetime even tho a timezone was explicitly given.