### PR TITLE
Various tweaks.

### DIFF
--- a/app/components/dashboard-pnv.js
+++ b/app/components/dashboard-pnv.js
@@ -14,7 +14,7 @@ import {
   WAITING
 } from "clubhouse/constants/dashboard";
 import * as DashboardStep from 'clubhouse/constants/dashboard-steps';
-import {PROSPECTIVE} from "../constants/person_status";
+import {BONKED, PROSPECTIVE, UBERBONKED} from "../constants/person_status";
 
 const SETUP_ACCOUNT_STEPS = [
   DashboardStep.UPLOAD_PHOTO,
@@ -36,7 +36,7 @@ const ALPHA_STEPS = [
   {
     name: 'Sign up for an Alpha shift',
     check({milestones, person}) {
-      if (person.status === 'bonked') {
+      if (person.status === BONKED || person.status === UBERBONKED) {
         return {result: SKIP};
       }
 
@@ -57,7 +57,7 @@ const ALPHA_STEPS = [
           route: 'me.schedule',
           linkedMessage: {
             route: 'me.schedule',
-            prefix: 'Visit',
+            prefix: htmlSafe('Alpha shifts are only available Saturday (the day before the gate opens), Sunday, Monday, and Tuesday. No shifts are offered later in the week.<br><br>Visit '),
             text: 'Me > Schedule / Sign Up',
             suffix: 'to sign up for an Alpha shift.'
           }
@@ -74,7 +74,7 @@ const ALPHA_STEPS = [
   {
     name: 'Attend your Alpha shift',
     check({milestones, person}) {
-      if (person.status === 'bonked') {
+      if (person.status === BONKED || person.status === UBERBONKED) {
         return {
           result: BLOCKED,
           message: 'You did not pass your Alpha shift. You are unable to sign up for Ranger shifts this season.',
@@ -88,7 +88,7 @@ const ALPHA_STEPS = [
             message: htmlSafe(`<p>Please read "<a href="${milestones.alpha_shift_prep_link}" target="_blank" rel="noopener noreferrer">Becoming a Ranger: On-playa Alpha Shifts</a>"`
               + ` on the Ranger website.</p>Your Alpha shift starts ${dayjs(milestones.alpha_shift.begins).format('ddd MMM DD [@] HH:mm')}.`
               + `<p><b class="text-danger">ARRIVE 30 MINUTES EARLY. Late arrivals will be turned away.</b></p>`
-              + `<p>Check-in at the Hat Rack located at Ranger HQ, 5:45 &amp; the Esplanda close to Center Camp.</p>`
+              + `<p>Check-in at the Hat Rack located at Ranger HQ, 5:45 &amp; the Esplanade close to Center Camp.</p>`
               + `If you know you won't be able to make your Alpha shift please email the Mentor Cadre or stop by Ranger HQ on playa.`),
             email: 'MentorEmail'
           };

--- a/app/components/dashboard-step.hbs
+++ b/app/components/dashboard-step.hbs
@@ -21,7 +21,7 @@
      {{@step.message}}
     {{/if}}
     {{#if @step.linkedMessage}}
-      &nbsp;{{@step.linkedMessage.prefix}}
+      {{@step.linkedMessage.prefix}}
       <LinkTo @route={{@step.linkedMessage.route}} disabled={{@isNotUser}}>{{@step.linkedMessage.text}}</LinkTo>
       {{@step.linkedMessage.suffix}}
     {{/if}}

--- a/app/components/schedule-position-list.hbs
+++ b/app/components/schedule-position-list.hbs
@@ -26,8 +26,8 @@
         <p>
           {{#if this.needsFullDayTraining}}
             <b>
-              Because you are {{this.personStatus}}, you must attend the <u class="text-danger">FULL DAY</u> In-Person
-              Training.
+              Because you are {{this.personStatus}}, you MUST attend the <u class="text-danger">FULL DAY</u>
+              In-Person Training.
             </b>
           {{else}}
             Since you have 2 or more years experience, you may choose to attend only the second
@@ -38,12 +38,30 @@
         <p>
           Additional training sessions will be posted through the end of Spring.
         </p>
+      {{else if this.isAlphaPosition}}
+        <p>
+          Note: Alpha shifts are only offered on Saturday (the day before the gate opens), Sunday, Monday, and Tuesday.
+          No other shifts are offered later in the week.
+        </p>
+        <p>
+          <b class="text-danger">ARRIVE 30 MINUTES EARLY for your Alpha shift. You be turned away if you arrive
+            after the start time.</b>
+        </p>
+        <p>
+          Check-in at the Hat Rack located at Ranger HQ, 5:45 &amp; the Esplanade close to Center Camp.
+        </p>
+        <p>
+          <b>Are you on playa and know you won't be able to make your Alpha shift?</b> Email the Mentor Cadre or stop
+          by Ranger HQ on playa to see if another shift can be attended.
+        </p>
       {{/if}}
       {{#if this.haveNoAppreciationSlots}}
-        <NoAppreciateIcon/> = the shift hours will not count towards provisions &amp; appreciations.<br>
+        <NoAppreciateIcon/>
+        = the shift hours will not count towards provisions &amp; appreciations.<br>
       {{/if}}
       {{#if this.haveShiftWithAdditionalInfo}}
-          <InfoIcon/> = More shift information available, click on the icon and/or text.<br>
+        <InfoIcon/>
+        = More shift information available, click on the icon and/or text.<br>
       {{/if}}
       {{#if this.haveOverlapping}}
         <div class="mt-1 text-danger">

--- a/app/constants/dashboard-steps.js
+++ b/app/constants/dashboard-steps.js
@@ -605,11 +605,12 @@ export const SIGN_RADIO_CHECKOUT_AGREEMENT = {
     }
 
 
-    let adj;
+    let adj, alpha = '';
     if (person.isNonRanger) {
       adj = 'Ranger volunteers';
     } else if (isPNV) {
       adj = 'Prospective Rangers'
+      alpha = ' You will be using a radio during your Alpha shift.';
     } else {
       adj = 'Rangers';
     }
@@ -622,7 +623,7 @@ export const SIGN_RADIO_CHECKOUT_AGREEMENT = {
       route: 'me.agreements',
       linkedMessage: {
         route: 'me.agreements',
-        prefix: htmlSafe(`All ${adj} must sign the Ranger Radio Checkout Agreement prior to checking out a radio from the Rangers.<br><br>Visit`),
+        prefix: htmlSafe(`All ${adj} must sign the Ranger Radio Checkout Agreement prior to checking out a radio from the Rangers.${alpha}<br><br>Visit`),
         text: 'Me > Radio Agreement',
         suffix: 'to review and agree to the Radio Checkout Agreement.'
       },

--- a/app/services/shift-manage.js
+++ b/app/services/shift-manage.js
@@ -1,6 +1,8 @@
 import Service from '@ember/service';
 import {service} from '@ember/service';
 import {set} from '@ember/object';
+import {shiftFormat} from 'clubhouse/helpers/shift-format';
+
 import ModalMultipleEnrollmentComponent from 'clubhouse/components/modal-multiple-enrollment';
 import ModalMissingRequirementsComponent from 'clubhouse/components/modal-missing-requirements';
 import ModalConfirmMultipleEnrollmentComponent from 'clubhouse/components/modal-confirm-multiple-enrollment';
@@ -228,7 +230,13 @@ export default class ShiftManageService extends Service {
   async checkDateTime(position_id, start, finished, callback) {
     let status, begins, ends, start_status, finished_status;
     try {
-      ({ status, begins, ends, start_status, finished_status } = await this.ajax.request('slot/check-datetime', {data: {position_id, start, finished }}));
+      ({
+        status,
+        begins,
+        ends,
+        start_status,
+        finished_status
+      } = await this.ajax.request('slot/check-datetime', {data: {position_id, start, finished}}));
     } catch (response) {
       this.house.handleErrorResponse(response);
       return;
@@ -249,16 +257,15 @@ export default class ShiftManageService extends Service {
     this.modal.confirm('Date(s) might be out of range', message, callback);
   }
 
-  alertRange(label, date, status, begins, ends)
-  {
+  alertRange(label, date, status, begins, ends) {
     if (status === 'success') {
       return '';
     }
 
     if (status === 'before-begins') {
-      return `<li>The ${label} time ${date} is before the first shift starting on ${begins}.</li>`;
+      return `<li >The ${label} time ${shiftFormat([date], {})} <b class="text-danger">is BEFORE the first shift</b> starting on ${shiftFormat([begins], {})}.</li>`;
     } else {
-      return `<li>The ${label} time ${date} is after the last shift ending on ${ends}.</li>`;
+      return `<li>The ${label} time ${shiftFormat([date], {})} <b class="text-danger">is AFTER the last shift</b> ending on ${shiftFormat([ends], {})}.</li>`;
     }
   }
 }

--- a/app/templates/reports/timesheet-correction-requests.hbs
+++ b/app/templates/reports/timesheet-correction-requests.hbs
@@ -20,9 +20,8 @@ Showing {{this.viewGroupCorrections.length}} of {{pluralize this.requests.length
     <th>Callsign</th>
     <th>Type</th>
     <th>Position</th>
-    <th>On Duty</th>
-    <th>Off Duty</th>
     <th>Time</th>
+    <th>Duration</th>
     <th>Credits</th>
   </tr>
   </thead>
@@ -39,10 +38,9 @@ Showing {{this.viewGroupCorrections.length}} of {{pluralize this.requests.length
         </td>
         <td>{{if request.is_missing "Missing Entry" "Correction"}}</td>
         <td>{{request.position.title}}</td>
-        <td>{{shift-format request.on_duty}}</td>
-        <td>{{shift-format request.off_duty}}</td>
-        <td>{{hour-minute-format request.duration}}</td>
-        <td>{{credits-format request.credits}}</td>
+        <td>{{shift-format request.on_duty request.off_duty}}</td>
+        <td class="text-end">{{hour-minute-format request.duration}}</td>
+        <td class="text-end">{{credits-format request.credits}}</td>
       </tr>
     {{/each}}
   {{else}}


### PR DESCRIPTION
- Added language to Alpha sign-up step, and Alpha position section on the sign-up listing to let the user know shifts are only offered on 4 days. (applicants were not clear on the available shifts)
- Format the before/after dates on the missing timesheet correction warnings.