### PR TITLE
HQ Window Interface tweaks

### DIFF
--- a/app/components/hq-todo-task.hbs
+++ b/app/components/hq-todo-task.hbs
@@ -1,0 +1,13 @@
+{{#if @todo.ignore}}
+    <div class="text-muted me-4">
+        {{fa-icon "ban" fixed=true right=1}} {{@todo.message}}
+    </div>
+{{else if @todo.completed}}
+    <div class="text-success me-4">
+        {{fa-icon "check" fixed=true right=1}} {{@todo.message}}
+    </div>
+{{else}}
+    <div class="me-4 {{if @todo.blink "hq-todo-blink"}}">
+        {{fa-icon "circle" type="far" fixed=true right=1}} {{@todo.message}}
+    </div>
+{{/if}}

--- a/app/components/shift-check-in-out.hbs
+++ b/app/components/shift-check-in-out.hbs
@@ -59,15 +59,14 @@
     {{#if (not @person.canStartShift)}}
         <UiNotice @icon="hand" @type="danger" @title="Status Issue">
             {{@person.callsign}} cannot start a shift because their status ({{@person.status}}) does not allow them to
-            work
-            shifts.
+            work shifts.
         </UiNotice>
     {{else if @hasUnreviewedTimesheet}}
         <UiNotice @icon="hand" @type="danger" @title="Outstanding Tasks">
             One or more timesheet entries has to be reviewed FIRST before a shift can be started.
         </UiNotice>
     {{else}}
-        {{#if this.isPersonDirtTrained}}
+        {{#if this.inPersonTrainingPassed}}
             {{#if @upcomingSlots.imminent}}
                 <p class="text-success">
                     {{pluralize @upcomingSlots.imminent.length "upcoming scheduled shift sign-up"}} found.
@@ -136,14 +135,13 @@
                                                 time while waiting to be deployed.
                                             </li>
                                             <li>
-                                                If this is a specialized shift (Mentors, Leads, Longs, Supervisors,
-                                                OODs, On Call, Shift
-                                                Command,
-                                                etc.), or if the person's cadre/team/manager has requested the person
-                                                start earlier than
-                                                scheduled, check in the person now. Rangers have to adapt to the
-                                                ever-changing situation on
-                                                playa.
+                                                If this is a specialized shift (e.g., Mentors, Leads, Longs,
+                                                Supervisors, OODs, On Call,
+                                                Shift Command, etc.), or if the person's cadre/team/manager has
+                                                requested the person start
+                                                earlier than scheduled, check in the person now. Rangers have to adapt
+                                                to the ever-changing
+                                                situation on playa.
                                             </li>
                                         </ul>
                                         <b>The recommendations are guidelines, not a hard set of
@@ -190,15 +188,29 @@
                     <p>
                         In case the person attended an In-Person Training earlier in the day, the trainers may be
                         delayed recording who passed the training. Have the HQ Short or Lead contact the trainers to
-                        verify the
-                        person attended and passed the training.
+                        verify the person attended and passed the training.
                     </p>
                     {{#if this.userCanForceCheckIn}}
                         You have the privileges to force a shift start.
                     {{else}}
-                        You do not have the privileges to force a shift start. A HQ Lead may be able to start the shift.
+                        You do not have the privileges to force a shift start. A HQ Short or Lead may be able to start
+                        the shift.
                     {{/if}}
                 </UiNotice>
+
+                {{#if this.noTrainingRequiredPositions}}
+                    <UiNotice @title="Has No Training Required Positions" @icon="thumbs-up" @type="success">
+                        <p>
+                        While {{@person.callsign}} has not passed an In-Person Training session, they do have
+                        positions which can be signed in to that do not require passing an In-Person Training.
+                            Select such a position and the Start Shift button will appear.
+                        </p>
+                        No training required position(s):<br>
+                        {{#each this.noTrainingRequiredPositions as |position idx|}}
+                            {{position.title}}{{if idx ", "}}
+                        {{/each}}
+                    </UiNotice>
+                {{/if}}
             {{/if}}
         {{/if}}
 
@@ -213,22 +225,35 @@
                                 @onChange={{this.updateShiftPosition}}/>
             </div>
             <div class="col-auto">
-                {{#if (or this.isPersonDirtTrained this.haveNoTrainingRequired)}}
+                {{#if this.selectedPosition.disqualified}}
+                    {{#if this.userCanForceCheckIn}}
+                        <UiButton @type="warning" @onClick={{this.startShiftAction}} @disabled={{this.isSubmitting}}>
+                            Force Shift Start
+                        </UiButton>
+                    {{else}}
+                        <div class="text-danger mt-1">Shift start not allowed</div>
+                    {{/if}}
+                {{else}}
                     <UiButton @onClick={{this.startShiftAction}} @disabled={{this.isSubmitting}}>
                         {{fa-icon "walking" right=2}} Start Shift
                     </UiButton>
-                {{else if this.userCanForceCheckIn}}
-                    <UiButton @type="warning" @onClick={{this.startShiftAction}} @disabled={{this.isSubmitting}}>
-                        Force Shift Start
-                    </UiButton>
-                {{else}}
-                    <div class="text-danger mt-1">NOT IN-PERSON TRAINED - SHIFT START IS NOT ALLOWED</div>
                 {{/if}}
                 {{#if this.isSubmitting}}
                     <LoadingIndicator/>
                 {{/if}}
             </div>
         </FormRow>
+        {{#if this.selectedPositionDisqualified}}
+            <div class="text-danger mb-2">
+                The selected position, {{this.selectedPosition.title}}, should not be signed in to because:<br>
+                {{this.selectedPositionDisqualified}}
+            </div>
+            {{#if this.userCanForceCheckIn}}
+                <b>You do have the privileges to force the shift start.</b>
+            {{else}}
+                <b>Consult with the HQ Short or Lead if this is an error.</b>
+            {{/if}}
+        {{/if}}
     {{/if}}
 {{/if}}
 
@@ -286,13 +311,12 @@
             <p>
                 <b class="text-danger">
                     WARNING: {{@person.callsign}} has not meet all the qualifications to start
-                    a {{this.forcePosition.title}}
-                    shift
+                    a {{this.forcePosition.title}} shift
                 </b>
             </p>
             <ul>
                 {{#if
-                        (and (not this.isPersonDirtTrained) (not this.forcePosition.is_untrained) (not this.forcePosition.is_unqualified))}}
+                        (and (not this.inPersonTrainingPassed) (not this.forcePosition.is_untrained) (not this.forcePosition.is_unqualified))}}
                     <li>In-Person Training has not been completed.</li>
                 {{/if}}
                 {{#if this.forcePosition.is_untrained}}
@@ -310,8 +334,7 @@
             </p>
             <p>
                 Are you absolutely sure you want to sign in this person at this time? Check with the HQ Lead or Short if
-                in
-                doubt.
+                in doubt.
             </p>
         </Modal.body>
         <Modal.footer>

--- a/app/constants/hq-todo.js
+++ b/app/constants/hq-todo.js
@@ -29,9 +29,10 @@ export class HqTodoTask {
   @tracked ignore = false;
   @tracked message;
 
-  constructor(task, ignore = false) {
+  constructor(task, ignore = false, blink = false) {
     this.task = task;
     this.message = HqTodoLabels[task];
     this.ignore = ignore;
+    this.blink = blink;
   }
 }

--- a/app/controllers/hq/site-checkin.js
+++ b/app/controllers/hq/site-checkin.js
@@ -16,7 +16,7 @@ export default class HqSiteCheckinController extends ClubhouseController {
     return this.assets.filter((asset) => !asset.checked_in);
   }
 
-  get isPersonDirtTrained() {
+  get inPersonTrainingPassed() {
     if (this.person.status === NON_RANGER) {
       return true;
     }

--- a/app/routes/hq/shift.js
+++ b/app/routes/hq/shift.js
@@ -44,12 +44,14 @@ export default class HqShiftRoute extends ClubhouseRoute {
     const {upcomingSlots} = model;
 
     if (!upcomingSlots.imminent.length && !upcomingSlots.upcoming.length) {
-      todos.push(new HqTodoTask(HQ_TODO_OFF_SITE));
+      controller.askIfDone = new HqTodoTask(HQ_TODO_OFF_SITE, false, true);
+    } else {
+      controller.askIfDone = null;
     }
 
     if (!controller.isOffDuty) {
       todos.push(new HqTodoTask(HQ_TODO_END_SHIFT));
-      if (controller.shiftRadios) {
+      if (controller.collectRadioCount) {
         todos.push(new HqTodoTask(HQ_TODO_COLLECT_RADIO));
       }
     } else {

--- a/app/styles/hq.scss
+++ b/app/styles/hq.scss
@@ -10,3 +10,15 @@
 button.btn-timesheet:not(:last-child) {
   margin-right: 1vw;
 }
+
+.hq-todo-blink {
+  animation: todo-blinker 2s linear infinite;
+  color: #ff0000;
+}
+
+@keyframes todo-blinker {
+   50% {
+     color: #ee7d7d;
+     opacity: 60%;
+  }
+}

--- a/app/templates/hq/shift.hbs
+++ b/app/templates/hq/shift.hbs
@@ -1,12 +1,16 @@
 {{#if this.isShinyPenny}}
-  <UiNotice @type="success" @icon="smile-beam" @iconType="fa-regular"
+  <UiNotice @type="success"
+            @icon="smile-beam"
+            @iconType="fa-regular"
             @title="{{this.person.callsign}} is a Shiny Penny">
     Share some Ranger love and welcome them to the family.
   </UiNotice>
 {{/if}}
 
 {{#unless this.person.on_site}}
-  <UiNotice @type="danger" @icon="hand-point-right" @title="{{this.person.callsign}} is marked as OFF SITE">
+  <UiNotice @type="danger"
+            @icon="hand-point-right"
+            @title="{{this.person.callsign}} is marked as OFF SITE">
     <p>
       Follow the procedures on the Site Check In page before signing the person into a shift.
     </p>
@@ -42,16 +46,13 @@
     <div class="d-flex justify-content-start flex-wrap">
       {{#if this.todos}}
         {{#each this.todos as |todo|}}
-          {{#if todo.ignore}}
-            <div class="text-muted me-4">{{fa-icon "ban" fixed=true right=1}} {{todo.message}}</div>
-          {{else if todo.completed}}
-            <div class="text-success me-4">{{fa-icon "check" fixed=true right=1}} {{todo.message}}</div>
-          {{else}}
-            <div class="me-4">{{fa-icon "circle" type="far" fixed=true right=1}} {{todo.message}}</div>
-          {{/if}}
+          <HqTodoTask @todo={{todo}} />
         {{/each}}
       {{/if}}
     </div>
+    {{#if this.askIfDone}}
+      <HqTodoTask @todo={{this.askIfDone}} />
+    {{/if}}
   </div>
 {{/if}}
 
@@ -61,9 +62,11 @@
       <div>
         Timesheet Review
         {{#if this.unreviewedTimesheetCount}}
-          <span class="ms-1 text-danger">({{pluralize this.unreviewedTimesheetCount "entry"}})</span>
+          <div class="text-danger">
+            ({{pluralize this.unreviewedTimesheetCount "entry"}})
+          </div>
         {{else}}
-          <div class="ms-1 text-muted">(not needed yet)</div>
+          <div class="text-muted">(not needed yet)</div>
         {{/if}}
       </div>
     </nav.item>
@@ -113,22 +116,25 @@
       {{#if (eq tab.activeId "assets")}}
         {{#unless this.personEvent.asset_authorized}}
           <UiNotice @title="Do Not Issue Radios or Gear" @type="danger" @icon="ban">
-            The Radio Checkout Agreement has not been signed. Direct {{this.person.callsign}} to the kiosk shack,
-            so they can log in into the Clubhouse, review, and sign the agreement.
+            The Radio Checkout Agreement has not been signed. Direct {{this.person.callsign}} to the kiosk
+            shack, so they can log in into the Clubhouse, review, and sign the agreement.
           </UiNotice>
         {{/unless}}
-        {{#if this.radioCount}}
-          {{#if this.shiftRadios}}
-            <div class="alert alert-danger">
-              Collect {{pluralize this.shiftRadios "shift radio"}} at the end of the shift.
-            </div>
-          {{/if}}
-          {{#if this.eventRadios}}
-            <h4 class="text-success">
-              {{this.person.callsign}} has {{pluralize this.eventRadios "event radio"}} checked out. Collect the
-              radio(s) after their very last shift of the season.
-            </h4>
-          {{/if}}
+        {{#if this.collectRadioCount}}
+          <div class="alert alert-warning">
+            {{#if this.shiftRadios}}
+              Collect {{pluralize this.shiftRadios "shift radio"}} at the end of the shift.<br>
+            {{/if}}
+            {{#if this.collectEventRadiosAtShiftEnd}}
+              Collect {{pluralize this.collectEventRadiosAtShiftEnd "event radio"}} at the end of the shift.
+            {{/if}}
+          </div>
+        {{/if}}
+        {{#if this.collectEventRadios}}
+          <div class="alert alert-secondary">
+            {{pluralize this.collectEventRadios "event radio"}} is checked out.
+            Collect the radio(s) after their very last shift of the event.
+          </div>
         {{/if}}
 
         <div class="mb-2">
@@ -139,8 +145,8 @@
           {{else}}
             {{#if this.mayNotNeedRadio}}
               <UiNotice @icon="hand-point-right" @type="secondary" @title="May not need radio">
-                {{this.person.callsign}} is working a Burn Perimeter shift and may not need a radio. Check with
-                the HQ Short or Lead if in doubt.
+                {{this.person.callsign}} is working a Burn Perimeter shift and may not need a radio.
+                Check with the HQ Short or Lead if in doubt.
               </UiNotice>
             {{/if}}
             {{this.person.callsign}} is only authorized for SHIFT RADIOS.
@@ -200,13 +206,16 @@
                 </li>
               {{/unless}}
               {{#if this.assetsCheckedOut}}
-                <li>{{pluralize this.assetsCheckedOut.length "asset"}} (radios, gear, etc.) not collected.</li>
+                <li>{{pluralize this.assetsCheckedOut.length "asset"}} (radios, gear, etc.) not
+                  collected.
+                </li>
               {{/if}}
               {{#if this.unverifiedTimesheets}}
                 <li>{{pluralize this.unverifiedTimesheets.length "timesheet entry"}} not reviewed.</li>
               {{/if}}
             </ul>
-            You may choose to ignore this warning and proceed to mark this person off site. However, you really should
+            You may choose to ignore this warning and proceed to mark this person off site. However, you
+            really should
             take care of the items listed above.
           </UiNotice>
         {{else}}


### PR DESCRIPTION
- Move the ask-if-person-is-done-working task to just below the task list. Blink the text red to combat playa brain.
- Let the worker know the exact reasons why a particular position cannot be signed in to.
- Indicate if the person has positions which do not require training and allow those to be signed in to even if an In Person training was not passed. (e.g., SITE Setup / Teardown)
- Only disable the Start Shift button for those positions not meeting all the qualifications.
- Ask the worker to 'review timesheets' instead of 'verify timesheets'.
- Ask the worker to collect the event radio when the person was only shift radio qualified. (was a bug)