### PR TITLE
Allow new Timecard Year Round permission holders to self check in/out (NVO/DPW Rangers)

### DIFF
--- a/app/components/me/timesheet-missing-common.js
+++ b/app/components/me/timesheet-missing-common.js
@@ -5,6 +5,7 @@ import {service} from '@ember/service';
 import {DIRT} from 'clubhouse/constants/positions';
 import validateDateTime from 'clubhouse/validators/datetime';
 import {tracked} from '@glimmer/tracking';
+import {TIMECARD_YEAR_ROUND} from "clubhouse/constants/roles";
 
 export default class MeTimesheetMissingCommonComponent extends Component {
   @service store;
@@ -46,8 +47,10 @@ export default class MeTimesheetMissingCommonComponent extends Component {
   get startDateForEntry() {
     const entry = this.entry;
 
-    if (entry.isNew) {
-      return `${this.args.timesheetInfo.correction_year}-08-15`;
+    // Timecard Year Round holders may require submitting timesheet entries occurring outside the normal
+    // event periods. E.g., NVO Rangers who start early in the summer.
+    if (entry.isNew && !this.session.hasRole(TIMECARD_YEAR_ROUND)) {
+      return `${this.args.timesheetInfo.correction_year}-08-01`;
     }
 
     return null;

--- a/app/components/shift-check-in-out.js
+++ b/app/components/shift-check-in-out.js
@@ -2,10 +2,10 @@ import Component from '@glimmer/component';
 import {set} from '@ember/object';
 import {action} from '@ember/object';
 import {service} from '@ember/service';
-import {DIRT, DIRT_SHINY_PENNY, TRAINING, BURN_PERIMETER} from 'clubhouse/constants/positions';
+import {DIRT, DIRT_SHINY_PENNY, TRAINING, BURN_PERIMETER, NVO_RANGER, DPW_RANGER} from 'clubhouse/constants/positions';
 import {tracked} from '@glimmer/tracking';
 import {NON_RANGER} from 'clubhouse/constants/person_status';
-import {ADMIN, CAN_FORCE_SHIFT} from 'clubhouse/constants/roles';
+import {ADMIN, CAN_FORCE_SHIFT, TIMECARD_YEAR_ROUND} from 'clubhouse/constants/roles';
 import {TOO_SHORT_DURATION} from 'clubhouse/models/timesheet';
 
 export default class ShiftCheckInOutComponent extends Component {
@@ -82,17 +82,14 @@ export default class ShiftCheckInOutComponent extends Component {
     // hack for operator convenience - Dirt is the most common
     // shift, so put that at top.
 
-    const dirt = signins.find((p) => p.id === DIRT);
-    if (dirt) {
-      signins.removeObject(dirt);
-      signins.unshift(dirt);
-    }
+    this._putOnTop(signins, DIRT);
+    this._putOnTop(signins, DIRT_SHINY_PENNY);
 
-    // .. and Shiny Penny shift should also be on top
-    const sp = signins.find((p) => p.id === DIRT_SHINY_PENNY);
-    if (sp) {
-      signins.removeObject(sp);
-      signins.unshift(sp);
+
+    if (+this.args.person.id === this.session.userId && this.session.hasRole(TIMECARD_YEAR_ROUND)) {
+      // Hacks for NVO / DPW Rangers who can sign themselves in and out.
+      this._putOnTop(signins, DPW_RANGER);
+      this._putOnTop(signins, NVO_RANGER);
     }
 
     this.signinPositions = signins;
@@ -116,6 +113,13 @@ export default class ShiftCheckInOutComponent extends Component {
     this.userCanForceCheckIn = this.session.hasRole([ADMIN, CAN_FORCE_SHIFT]);
   }
 
+  _putOnTop(signins, positionId) {
+    const position = signins.find((p) => p.id === positionId);
+    if (position) {
+      signins.removeObject(position);
+      signins.unshift(position);
+    }
+  }
   /**
    * Does the person actually need a radio?
    *

--- a/app/constants/positions.js
+++ b/app/constants/positions.js
@@ -66,6 +66,7 @@ export const MENTOR_LEAD = 15;
 export const MENTOR_MITTEN = 67;
 export const MENTOR_RADIO_TRAINER = 72;
 export const MENTOR_SHORT = 35;
+export const NVO_RANGER = 168;
 export const OOD = 10;
 export const OPERATIONS_MANAGER = 37;
 export const OPERATOR = 56;

--- a/app/constants/roles.js
+++ b/app/constants/roles.js
@@ -25,6 +25,7 @@ export const CAN_FORCE_SHIFT = 113; // Person can force a shift check in
 export const REGIONAL_MANAGEMENT = 114;    // Person can access Regional Ranger liaison features.
 export const PAYROLL = 115;                // Can access payroll features
 export const VEHICLE_MANAGEMENT = 116;     // Can access vehicle fleet management features
+export const TIMECARD_YEAR_ROUND = 117;    // Paid folks who can self check in/out, and submit timesheet corrections year round.
 
 export const Role = {
   ADMIN,
@@ -46,6 +47,7 @@ export const Role = {
   PAYROLL,
   SURVEY_MANAGEMENT,
   TECH_NINJA,
+  TIMECARD_YEAR_ROUND,
   TIMESHEET_MANAGEMENT,
   TRAINER,
   TRAINER_SEASONAL,
@@ -73,6 +75,7 @@ export const RoleToString = {
   [PAYROLL]: 'payroll',
   [REGIONAL_MANAGEMENT]: 'regional',
   [TECH_NINJA]: 'tech-ninja',
+  [TIMECARD_YEAR_ROUND]: 'timecard-year-round',
   [TIMESHEET_MANAGEMENT]: 'timesheet-management',
   [TRAINER]: 'trainer',
   [TRAINER_SEASONAL]: 'trainer-seasonal',

--- a/app/controllers/me/timesheet.js
+++ b/app/controllers/me/timesheet.js
@@ -102,4 +102,40 @@ export default class MeTimesheetController extends ClubhouseController {
     }).catch((response) => this.house.handleErrorResponse(response))
       .finally(() => this.isSubmitting = false);
   }
+
+  @action
+  async startShiftNotify() {
+    try {
+      await this.timesheets.update();
+    } catch (response) {
+      this.house.handleErrorResponse(response);
+    }
+  }
+
+  @action
+  async endShiftNotify() {
+    try {
+      await this.timesheets.update();
+    } catch (response) {
+      this.house.handleErrorResponse(response);
+    }
+    await this._updateTimesheetSummary();
+  }
+
+  async _updateTimesheetSummary() {
+    try {
+      this.timesheetSummary = (await this.ajax.request(`person/${this.person.id}/timesheet-summary`, {data: {year: this.year}})).summary;
+      this.timesheetInfo = (await this.ajax.request('timesheet/info', {data: {person_id: this.person.id}})).info;
+      if (this.timecardYearRound) {
+        this.timesheetInfo.correction_enabled = true;
+      }
+    } catch (response) {
+      this.house.handleErrorResponse(response);
+    }
+  }
+
+  @cached
+  get onDutyEntry() {
+    return this.timesheets.find((t) => t.off_duty == null)
+  }
 }

--- a/app/routes/me/timesheet.js
+++ b/app/routes/me/timesheet.js
@@ -1,6 +1,7 @@
 import ClubhouseRoute from 'clubhouse/routes/clubhouse-route';
 import requestYear from 'clubhouse/utils/request-year';
 import currentYear from 'clubhouse/utils/current-year';
+import {TIMECARD_YEAR_ROUND} from "clubhouse/constants/roles";
 
 export default class MeTimesheetRoute extends ClubhouseRoute {
   queryParams = {
@@ -15,10 +16,10 @@ export default class MeTimesheetRoute extends ClubhouseRoute {
     this.store.unloadAll('timesheet');
 
     // Figure out if timesheet corrections are enabled, and for what year.
-    const timesheetInfo = await this.ajax.request('timesheet/info', {
+    const timesheetInfo = (await this.ajax.request('timesheet/info', {
       method: 'GET',
       data: {person_id}
-    }).then(({info}) => info);
+    })).info;
 
     const data = {
       timesheetInfo,
@@ -26,18 +27,24 @@ export default class MeTimesheetRoute extends ClubhouseRoute {
       person: this.session.user
     };
 
-    data.timesheetSummary = await this.ajax.request(`person/${person_id}/timesheet-summary`, {data: {year}}).then(({summary}) => summary);
+    data.timesheetSummary = (await this.ajax.request(`person/${person_id}/timesheet-summary`, {data: {year}})).summary;
     data.timesheets = await this.store.query('timesheet', queryParams);
 
-    // When corrections are enabled, pull in timesheet entries, missing requests,
-    // and person positions (for missing requests)
+    data.timecardYearRound = this.session.hasRole(TIMECARD_YEAR_ROUND);
 
-    if (timesheetInfo.correction_enabled) {
+    // When corrections are enabled or if the person has the Timecard Year Round permission (NVO personnel),
+    // pull in timesheet entries, missing requests,and person positions (for missing requests)
+
+    if (timesheetInfo.correction_enabled || data.timecardYearRound) {
       this.store.unloadAll('timesheet-missing');
 
       data.timesheetsMissing = await this.store.query('timesheet-missing', queryParams);
-      data.positions = await this.ajax.request(`person/${person_id}/positions`, {data: {include_mentee: 1}})
-        .then(({positions}) => positions);
+      data.positions = (await this.ajax.request(`person/${person_id}/positions`, {data: {include_mentee: 1}})).positions;
+
+      if (data.timecardYearRound) {
+        data.eventInfo = (await this.ajax.request(`person/${person_id}/event-info`, { data: { year } })).event_info;
+        timesheetInfo.correction_enabled = true;
+      }
     } else {
       data.positions = [];
       data.timesheetsMissing = [];

--- a/app/templates/me/timesheet.hbs
+++ b/app/templates/me/timesheet.hbs
@@ -66,7 +66,8 @@
     </UiNotice>
   {{/if}}
 {{else}}
-  Contact <VcEmail /> if you have questions or concerns about your timesheet.
+  Contact
+  <VcEmail/> if you have questions or concerns about your timesheet.
 {{/if}}
 
 <UiTab as |tab|>
@@ -109,6 +110,23 @@
       <WorkHistory @person={{this.person}} />
     {{/if}}
   </tab.pane>
+  {{#if this.timecardYearRound}}
+    <tab.pane @title="Shift Check In/Out" @id="shift">
+      {{#if (is-current-year this.year)}}
+        <ShiftCheckInOut @positions={{this.positions}}
+                         @timesheets={{this.timesheets}}
+                         @person={{this.person}}
+                         @eventInfo={{this.eventInfo}}
+                         @onDutyEntry={{this.onDutyEntry}}
+                         @startShiftNotify={{this.startShiftNotify}}
+                         @endShiftNotify={{this.endShiftNotify}}
+                         @year={{this.year}}
+        />
+      {{else}}
+        Select the current year to start or end a shift
+      {{/if}}
+    </tab.pane>
+  {{/if}}
 </UiTab>
 
 {{#if this.showFinalConfirmation}}

--- a/app/templates/person/timesheet.hbs
+++ b/app/templates/person/timesheet.hbs
@@ -20,8 +20,7 @@
         <UiNotice @title="Timesheet Confirmed" @icon="check" @type="success">
           The {{this.year}} timesheet was confirmed correct on
           {{shift-format this.timesheetInfo.timesheet_confirmed_at year=true}} (Pacific). Any further updates to the
-          entries
-          will un-confirm the entire timesheet.
+          entries will un-confirm the entire timesheet.
         </UiNotice>
       {{else}}
         <UiNotice @title="Timesheet Not Confirmed" @icon="hand">


### PR DESCRIPTION
- New permissions keeps the timesheet interface open year round for said individuals.
- Put DPW / NVO Ranger positions on top of selection list if person is checking themselves in.
