### PR TITLE
Updated Mentor meal pog advisory.

### DIFF
--- a/app/components/hq-pogs.hbs
+++ b/app/components/hq-pogs.hbs
@@ -24,6 +24,13 @@
       {{@person.callsign}} has a BMID Meal Pass for the {{this.currentPeriodLabel}} period.
     </UiNotice>
    {{else}}
+    {{#if this.isMentor}}
+      <div class="alert alert-danger fs-6">
+        {{fa-icon "hand-point-right" right=1}} {{@person.callsign}} is on a Mentor shift and will receive their meal pogs directly
+        from the Mentor Shack.
+      </div>
+    {{/if}}
+
     <p>
       <b>For the current event period, issue a Full Meal Pog for every 6+ hours worked in a shift.</b>
       {{#if this.config.meal_half_pog_enabled}}

--- a/app/components/hq-pogs.js
+++ b/app/components/hq-pogs.js
@@ -14,6 +14,24 @@ import {
 import {EventPeriodLabels} from 'clubhouse/models/event-date';
 import {validatePresence} from 'ember-changeset-validations/validators';
 import {htmlSafe} from '@ember/template';
+import {
+  MENTOR,
+  MENTOR_APPRENTICE,
+  MENTOR_KHAKI,
+  MENTOR_MITTEN,
+  MENTOR_LEAD,
+  MENTOR_SHORT
+} from 'clubhouse/constants/positions';
+
+// Who are the mentors?
+const MENTOR_POSITIONS = [
+  MENTOR,
+  MENTOR_APPRENTICE,
+  MENTOR_MITTEN,
+  MENTOR_LEAD,
+  MENTOR_KHAKI,
+  MENTOR_SHORT,
+];
 
 export default class HqPogsComponent extends Component {
   @service ajax;
@@ -236,4 +254,18 @@ export default class HqPogsComponent extends Component {
     pog.status = STATUS_CANCELLED;
     this._commonPogSave(pog, 'Pog has been cancelled.', () => this.pogToCancel = null);
   }
+
+
+  /**
+   * Is the person on a Mentor shift? Used to alert the worker the Mentor will be picking up their
+   * pogs from the Mentor Cadre in the Mentor Shack.
+   *
+   * @returns {boolean}
+   */
+
+  get isMentor() {
+    const {onDutyEntry} = this.args;
+    return !!(onDutyEntry && MENTOR_POSITIONS.includes(onDutyEntry.position_id));
+  }
+
 }

--- a/app/components/hq-provision-info.hbs
+++ b/app/components/hq-provision-info.hbs
@@ -1,9 +1,3 @@
-{{#if this.mayRequestTwoMealPogs}}
-  <div class="alert alert-danger fs-6">
-    {{fa-icon "hand-point-right"}} {{@person.callsign}} is on a Mentor shift and may be eligible for TWO meal pogs.
-  </div>
-{{/if}}
-
 <div class="d-flex flex-wrap">
   <div class="me-4">
     <h4>{{fa-icon "utensils" right=1 fixed=true}} Meals</h4>

--- a/app/components/hq-provision-info.js
+++ b/app/components/hq-provision-info.js
@@ -1,27 +1,9 @@
 import Component from '@glimmer/component';
 import {isEmpty} from '@ember/utils';
-import {
-  MENTOR,
-  MENTOR_APPRENTICE,
-  MENTOR_KHAKI,
-  MENTOR_MITTEN,
-  MENTOR_LEAD,
-  MENTOR_SHORT
-} from 'clubhouse/constants/positions';
 import {tracked} from '@glimmer/tracking';
 import {action} from '@ember/object';
 import {htmlSafe} from '@ember/template';
 import {EventPeriodLabels} from 'clubhouse/models/event-date';
-
-// Who is allowed to receive two pogs during their shift
-const TWO_POGS_POSITIONS = [
-  MENTOR,
-  MENTOR_APPRENTICE,
-  MENTOR_MITTEN,
-  MENTOR_LEAD,
-  MENTOR_KHAKI,
-  MENTOR_SHORT,
-];
 
 export default class HqProvisionInfoComponent extends Component {
   @tracked periodLabel;
@@ -66,19 +48,5 @@ export default class HqProvisionInfoComponent extends Component {
 
   get onlyPogs() {
     return isEmpty(this.args.meals);
-  }
-
-  /**
-   * Is the person allowed to request two meal pogs (i.e., a Mentor Shift)
-   *
-   * @returns {boolean}
-   */
-
-  get mayRequestTwoMealPogs() {
-    const {onDutyEntry, meals} = this.args;
-    if (this.args.meals === 'all' || meals?.match(/event/)) {
-      return false;
-    }
-    return !!(onDutyEntry && TWO_POGS_POSITIONS.includes(onDutyEntry.position_id));
   }
 }

--- a/app/templates/hq/shift.hbs
+++ b/app/templates/hq/shift.hbs
@@ -171,6 +171,7 @@
 
     <tab.pane @id="pogs">
       <HqPogs @person={{this.person}}
+              @onDutyEntry={{this.onDutyEntry}}
               @endedShiftEntry={{this.endedShiftEntry}}
               @period={{this.eventInfo.event_period}}
               @eventPeriods={{this.eventPeriods}}


### PR DESCRIPTION
For 2023, Mentors will receive the meal pogs from the Mentor Shack and not use HQ Window. Let the HQ worker know that.