### PR TITLE
Timesheet tweaks

### DIFF
--- a/app/components/me/timesheet-review-common.hbs
+++ b/app/components/me/timesheet-review-common.hbs
@@ -35,19 +35,19 @@
           {{#if this.correctionsEnabled}}
             <div class="timesheet-row-header {{this.timesheetRowClass ts}}">
               {{#if ts.stillOnDuty}}
-                {{fa-icon "ban"}} The entry cannot be verified or a correction submitted
+                {{fa-icon "ban" right=1}} The entry cannot be verified or a correction submitted
                 until after the shift has ended.
               {{else if ts.isVerified}}
-                {{fa-icon "check"}} Entry was verified as correct on {{shift-format ts.verified_at}} (Pacific)
+                {{fa-icon "check" right=1}} Entry was verified as correct on {{shift-format ts.verified_at}} (Pacific)
               {{else if ts.isUnverified}}
-                {{fa-icon "arrow-right"}} The entry has not been verified as correct or a correction submitted.
+                {{fa-icon "arrow-right" right=1}} The entry has not been verified as correct or a correction submitted.
               {{else if ts.isApproved}}
-                {{fa-icon "arrow-right"}} The correction request has been approved. You will need verify the
+                {{fa-icon "arrow-right" right=1}} The correction request has been approved. You will need verify the
                 correction is accurate.
               {{else if ts.isRejected}}
-                {{fa-icon "times"}} The correction request has been denied. An appeal may be submitted.
+                {{fa-icon "times" right=1}} The correction request has been denied. An appeal may be submitted.
               {{else if ts.isPending}}
-                {{fa-icon "hourglass-half"}} The correction request is pending review.
+                {{fa-icon "hourglass-half" right=1}} The correction request is pending review.
               {{else}}
                 Unknown state? [{{ts.review_status}}]
               {{/if}}

--- a/app/components/person/timesheet-log.hbs
+++ b/app/components/person/timesheet-log.hbs
@@ -6,26 +6,25 @@
   <LoadingIndicator @text="Loading timesheet audit log"/>
 {{else}}
   {{#each this.logs as |entry|}}
-    <UiSection>
-      <:title>
+    <UiAccordion as |Accordion|>
+      <Accordion.title>
         #{{entry.timesheet_id}}
         {{#if entry.deleted}}
           <span class="text-danger mx-1">DELETED</span>
         {{/if}}
         {{#if entry.timesheet}}
           {{entry.timesheet.position_title}}:
-          {{shift-format entry.timesheet.on_duty}} -
           {{#if entry.timesheet.off_duty}}
-            {{shift-format entry.timesheet.off_duty}}
+            {{shift-format entry.timesheet.on_duty entry.timesheet.off_duty}}
           {{else}}
-            <i class="text-danger">Still On Duty</i>
+            {{shift-format entry.timesheet.on_duty}} - <i class="text-danger">Still On Duty</i>
           {{/if}}
         {{else}}
           <b class="text-danger">Timesheet association failure</b>
         {{/if}}
-      </:title>
+      </Accordion.title>
 
-      <:body>
+      <Accordion.body>
         <table class="table table-sm table-striped table-hover max-width-900">
           <thead>
           <tr>
@@ -61,34 +60,37 @@
                     {{data.message}}<br>
                   {{/if}}
                   {{#if data.forced}}
-                    <span class="text-danger">Forced - unqualified "{{data.forced.message}}"</span><br>
+                    <span class="text-danger">Forced - Unqualified "{{data.forced.message}}"</span><br>
                   {{/if}}
                   {{#if (eq log.action "update")}}
                     {{#if data.review_status}}
-                      Status update {{get data.review_status 0}} &rarr; {{get data.review_status 1}}<br>
+                      <span class="me-2">Status update:</span>
+                      {{get data.review_status 0}} &rarr; {{get data.review_status 1}}<br>
                     {{/if}}
                     {{#if data.position_id}}
-                      Position update {{get (get data.position_id 0) 'title'}} &rarr; {{get (get data.position_id 1)
-                                                                                            'title'}}<br>
+                      <span class="me-2">Position update:</span>
+                      {{get (get data.position_id 0) 'title'}} &rarr; {{get (get data.position_id 1) 'title'}}<br>
                     {{/if}}
                     {{#if data.on_duty}}
-                      On duty update {{shift-format (get data.on_duty 0)}} &rarr; {{shift-format (get data.on_duty 1)}}
-                      <br>
+                      <span class="me-2">On Duty update:</span>
+                      {{shift-format (get data.on_duty 0)}} &rarr; {{shift-format (get data.on_duty 1)}}<br>
                     {{/if}}
                     {{#if data.off_duty}}
-                      Off duty update {{shift-format (get data.off_duty 0)}} &rarr;
-                      {{shift-format (get data.off_duty 1)}}
-                      <br>
+                      <span class="me-2">Off Duty update:</span>
+                      {{shift-format (get data.off_duty 0)}} &rarr; {{shift-format (get data.off_duty 1)}}<br>
                     {{/if}}
                   {{else}}
                     {{#if data.position_title}}
-                      Position {{data.position_title}}<br>
+                      <span class="me-2">Position:</span>
+                      {{data.position_title}}<br>
                     {{/if}}
                     {{#if data.on_duty}}
-                      On duty {{shift-format data.on_duty}}<br>
+                      <span class="me-2">On Duty:</span>
+                      {{shift-format data.on_duty}}<br>
                     {{/if}}
                     {{#if data.off_duty}}
-                      Off duty {{shift-format data.off_duty}}<br>
+                      <span class="me-2">Off Duty:</span>
+                      {{shift-format data.off_duty}}<br>
                     {{/if}}
                   {{/if}}
                   {{#if data.notes}}
@@ -109,8 +111,8 @@
           {{/each}}
           </tbody>
         </table>
-      </:body>
-    </UiSection>
+      </Accordion.body>
+    </UiAccordion>
   {{else}}
     <p>
       <b class="text-danger">
@@ -124,9 +126,9 @@
   {{/each}}
 
   {{#if (gte @year 2018)}}
-    <UiSection>
-      <:title>Other Timesheet Actions</:title>
-      <:body>
+    <UiAccordion as |Accordion|>
+      <Accordion.title>Other Timesheet Actions</Accordion.title>
+      <Accordion.body>
         <table class="table table-sm table-striped table-hover max-width-900">
           <thead>
           <tr>
@@ -145,7 +147,7 @@
               </td>
               <td class="timesheetlog-message">
                 <b>
-                  {{get this.actionLabels log.action}}
+                  {{this.actionLabel log.action}}
                   {{#if log.data.via}}
                     via
                     {{#if (eq log.data.via "bulk-upload")}}
@@ -170,7 +172,7 @@
           {{/each}}
           </tbody>
         </table>
-      </:body>
-    </UiSection>
+      </Accordion.body>
+    </UiAccordion>
   {{/if}}
 {{/if}}

--- a/app/components/schedule-position-list.hbs
+++ b/app/components/schedule-position-list.hbs
@@ -44,7 +44,7 @@
           No other shifts are offered later in the week.
         </p>
         <p>
-          <b class="text-danger">ARRIVE 30 MINUTES EARLY for your Alpha shift. You be turned away if you arrive
+          <b class="text-danger">ARRIVE 30 MINUTES EARLY for your Alpha shift. You will be turned away if you arrive
             after the start time.</b>
         </p>
         <p>

--- a/app/models/timesheet.js
+++ b/app/models/timesheet.js
@@ -70,7 +70,7 @@ export default class TimesheetModel extends Model {
 
   // Timesheet has not been reviewed yet
   get isUnverified() {
-    return (this.off_duty && this.review_status === STATUS_UNVERIFIED);
+    return (this.off_duty && (this.review_status === STATUS_UNVERIFIED || this.review_status === STATUS_APPROVED));
   }
 
 

--- a/app/routes/me/timesheet.js
+++ b/app/routes/me/timesheet.js
@@ -29,6 +29,7 @@ export default class MeTimesheetRoute extends ClubhouseRoute {
 
     data.timesheetSummary = (await this.ajax.request(`person/${person_id}/timesheet-summary`, {data: {year}})).summary;
     data.timesheets = await this.store.query('timesheet', queryParams);
+    data.eventInfo = (await this.ajax.request(`person/${person_id}/event-info`, { data: { year } })).event_info;
 
     data.timecardYearRound = this.session.hasRole(TIMECARD_YEAR_ROUND);
 
@@ -42,7 +43,6 @@ export default class MeTimesheetRoute extends ClubhouseRoute {
       data.positions = (await this.ajax.request(`person/${person_id}/positions`, {data: {include_mentee: 1}})).positions;
 
       if (data.timecardYearRound) {
-        data.eventInfo = (await this.ajax.request(`person/${person_id}/event-info`, { data: { year } })).event_info;
         timesheetInfo.correction_enabled = true;
       }
     } else {
@@ -58,6 +58,7 @@ export default class MeTimesheetRoute extends ClubhouseRoute {
     controller.finalConfirmation = model.timesheetInfo.timesheet_confirmed;
     controller.confirmedAt = model.timesheetInfo.timesheet_confirmed_at;
     controller.isCurrentYear = currentYear() === +model.year;
+    controller.askForFinalConfirmation = (model.eventInfo.event_period !== 'before-event');
   }
 
   resetController(controller, isExiting) {

--- a/app/templates/me/timesheet.hbs
+++ b/app/templates/me/timesheet.hbs
@@ -5,177 +5,182 @@
 <BackToHome/>
 
 {{#if this.correctionsEnabled}}
-    {{#if this.haveOutstandingTasks}}
-        <UiNotice @title="Action required - Timesheet Entry Review" @type="danger" @icon="hand-point-right">
-            <p>
-                Please carefully review your timesheet so the proper credit can be given for{{this.year}} Ranger
-                volunteer work (i.e., ensure you'll receive a ticket and provisions if you worked
-                enough).
-            </p>
-            <p>
-                <b>Missing a timesheet entry?</b> Use the "Missing Requests" tab to submit one or more missing timesheet
-                entry requests.
-            </p>
-            <p>
-                The following are outstanding tasks:
-            </p>
-            <ul>
-                {{#if this.unverifiedCount}}
-                    <li>You need to review {{pluralize this.unverifiedCount "timesheet entry"}}.</li>
-                {{/if}}
-                {{#if this.correctionPendingReviewCount}}
-                    <li>
-                        {{pluralize this.correctionPendingReviewCount "timesheet entry correction request"}}
-                        {{if (eq this.correctionPendingReviewCount 1) "is" "are"}} pending review.
-                    </li>
-                {{/if}}
-                {{#if this.missingPendingReviewCount}}
-                    <li>
-                        {{pluralize this.missingPendingReviewCount "missing timesheet entry request"}}
-                        {{if (eq this.missingPendingReviewCount 1) "is" "are"}} pending review.
-                    </li>
-                {{/if}}
-            </ul>
-            Once the above have been completed, you will need to indicate no more changes will happen
-            with your {{this.year}} timesheet. The "Final Confirmation Needed" notice will appear once all
-            tasks have been completed with a button "Confirm Final Confirmation". Use the button to state no more
-            changes will happen.
-        </UiNotice>
-    {{else if this.finalConfirmation}}
-        <UiNotice @title="Timesheet Review & Final Confirmation Completed"
-                  @icon="thumbs-up"
-                  @type="success">
-            <p>
-                All your timesheet entries have been reviewed, there are no outstanding corrections, and
-                you stated no further corrections will be submitted (aka Final Confirmation).
-            </p>
-            <p>
-                Nothing else need to be done. Thank you for being the awesome Ranger that you are!
-            </p>
-            You may submit additional correction requests, however, you will need to go through the Final Confirmation
-            step again after the requests have been reviewed.
-        </UiNotice>
-    {{else}}
-        <UiNotice @type="danger"
-                  @icon="hand-point-right"
-                  @title="Action Required - Final Confirmation">
-            <p>
-                Please indicate you are done with submitted corrections - aka Final Confirmation. It appears all of your
-                timesheet entries have been verified/corrected and there are no outstanding requests.
-            </p>
-            <UiButton @onClick={{this.showFinalConfirmationAction}}>Confirm Final Confirmation</UiButton>
-        </UiNotice>
-    {{/if}}
+  {{#if this.haveOutstandingTasks}}
+    <UiNotice @title="Action required - Timesheet Entry Review" @type="danger" @icon="hand-point-right">
+      <p>
+        Please carefully review your timesheet so proper credit can be given for {{this.year}} Ranger
+        volunteer work (i.e., ensure you'll receive a ticket and provisions if you worked enough).
+      </p>
+      <p>
+        <b>Missing a timesheet entry?</b> Use the "Missing Requests" tab to submit one or more missing timesheet
+        entry requests.
+      </p>
+      <p>
+        The following are outstanding tasks:
+      </p>
+      <ul>
+        {{#if this.unverifiedCount}}
+          <li>You need to review {{pluralize this.unverifiedCount "timesheet entry"}}.</li>
+        {{/if}}
+        {{#if this.correctionPendingReviewCount}}
+          <li>
+            {{pluralize this.correctionPendingReviewCount "timesheet entry correction request"}}
+            {{if (eq this.correctionPendingReviewCount 1) "is" "are"}} pending review.
+          </li>
+        {{/if}}
+        {{#if this.missingPendingReviewCount}}
+          <li>
+            {{pluralize this.missingPendingReviewCount "missing timesheet entry request"}}
+            {{if (eq this.missingPendingReviewCount 1) "is" "are"}} pending review.
+          </li>
+        {{/if}}
+      </ul>
+      Once the above have been completed, you will need to indicate no more changes will happen
+      with your {{this.year}} timesheet and you are finished working for the year. The "Final Confirmation Needed"
+      notice will appear once all tasks have been completed with a button "Confirm Final Confirmation". Use the button
+      to state no more changes will happen, and you are finished working for the year. Otherwise, the Timesheet
+      Wranglers will reach out post event to ask about your situation.
+    </UiNotice>
+  {{else if this.finalConfirmation}}
+    <UiNotice @title="Timesheet Review & Final Confirmation Completed"
+              @icon="thumbs-up"
+              @type="success">
+      <p>
+        All your timesheet entries have been reviewed, there are no outstanding corrections, you stated no further
+        corrections will be submitted, and you are finished working for the year (aka Final Confirmation).
+      </p>
+      <p>
+        Nothing else need to be done. Thank you for being the awesome Ranger that you are!
+      </p>
+      You may submit additional correction requests, however, you will need to go through the Final Confirmation
+      step again after the requests have been processed.
+    </UiNotice>
+  {{else if this.askForFinalConfirmation}}
+    <UiNotice @type="danger"
+              @icon="hand-point-right"
+              @title="Action Required - Final Confirmation">
+      <p>
+        All of your timesheet entries have been verified/corrected and there are no outstanding requests.
+      </p>
+      <p>
+        If you are finished working for the year, and no further corrections will be submitted, let us know
+        by using the button below. Otherwise, the Timesheet Wranglers will reach out post event to ask about
+        your situation.
+      </p>
+      <UiButton @onClick={{this.showFinalConfirmationAction}}>Confirm Final Confirmation</UiButton>
+    </UiNotice>
+  {{/if}}
 {{else}}
-    Contact
-    <VcEmail/> if you have questions or concerns about your timesheet.
+  Contact
+  <VcEmail/> if you have questions or concerns about your timesheet.
 {{/if}}
 
 <UiTab as |tab|>
-    <tab.pane @title="{{this.year}} Timesheet" @id="entries">
-        <Me::TimesheetReviewCommon @person={{this.person}}
-                                   @timesheets={{this.timesheets}}
-                                   @timesheetInfo={{this.timesheetInfo}}
-                                   @year={{this.year}}
-                                   @onUpdate={{this.onEntryUpdate}}
-                                   @onVerified={{this.onEntryVerify}}
+  <tab.pane @title="{{this.year}} Timesheet" @id="entries">
+    <Me::TimesheetReviewCommon @person={{this.person}}
+                               @timesheets={{this.timesheets}}
+                               @timesheetInfo={{this.timesheetInfo}}
+                               @year={{this.year}}
+                               @onUpdate={{this.onEntryUpdate}}
+                               @onVerified={{this.onEntryVerify}}
+    />
+  </tab.pane>
+  {{#if this.correctionsEnabled}}
+    <tab.pane @title="Missing Requests" @id="missing-requests">
+      <Me::TimesheetMissingCommon @person={{this.person}}
+                                  @timesheetsMissing={{this.timesheetsMissing}}
+                                  @timesheetInfo={{this.timesheetInfo}}
+                                  @positions={{this.positions}}
+      />
+    </tab.pane>
+  {{/if}}
+  <tab.pane @title="{{this.year}} Summary" @id="summary">
+    <TimesheetSummary @summary={{this.timesheetSummary}} />
+    <TimesheetPositionSummary @timesheets={{this.timesheets}} />
+  </tab.pane>
+  <tab.pane @title="Qualifications" @id="progress">
+    <p>
+      This tab shows what tickets and provisions (meals, showers, event radios) you might qualify for.
+    </p>
+    {{#if this.isCurrentYear}}
+      {{#if (eq tab.activeId "progress")}}
+        <PersonTicketProvisionsProgress @person={{this.session.user}} @year={{this.year}} />
+      {{/if}}
+    {{else}}
+      Ticket &amp; Stuff qualification information is only available for the current event.
+    {{/if}}
+  </tab.pane>
+  <tab.pane @title="Work History" @id="work-history">
+    {{#if (eq tab.activeId "work-history")}}
+      <WorkHistory @person={{this.person}} />
+    {{/if}}
+  </tab.pane>
+  {{#if this.timecardYearRound}}
+    <tab.pane @title="Shift Check In/Out" @id="shift">
+      {{#if (is-current-year this.year)}}
+        <ShiftCheckInOut @positions={{this.positions}}
+                         @timesheets={{this.timesheets}}
+                         @person={{this.person}}
+                         @eventInfo={{this.eventInfo}}
+                         @onDutyEntry={{this.onDutyEntry}}
+                         @startShiftNotify={{this.startShiftNotify}}
+                         @endShiftNotify={{this.endShiftNotify}}
+                         @year={{this.year}}
+                         @isSelfServe={{true}}
         />
+      {{else}}
+        Select the current year to start or end a shift
+      {{/if}}
     </tab.pane>
-    {{#if this.correctionsEnabled}}
-        <tab.pane @title="Missing Requests" @id="missing-requests">
-            <Me::TimesheetMissingCommon @person={{this.person}}
-                                        @timesheetsMissing={{this.timesheetsMissing}}
-                                        @timesheetInfo={{this.timesheetInfo}}
-                                        @positions={{this.positions}}
-            />
-        </tab.pane>
-    {{/if}}
-    <tab.pane @title="{{this.year}} Summary" @id="summary">
-        <TimesheetSummary @summary={{this.timesheetSummary}} />
-        <TimesheetPositionSummary @timesheets={{this.timesheets}} />
-    </tab.pane>
-    <tab.pane @title="Qualifications" @id="progress">
-        <p>
-            This tab shows what tickets and provisions (meals, showers, event radios) you might qualify for.
-        </p>
-        {{#if this.isCurrentYear}}
-            {{#if (eq tab.activeId "progress")}}
-                <PersonTicketProvisionsProgress @person={{this.session.user}} @year={{this.year}} />
-            {{/if}}
-        {{else}}
-            Ticket &amp; Stuff qualification information is only available for the current event.
-        {{/if}}
-    </tab.pane>
-    <tab.pane @title="Work History" @id="work-history">
-        {{#if (eq tab.activeId "work-history")}}
-            <WorkHistory @person={{this.person}} />
-        {{/if}}
-    </tab.pane>
-    {{#if this.timecardYearRound}}
-        <tab.pane @title="Shift Check In/Out" @id="shift">
-            {{#if (is-current-year this.year)}}
-                <ShiftCheckInOut @positions={{this.positions}}
-                                 @timesheets={{this.timesheets}}
-                                 @person={{this.person}}
-                                 @eventInfo={{this.eventInfo}}
-                                 @onDutyEntry={{this.onDutyEntry}}
-                                 @startShiftNotify={{this.startShiftNotify}}
-                                 @endShiftNotify={{this.endShiftNotify}}
-                                 @year={{this.year}}
-                                 @isSelfServe={{true}}
-                />
-            {{else}}
-                Select the current year to start or end a shift
-            {{/if}}
-        </tab.pane>
-    {{/if}}
+  {{/if}}
 </UiTab>
 
 {{#if this.showFinalConfirmation}}
-    <ModalDialog @onEscape={{this.cancelFinalConfirmationAction}} as |Modal|>
-        <Modal.title>
-            Final Confirmation Action
-        </Modal.title>
-        <Modal.body>
-            <p>
-                By clicking the "I Agree" button below, you are agreeing to:
-            </p>
-            <ul>
-                <li>All your {{this.timesheetInfo.correction_year}} timesheet entries have been reviewed.</li>
-                <li>All entries are correct.</li>
-                <li>There are no outstanding corrections or missing entry requests waiting for timesheet review.</li>
-                <li>
-                    You do not plan to submit any additional corrections and/or missing entry requests for
-                    your {{this.timesheetInfo.correction_year}} timesheet.
-                </li>
-            </ul>
-        </Modal.body>
-        <Modal.footer>
-            <UiCancelButton @onClick={{this.cancelFinalConfirmationAction}} />
-            <UiButton @onClick={{this.confirmAction}}>I Agree</UiButton>
-        </Modal.footer>
-    </ModalDialog>
+  <ModalDialog @onEscape={{this.cancelFinalConfirmationAction}} as |Modal|>
+    <Modal.title>
+      Final Confirmation Action
+    </Modal.title>
+    <Modal.body>
+      <p>
+        By clicking the "I Agree" button below, you are agreeing to:
+      </p>
+      <ul>
+        <li>All your {{this.timesheetInfo.correction_year}} timesheet entries have been reviewed.</li>
+        <li>All entries are correct.</li>
+        <li>There are no outstanding corrections or missing entry requests waiting for timesheet review.</li>
+        <li>
+          You do not plan to submit any additional corrections and/or missing entry requests for
+          your {{this.timesheetInfo.correction_year}} timesheet.
+        </li>
+        <li>You are finished working for the year.</li>
+      </ul>
+    </Modal.body>
+    <Modal.footer>
+      <UiCancelButton @onClick={{this.cancelFinalConfirmationAction}} />
+      <UiButton @onClick={{this.confirmAction}}>I Agree</UiButton>
+    </Modal.footer>
+  </ModalDialog>
 {{/if}}
 
 {{#if this.askIfDone}}
-    <ModalDialog @onEscape={{this.cancelAskIfDone}} as |Modal|>
-        <Modal.title>
-            No More Outstanding Tasks
-        </Modal.title>
-        <Modal.body>
-            <p>
-                Congratulations! You have marked the last timesheet entry as correct, and there are no pending
-                correction or missing timesheet entry requests. Please confirm no further confirmations will be
-                submitted, and your entire timesheet is correct by the "Confirm Final Confirmation" button.
-            </p>
-            <p>
-                In case you have additional corrections to submit, use the "Cancel" button to clear this dialog,
-                and submit the requests.
-            </p>
-        </Modal.body>
-        <Modal.footer>
-            <UiCancelButton @onClick={{this.cancelAskIfDone}} />
-            <UiButton @onClick={{this.isDoneAction}}>Confirm Final Confirmation</UiButton>
-        </Modal.footer>
-    </ModalDialog>
+  <ModalDialog @onEscape={{this.cancelAskIfDone}} as |Modal|>
+    <Modal.title>
+      No More Outstanding Tasks
+    </Modal.title>
+    <Modal.body>
+      <p>
+        Congratulations! You have marked the last timesheet entry as correct, and there are no pending
+        correction or missing timesheet entry requests. Please confirm no further confirmations will be
+        submitted, and your entire timesheet is correct by the "Confirm Final Confirmation" button.
+      </p>
+      <p>
+        In case you have additional corrections to submit, use the "Cancel" button to clear this dialog,
+        and submit the requests.
+      </p>
+    </Modal.body>
+    <Modal.footer>
+      <UiCancelButton @onClick={{this.cancelAskIfDone}} />
+      <UiButton @onClick={{this.isDoneAction}}>Confirm Final Confirmation</UiButton>
+    </Modal.footer>
+  </ModalDialog>
 {{/if}}


### PR DESCRIPTION
- Fixed a bug where the final confirmation modal would pop up after marking an entry  correct and there's still pending entries.
- Add language the timesheet wranglers may contact you if you don't do the final confirmation thing.
- Also included language about only confirm your timesheet if you are done working.
- Switched over to using accordions for each timesheet audit log group. -