### PR TITLE
Gender field cleanup.

### DIFF
--- a/app/components/me/pii-general.hbs
+++ b/app/components/me/pii-general.hbs
@@ -3,32 +3,40 @@
 </div>
 <FormRow>
    <@f.text @name="first_name"
-          @label="Legal First Name"
-          @maxlength={{25}}/>
+            @label="Legal First Name"
+            @maxlength={{25}}/>
   <@f.text @name="mi"
-          @label="Middle Initial"
-          @maxlength={{10}}
+           @label="Middle Initial"
+           @maxlength={{10}}
   />
   <@f.text @name="last_name"
-          @label="Legal Last Name"
-          @maxlength={{25}}/>
+           @label="Legal Last Name"
+           @maxlength={{25}}/>
 </FormRow>
 <FormRow>
-  <@f.text @name="gender"
-          @label="Gender (optional)"
-          @hint="Examples: female, male, non-binary, gender fluid, etc."
-          @maxlength={{32}}/>
+  <@f.select @name="gender_identity"
+             @label="Gender (optional)"
+             @options={{this.genderIdentityOptions}}
+  />
+  {{#if (eq @f.model.gender_identity "custom")}}
+    <@f.text @name="gender_custom"
+             @label="Tell us your gender"
+             @size={{25}}
+             @maxlength={{25}}
+             @showCharCount={{true}}
+    />
+  {{/if}}
 </FormRow>
 <FormRow>
   <@f.select @name="pronouns"
-            @label="Pronouns (optional)"
-            @options={{@pronounOptions}}/>
+             @label="Pronouns (optional)"
+             @options={{@pronounOptions}}/>
   {{#if (eq @f.model.pronouns "custom")}}
-    <@f.text
-      @name="pronouns_custom"
-      @label="Tell us your pronouns (e.g, ze/zim/zir, she/them/theirs, etc.)"
-      @size={{30}}
-      @maxlength={{30}}
+    <@f.text @name="pronouns_custom"
+             @label="Tell us your pronouns (e.g, ze/zim/zir, she/them/theirs, etc.)"
+             @size={{30}}
+             @maxlength={{30}}
+             @showCharCount={{true}}
     />
   {{/if}}
 </FormRow>

--- a/app/components/me/pii-general.js
+++ b/app/components/me/pii-general.js
@@ -1,0 +1,6 @@
+import Component from '@glimmer/component';
+import {GenderIdentityOptions} from 'clubhouse/models/person';
+
+export default class MePiiGeneralComponent extends Component {
+  genderIdentityOptions = GenderIdentityOptions;
+}

--- a/app/components/mentor/alphas-signed-in-sheet.hbs
+++ b/app/components/mentor/alphas-signed-in-sheet.hbs
@@ -7,80 +7,88 @@
 
     <table class="signup-table">
       <tbody>
-        {{#each alphaPage as |person|}}
-          <tr>
-            <td class="w-5 text-center">
-              <div class="signup-label">&nbsp;</div>
-              {{#if person.have_mentor_flags}}
-                {{fa-icon "flag" size="2x"}}
-              {{else}}
-                &nbsp;
-              {{/if}}
-            </td>
-            <td class="w-20">
-              <div class="signup-label">Handle</div>
-              {{person.callsign}}
-            </td>
-            <td class="w-5  text-center">
-              <div class="signup-label">Gender</div>
-              {{person.gender}}
-            </td>
-            <td class="w-25">
-              <div class="signup-label">Training Location</div>
-              {{#each person.trainings as |place|}}
-                {{ymd-format place.slot_begins}}  {{place.slot_description}} <IntakeRanking @type="training" @rank={{place.training_rank}} /><br>
+      {{#each alphaPage as |person|}}
+        <tr>
+          <td class="w-5 text-center">
+            <div class="signup-label">&nbsp;</div>
+            {{#if person.have_mentor_flags}}
+              {{fa-icon "flag" size="2x"}}
+            {{else}}
+              &nbsp;
+            {{/if}}
+          </td>
+          <td class="w-20">
+            <div class="signup-label">Handle</div>
+            {{person.callsign}}
+          </td>
+          <td class="w-5  text-center">
+            <div class="signup-label">Gender</div>
+            {{#if (eq person.gender_identity "custom")}}
+              {{person.gender_custom}}
+            {{else}}
+              {{this.genderIdentityLabel person.gender_identity}}
+            {{/if}}
+          </td>
+          <td class="w-25">
+            <div class="signup-label">Training Location</div>
+            {{#each person.trainings as |place|}}
+              {{ymd-format place.slot_begins}}  {{place.slot_description}}
+              <IntakeRanking @type="training" @rank={{place.training_rank}} />
+              <br>
+            {{/each}}
+          </td>
+          <td class="w-25">
+            <div class="signup-label">Home</div>
+            {{person.city}} {{person.state}} {{person.country}}
+          </td>
+        </tr>
+        <tr>
+          <td class="w-35" colspan="3">
+            <div class="signup-label">Known Rangers</div>
+            &nbsp;{{join ", " person.known_rangers}}
+          </td>
+          <td class="w-35" colspan="2">
+            <div class="signup-label">Known Alphas</div>
+            {{join ", " person.known_pnvs}}
+          </td>
+        </tr>
+        <tr>
+          <td class="w-45" colspan="3">
+            <div class="signup-label">Prior Mentors</div>
+            {{#each person.mentor_history as |history| }}
+              {{history.year}} ({{mentor-short-status history.status}})
+              {{#each history.mentors as |mentor idx|}}
+                {{if idx " / "}}{{mentor.callsign}}
               {{/each}}
-            </td>
-            <td class="w-25">
-              <div class="signup-label">Home</div>
-              {{person.city}} {{person.state}} {{person.country}}
-            </td>
-          </tr>
-          <tr>
-            <td class="w-35" colspan="3">
-              <div class="signup-label">Known Rangers</div>
-              &nbsp;{{join ", " person.known_rangers}}
-            </td>
-            <td class="w-35" colspan="2">
-              <div class="signup-label">Known Alphas</div>
-              {{join ", " person.known_pnvs}}
-            </td>
-          </tr>
-          <tr>
-            <td class="w-45" colspan="3">
-              <div class="signup-label">Prior Mentors</div>
-              {{#each person.mentor_history as |history| }}
-                {{history.year}} ({{mentor-short-status history.status}})
-                {{#each history.mentors as |mentor idx|}}
-                  {{if idx " / "}}{{mentor.callsign}}
-                {{/each}}
-                <br>
-              {{else}}
-                <i>None</i>
-              {{/each}}
-            </td>
-            <td class="w-40" colspan="2">
-              <div class="signup-label">Mentor Notes</div>
-              {{#each person.mentor_team as |info|}}
+              <br>
+            {{else}}
+              <i>None</i>
+            {{/each}}
+          </td>
+          <td class="w-40" colspan="2">
+            <div class="signup-label">Mentor Notes</div>
+            {{#each person.mentor_team as |info|}}
               {{info.year}}
-              <IntakeRanking @type="mentor" @rank={{info.rank}} />:
+              <IntakeRanking @type="mentor" @rank={{info.rank}} />
+              :
               <br>
               {{#each info.notes as |note|}}
                 {{#unless note.is_log}}
                   <div>
-                    &mdash; {{#if note.person_source}}{{note.person_source.callsign}}{{else}}<i>Unknown</i>{{/if}}: {{note.note}}
+                    &mdash; {{#if note.person_source}}{{note.person_source.callsign}}{{else}}<i>Unknown</i>{{/if}}
+                    : {{note.note}}
                   </div>
                 {{/unless}}
               {{/each}}
-              {{else}}
-                <i>None</i>
-              {{/each}}
-            </td>
-          </tr>
-          <tr class="signup-separator">
-            <td colspan="5">&nbsp;</td>
-          </tr>
-        {{/each}}
+            {{else}}
+              <i>None</i>
+            {{/each}}
+          </td>
+        </tr>
+        <tr class="signup-separator">
+          <td colspan="5">&nbsp;</td>
+        </tr>
+      {{/each}}
       </tbody>
     </table>
   {{else}}

--- a/app/components/mentor/alphas-signed-in-sheet.js
+++ b/app/components/mentor/alphas-signed-in-sheet.js
@@ -1,5 +1,6 @@
 import Component from '@glimmer/component';
 import _ from 'lodash';
+import {GenderIdentityLabels, GENDER_NONE} from "clubhouse/models/person";
 
 const ALPHAS_PER_PAGE = 7;
 
@@ -9,5 +10,12 @@ export default class MentorAlphasSignInSheetComponent extends Component {
   get alphaPages() {
     // Filter to those only signed in
     return _.chunk(this.args.slot.people.filter((p) => p.on_alpha_shift), ALPHAS_PER_PAGE);
+  }
+
+  genderIdentityLabel(id) {
+    if (id === GENDER_NONE) {
+      return '';
+    }
+    return GenderIdentityLabels[id] ?? id;
   }
 }

--- a/app/controllers/mentor/potentials.js
+++ b/app/controllers/mentor/potentials.js
@@ -1,6 +1,7 @@
 import ClubhouseController from 'clubhouse/controllers/clubhouse-controller';
 import {action} from '@ember/object';
 import {cached, tracked} from '@glimmer/tracking';
+import {GENDER_CUSTOM, GenderIdentityLabels} from "clubhouse/models/person";
 
 export default class MentorPotentialsController extends ClubhouseController {
   @tracked mentees;
@@ -85,5 +86,14 @@ export default class MentorPotentialsController extends ClubhouseController {
     this.ajax.request('mentor/mentees', {data: {year: this.year, person_id: person.id}}).then(({mentee}) => {
       this.mentees = this.mentees.map((m) => m.id == person.id ? mentee : m);
     }).catch((response) => this.house.handleErrorResponse(response));
+  }
+
+  genderIdentityLabel(person) {
+    switch (person.gender_identity) {
+      case GENDER_CUSTOM:
+        return person.gender_custom;
+      default:
+        return GenderIdentityLabels[person.gender_identity] ?? person.gender_identity;
+    }
   }
 }

--- a/app/controllers/mentor/schedule.js
+++ b/app/controllers/mentor/schedule.js
@@ -3,6 +3,7 @@ import EmberObject, {action} from '@ember/object';
 import {debounce} from '@ember/runloop';
 import {tracked} from '@glimmer/tracking';
 import {service} from '@ember/service';
+import {GENDER_CUSTOM, GenderIdentityLabels} from "clubhouse/models/person";
 
 const SEARCH_RATE_MS = 300;
 
@@ -156,5 +157,14 @@ export default class MentorScheduleController extends ClubhouseController {
   @action
   clearAlphaApparel() {
     this.apparelSlot = null;
+  }
+
+  genderIdentityLabel(person) {
+    switch (person.gender_identity) {
+      case GENDER_CUSTOM:
+        return person.gender_custom;
+      default:
+        return GenderIdentityLabels[person.gender_identity] ?? person.gender_identity;
+    }
   }
 }

--- a/app/controllers/person/personal-info.js
+++ b/app/controllers/person/personal-info.js
@@ -5,6 +5,7 @@ import PersonInfoValidations, {REQUIRED_PII_VALIDATIONS} from 'clubhouse/validat
 import {pronounOptions} from 'clubhouse/constants/pronouns';
 import {ADMIN, VC} from 'clubhouse/constants/roles';
 import {ADDRESS_VALIDATION_NOT_REQUIRED} from 'clubhouse/constants/person_status';
+import { GenderIdentityOptions} from 'clubhouse/models/person';
 
 export default class PersonPersonalInfoController extends ClubhouseController {
   @tracked person;
@@ -13,6 +14,7 @@ export default class PersonPersonalInfoController extends ClubhouseController {
   @tracked shirtsById;
 
   pronounOptions = pronounOptions;
+  genderIdentityOptions = GenderIdentityOptions;
 
   @cached
   get personInfoValidations() {

--- a/app/models/person.js
+++ b/app/models/person.js
@@ -2,6 +2,37 @@ import Model, {attr} from '@ember-data/model';
 import {service} from '@ember/service';
 // eslint-disable-next-line ember/no-mixins
 import PersonMixin from 'clubhouse/mixins/models/person';
+import optionsToLabels from "clubhouse/utils/options-to-labels";
+
+export const GENDER_CIS_FEMALE = 'cis-female';
+export const GENDER_CIS_MALE = 'cis-male';
+export const GENDER_CUSTOM = 'custom';     // Used when the person wants to state a gender not listed. gender_custom is used.
+export const GENDER_FEMALE = 'female';
+export const GENDER_FLUID = 'fluid';
+export const GENDER_MALE = 'male';
+export const GENDER_NONE = ''; // Not stated
+export const GENDER_NON_BINARY = 'non-binary';
+export const GENDER_QUEER = 'queer';
+export const GENDER_TRANS_FEMALE = 'trans-female';
+export const GENDER_TRANS_MALE = 'trans-male';
+export const GENDER_TWO_SPIRIT = 'two-spirit';
+
+export const GenderIdentityOptions = [
+  ['Not Stated', GENDER_NONE],
+  ['Cis-Female', GENDER_CIS_FEMALE],
+  ['Cis-Male', GENDER_CIS_MALE],
+  ['Female', GENDER_FEMALE],
+  ['Male', GENDER_MALE],
+  ['Non-Binary', GENDER_NON_BINARY],
+  ['Gender Fluid', GENDER_FLUID],
+  ['Gender Queer', GENDER_QUEER],
+  ['Trans-Female', GENDER_TRANS_FEMALE],
+  ['Trans-Male', GENDER_TRANS_MALE],
+  ['Two Spirit', GENDER_TWO_SPIRIT],
+  ['Something Else', GENDER_CUSTOM],
+];
+
+export const GenderIdentityLabels = optionsToLabels(GenderIdentityOptions);
 
 export default class PersonModel extends PersonMixin(Model) {
   @service ajax;
@@ -53,7 +84,8 @@ export default class PersonModel extends PersonMixin(Model) {
   @attr('string') pronouns;
   @attr('string') pronouns_custom;
 
-  @attr('string') gender;
+  @attr('string') gender_identity;
+  @attr('string') gender_custom;
 
   @attr('number') long_sleeve_swag_ig;
   @attr('number') tshirt_swag_id;

--- a/app/templates/mentor/potentials.hbs
+++ b/app/templates/mentor/potentials.hbs
@@ -63,8 +63,7 @@ Showing {{this.viewPotentials.length}} of {{pluralize this.mentees.length "poten
         {{/if}}
         <PersonLink @person={{person}} /> &lt;{{person.status}}&gt;<br>
         {{person.first_name}} {{person.last_name}}<br>
-        <PresentOrNot @value={{person.gender}} @empty="no gender stated"/>
-        <br>
+          {{this.genderIdentityLabel person}}
       </td>
       <td class="w-10">
         {{#each person.mentor_history as |history|}}

--- a/app/templates/mentor/schedule.hbs
+++ b/app/templates/mentor/schedule.hbs
@@ -52,7 +52,7 @@
                 <PersonLink @person={{person}} />
               </td>
               <td class="w-15">{{person.first_name}} {{person.last_name}}</td>
-              <td class="w-5 text-center">{{person.gender}}</td>
+              <td class="w-5 text-center">{{this.genderIdentityLabel person}}</td>
               <td class="w-5 text-center">{{yesno person.on_alpha_shift}}</td>
               <td class="w-10">
                 {{#if person.have_mentor_flags}}

--- a/app/templates/person/personal-info.hbs
+++ b/app/templates/person/personal-info.hbs
@@ -1,18 +1,16 @@
 <h3>Personal Information for {{this.person.callsign}}</h3>
 <p>
-  {{this.person.callsign}}
   {{#if this.person.reviewed_pi_at}}
-    last reviewed their PII on
-    {{timestamp-format this.person.reviewed_pi_at "MMM DD, YYYY @ HH:mm"}} (Pacific)
+    Last updated their PII on {{timestamp-format this.person.reviewed_pi_at "MMM DD, YYYY @ HH:mm"}} (Pacific)
   {{else}}
-    has not updated their PII yet.
+    Has not updated their PII yet.
   {{/if}}
   <br>
   {{#if this.person.pi_reviewed_for_dashboard_at}}
-    Last reviewed for dashboard on
+    Last reviewed their PII for the dashboard PII step on
     {{timestamp-format this.person.pi_reviewed_for_dashboard_at "MMM DD, YYYY @ HH:mm"}} (Pacific).
   {{else}}
-    Has not reviewed for dashboard yet.
+    Has not yet reviewed their PII for the dashboard PII step.
   {{/if}}
 </p>
 {{#if this.canEditPersonalInfo}}
@@ -27,26 +25,39 @@
           <:body>
             <FormRow>
               <f.text @name="first_name"
-                      @label="First Name"
-                      @maxlength={{25}}/>
+                      @label="Legal First Name"
+                      @maxlength={{25}}
+                      @showCharCount={{true}}
+              />
               <f.text @name="mi"
                       @label="M.I."
                       @size={{2}}
-                      @maxlength={{10}}/>
+                      @maxlength={{10}}
+              />
               <f.text @name="last_name"
-                      @label="Last Name"
-                      @maxlength={{25}}/>
+                      @label="Legal Last Name"
+                      @maxlength={{25}}
+                      @showCharCount={{true}}
+
+              />
             </FormRow>
             <FormRow>
-              <f.text @name="gender"
-                      @label="Gender"
-                      @hint="female, male, non-binary, gender fluid, etc."
-                      @maxlength={{32}}
+              <f.select @name="gender_identity"
+                        @label="Gender (optional)"
+                        @options={{this.genderIdentityOptions}}
               />
+              {{#if (eq f.model.gender_identity "custom")}}
+                <f.text @name="gender_custom"
+                        @label="Their Gender"
+                        @size={{25}}
+                        @maxlength={{25}}
+                        @showCharCount={{true}}
+                />
+              {{/if}}
             </FormRow>
             <FormRow class="mb-4">
               <f.select @name="pronouns"
-                        @label="Pronouns"
+                        @label="Pronouns (optional)"
                         @options={{this.pronounOptions}}/>
               {{#if (eq f.model.pronouns "custom")}}
                 <f.text

--- a/mirage/factories/person.js
+++ b/mirage/factories/person.js
@@ -11,7 +11,8 @@ export default Factory.extend({
   tshirt_swag_id: null,
   tshirt_secondary_swag_id: null,
   long_sleeve_swag_ig: null,
-  gender: '',
+  gender_identity: 'female',
+  gender_custom: '',
   has_reviewed_pi: false,
 
   callsign() {

--- a/tests/acceptance/me/personal-info-test.js
+++ b/tests/acceptance/me/personal-info-test.js
@@ -14,7 +14,7 @@ module('Acceptance | me/personal info', function(hooks) {
 
     const fields = [
       'first_name', 'mi', 'last_name',
-      'email', 'home_phone', 'alt_phone', 'gender',
+      'email', 'home_phone', 'alt_phone', 'gender_identity',
       'camp_location',
       'street1', 'street2', 'apt', 'city', 'state', 'country',
     ];


### PR DESCRIPTION
- person.gender split into person.gender_identity (options - female, male, non-binary, custom) and person.gender_custom (free form)
- Mentor interfaces and Shift Lead report updated to use the new gender fields.