### PR TITLE
Timesheet administration work.

### DIFF
--- a/app/components/datetime-picker.js
+++ b/app/components/datetime-picker.js
@@ -62,7 +62,6 @@ export default class DatetimePickerComponent extends Component {
   blurEvent() {
     later(() => {
       if (document.activeElement !== this.element && document.activeElement.tagName === 'INPUT') {
-        console.log('BLUR ', document.activeElement);
         this.picker?.hide();
       }
     }, 100);

--- a/app/components/me/timesheet-missing-common.hbs
+++ b/app/components/me/timesheet-missing-common.hbs
@@ -3,7 +3,7 @@
   = the shift hours do not count towards provisions and appreciations.
   <div class="timesheet-table">
     <div class="timesheet-row timesheet-header">
-      <div class="timesheet-time">From</div>
+      <div class="timesheet-time">Time</div>
       <div class="timesheet-duration">Duration</div>
       <div class="timesheet-position">Position</div>
     </div>
@@ -11,23 +11,18 @@
       <div class="timesheet-entry">
         <div class="timesheet-row-header {{this.requestClass tsm}}">
           {{#if tsm.isPending}}
-            {{fa-icon "hourglass"}}The request is pending review.
+            {{fa-icon "hourglass" right=1}} The request is pending review.
           {{else}}
             {{#if tsm.isApproved}}
-              {{fa-icon "check"}} The request has been APPROVED. The missing shift has been added to your timesheet.
+              {{fa-icon "check" right=1}} The request has been APPROVED. The missing shift has been added to your
+              timesheet.
             {{else if tsm.isRejected}}
-              {{fa-icon "ban"}} The request has been rejected.
+              {{fa-icon "ban" right=1}} The request has been rejected.
             {{else}}
               Unknown status [{{tsm.review_status}}].
             {{/if}}
           {{/if}}
         </div>
-        {{#if (and tsm.reviewer_notes (or tsm.isApproved tsm.isRejected))}}
-          <div class="timesheet-row-header">
-            <b>Response from the reviewer:</b><br>
-            {{nl2br tsm.reviewer_notes}}
-          </div>
-        {{/if}}
         <div class="timesheet-row">
           <div class="timesheet-time">{{shift-format tsm.on_duty tsm.off_duty}}</div>
           <div class="timesheet-duration">
@@ -35,6 +30,14 @@
           </div>
           <div class="timesheet-position">{{tsm.position.title}}</div>
         </div>
+        {{#if tsm.notes}}
+          <div class="timesheet-row-info">
+            <div class="border p-2 my-2">
+              <h5 class="mx-n2 mt-n2 p-2 bg-secondary text-white">Notes from you &amp; the Timesheet Wranglers</h5>
+              <TimesheetNotes @notes={{tsm.notes}} @isMe={{this.isMe}} />
+            </div>
+          </div>
+        {{/if}}
         <div class="timesheet-actions">
           {{#if (or tsm.isPending tsm.isRejected)}}
             <UiButton @onClick={{fn this.editAction tsm}} @disabled={{or tsm.isReloading tsm.isSaving}}>
@@ -94,7 +97,7 @@
           <f.datetime @name="on_duty"
                       @label="What was the START date & time of the shift?"
                       @size={{15}}
-           />
+          />
           <f.datetime @name="off_duty"
                       @label="What was the END date & time of the shift?"
                       @size={{15}}
@@ -110,11 +113,11 @@
         </FormRow>
         {{#if this.entry.isRejected}}
           <b class="text-danger">Sorry, the correction request has been rejected.</b>
-          <div class="card mb-4">
-            <div class="card-header">The Timesheet Correction Team has left you a note:</div>
-            <div class="card-body">
-              {{this.entry.reviewer_notes}}
-            </div>
+        {{/if}}
+        {{#if this.entry.notes}}
+          <div class="border p-2 my-2">
+            <h5 class="mx-n2 mt-n2 p-2 bg-secondary text-white">Notes from you &amp; the Timesheet Wranglers</h5>
+            <TimesheetNotes @notes={{this.entry.notes}} @isMe={{true}} />
           </div>
         {{/if}}
         <FormRow>

--- a/app/components/me/timesheet-missing-common.js
+++ b/app/components/me/timesheet-missing-common.js
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 import {action, set} from '@ember/object';
 import {validatePresence} from 'ember-changeset-validations/validators';
 import {service} from '@ember/service';
-import {DIRT} from 'clubhouse/constants/positions';
+import {DIRT, TRAINING} from 'clubhouse/constants/positions';
 import validateDateTime from 'clubhouse/validators/datetime';
 import {tracked} from '@glimmer/tracking';
 import _ from 'lodash';
@@ -10,6 +10,7 @@ import _ from 'lodash';
 export default class MeTimesheetMissingCommonComponent extends Component {
   @service house;
   @service modal;
+  @service session;
   @service shiftManage;
   @service store;
   @service toast;
@@ -30,7 +31,7 @@ export default class MeTimesheetMissingCommonComponent extends Component {
   constructor() {
     super(...arguments);
 
-    const positions = this.args.positions.map((p) => [p.title, p.id]);
+    const positions = this.args.positions.filter((p) => p.id !== TRAINING).map((p) => [p.title, p.id]);
     const dirt = positions.find((p) => p[1] === DIRT);
     if (dirt) {
       _.pull(positions, dirt);
@@ -38,6 +39,10 @@ export default class MeTimesheetMissingCommonComponent extends Component {
     }
 
     this.positionOptions = positions;
+  }
+
+  get isMe() {
+    return +this.args.person.id === this.session.userId;
   }
 
   /**
@@ -137,7 +142,7 @@ export default class MeTimesheetMissingCommonComponent extends Component {
     );
   }
 
-   /**
+  /**
    * Helper to color the row header. (aka entry status header)
    *
    * @param {TimesheetMissingModel} ts
@@ -159,5 +164,4 @@ export default class MeTimesheetMissingCommonComponent extends Component {
 
     return ''
   }
-
 }

--- a/app/components/me/timesheet-review-common.hbs
+++ b/app/components/me/timesheet-review-common.hbs
@@ -1,11 +1,7 @@
 <UiSection>
   <:title>
     {{@year}} Timesheet
-    {{#if @isHQView}}
-      for {{@person.callsign}}
-      <HelpPopover @slug="hq-timesheet-entries"/>
-    {{/if}}
-  </:title>
+   </:title>
   <:body>
     {{#if (lt @year 2008)}}
       <p class="text-danger">
@@ -16,9 +12,8 @@
 
     {{#if (and @person.employee_id this.havePaidEntries)}}
       <p>
-        Note: Paid position entries may have a daily hour cap applied before being uploaded to the payroll system. This
-        will
-        not affect the hours and credits applied towards tickets and provisions.
+        Note: Paid position entries may have a daily hour cap applied before being uploaded to the payroll system.
+        This will not affect the hours and credits applied towards tickets and provisions.
       </p>
     {{/if}}
     <NoAppreciateIcon/>
@@ -146,15 +141,9 @@
         </ul>
         {{#if this.entry.isRejected}}
           <UiNotice @type="danger" @icon="times" @title="Correction request has been denied">
-            The response from the timesheet review team:<br>
-            {{nl2br this.entry.reviewer_notes}}
           </UiNotice>
         {{/if}}
 
-        {{#if this.entry.notes}}
-          Your previous message to the timesheet review team:<br>
-          {{nl2br this.entry.notes}}
-        {{/if}}
         <table class="table table-width-auto table-sm">
           <thead>
           <tr>
@@ -173,6 +162,12 @@
           </tr>
           </tbody>
         </table>
+        {{#if this.entry.notes}}
+          <div class="border p-2 my-2">
+            <h5 class="mx-n2 mt-n2 p-2 bg-secondary text-white">Notes from you &amp; the Timesheet Wranglers</h5>
+            <TimesheetNotes @notes={{this.entry.notes}} @isMe={{true}} />
+          </div>
+        {{/if}}
         <FormRow>
           <f.textarea @name="additional_notes"
                       @label={{if this.entry.isRejected "Supply additional information for an appeal:"

--- a/app/components/me/timesheet-review-common.js
+++ b/app/components/me/timesheet-review-common.js
@@ -3,8 +3,7 @@ import {action} from '@ember/object';
 import {tracked} from '@glimmer/tracking';
 import {service} from '@ember/service';
 import {validatePresence} from 'ember-changeset-validations/validators';
-import {isEmpty } from '@ember/utils';
-
+import {isEmpty} from '@ember/utils';
 import {STATUS_PENDING, STATUS_VERIFIED} from "clubhouse/models/timesheet";
 import currentYear from 'clubhouse/utils/current-year';
 

--- a/app/components/person/timesheet-edit-modal.hbs
+++ b/app/components/person/timesheet-edit-modal.hbs
@@ -1,0 +1,191 @@
+<ModalDialog @size="xl" @onEscape={{@cancelEntryAction}} as |Modal|>
+  <Modal.title>Edit Timesheet #{{@entry.id}}</Modal.title>
+  <ChForm @formId="entry" @formFor={{@entry}}
+          @validator={{this.timesheetValidations}}
+          @onSubmit={{@saveEntryAction}}
+          as |f|>
+    <Modal.body>
+      {{#if @entry.stillOnDuty}}
+        <UiNotice @type="danger" @icon="hand" @title="Still On Duty">
+          {{@person.callsign}} is still on duty. Please do not touch the entry until the shift has ended.
+        </UiNotice>
+      {{else if @entry.isPending}}
+        <UiNotice @type="danger" @icon="arrow-right" @title="Correction Request Review Required">
+          Entry has a correction request and needs to be reviewed.
+        </UiNotice>
+      {{else if @entry.isUnverified}}
+        <UiNotice @type="danger" @title="Unverified - No Review Required" @icon="hourglass">
+          No review action required at this time. {{@person.callsign}} needs to verify this entry.
+        </UiNotice>
+      {{else if @entry.isVerified}}
+        <UiNotice @type="success" @icon="check" @title="Entry Verified - No Review Required">
+          Review is not needed at this time.
+          Verified on {{shift-format @entry.verified_at}} by {{@entry.verified_person.callsign}}.
+        </UiNotice>
+      {{else if @entry.isApproved}}
+        <UiNotice @type="danger" @title="Verification Needed - No Review Required" @icon="hourglass">
+          Review is not needed at this time. The correction request was approved.
+          However, the correction still needs to be reviewed by {{@person.callsign}}.
+        </UiNotice>
+      {{/if}}
+
+      <fieldset>
+        <legend>User &amp; Timesheet Wrangler Notes</legend>
+        <TimesheetNotes @notes={{@entry.notes}} @showNoNotesMessage={{true}} />
+        {{#if @canManageTimesheets}}
+          <FormRow>
+            <f.textarea @name="additional_wrangler_notes"
+                        @label="New note to {{@person.callsign}}  (your callsign & the time will automatically be added):"
+                        @cols={{80}}
+                        @rows={{2}}/>
+          </FormRow>
+        {{/if}}
+      </fieldset>
+      {{#if @canManageTimesheets}}
+        <fieldset>
+          <legend>Administration Notes</legend>
+          <TimesheetNotes @notes={{@entry.admin_notes}} @showNoNotesMessage={{true}} />
+          <FormRow>
+            <f.textarea @name="additional_admin_notes"
+                        @label="New admin. note (your callsign & the time will automatically be added):"
+                        @cols={{80}}
+                        @rows={{2}}/>
+          </FormRow>
+        </fieldset>
+      {{/if}}
+      <fieldset>
+        <legend>Time &amp; Position</legend>
+         <div class="my-1">
+          {{#if @entry.slot}}
+            For reference, the scheduled sign-up is:
+            <table class="table table-width-auto my-1">
+              <thead>
+              <tr>
+                <th>Scheduled Time</th>
+                <th>Duration</th>
+                <th>Slot ID</th>
+              </tr>
+              </thead>
+              <tbody>
+              <tr>
+                <td>{{shift-format @entry.slot.begins @entry.slot.ends}}</td>
+                <td>{{hour-minute-words @entry.slot.duration}}</td>
+                <td class="text-end">{{@entry.slot.id}}</td>
+              </tr>
+              </tbody>
+            </table>
+            The actual time worked might be longer or shorter than the scheduled sign-up.
+          {{else}}
+            Entry does not appear to be associated with a scheduled signed-up.
+          {{/if}}
+        </div>
+        {{#if @entry.isTooShort}}
+          <div class="text-danger">
+            Warning: Entry might be too short. Duration is less than 15 minutes.
+          </div>
+        {{else if @entry.isTooLong}}
+          <div class="text-danger">
+            Warning: Entry might be too long. Duration is over 1.5x the scheduled shift of
+            {{hour-minute-words @entry.slot.duration}}.
+          </div>
+        {{/if}}
+
+        {{#if @canManageTimesheets}}
+          <div class="fw-medium">Timesheet Duration {{this.entryDuration f.model}}</div>
+          <FormRow class="mt-2">
+            <f.datetime @name="on_duty"
+                        @label="On Duty"
+                        @size={{20}}
+            />
+            <f.datetime @name="off_duty"
+                        @label="Off Duty"
+                        @size={{20}}
+            />
+            <f.select @name="position_id"
+                      @label="Position"
+                      @options={{@positionOptions}}
+            />
+          </FormRow>
+        {{else}}
+          <table class="table table-width-auto">
+            <thead>
+            <tr>
+              <th>Position</th>
+              <th>Time</th>
+              <th>Duration</th>
+              <th>Credits</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr>
+              <td>
+                {{@entry.position.title}}
+                {{#if @entry.is_non_ranger}}
+                  (as non ranger volunteer)
+                {{/if}}
+              </td>
+              <td>
+                {{shift-format @entry.on_duty @entry.off_duty}}
+              </td>
+              <td>
+                {{hour-minute-words @entry.duration}}
+              </td>
+              <td>
+                {{credits-format @entry.credits}}
+              </td>
+            </tr>
+            </tbody>
+          </table>
+        {{/if}}
+      </fieldset>
+      {{#if @canManageTimesheets}}
+        <fieldset>
+          <legend>Attributes</legend>
+          <FormRow class="mt-3">
+            <div class="col-auto">
+              <f.checkbox @name="is_non_ranger"
+                          @label="Entry is for a dept volunteer (non-ranger status) - time will not count towards service years"/>
+            </div>
+          </FormRow>
+          <FormRow>
+            <div class="col-auto">
+              <f.checkbox @name="suppress_duration_warning"
+                          @label="Supress duration warnings (too short / too long). Duration confirmed correct."/>
+            </div>
+          </FormRow>
+        </fieldset>
+        <fieldset>
+          <legend>Entry Status</legend>
+          <FormRow>
+            <div class="col-auto">
+              <f.radioGroup @name="review_status"
+                            @options={{this.reviewOptions}}
+                            @inline={{true}}
+              />
+            </div>
+          </FormRow>
+        </fieldset>
+      {{else}}
+        <b>Review Status:</b> {{@entry.review_status}}
+      {{/if}}
+    </Modal.body>
+    <Modal.footer @noAlign={{true}}>
+      {{#if @canManageTimesheets}}
+        <f.submit @label="Update" @disabled={{@entry.isSaving}} />
+        <UiCancelButton @disabled={{@entry.isSaving}} @onClick={{@cancelEntryAction}} />
+        {{#if @entry.isSaving}}
+          <LoadingIndicator/>
+        {{/if}}
+        <div class="ms-auto">
+          <UiButton @type="danger"
+                    @onClick={{fn @showDeleteDialogAction f.model}}
+                    @disabled={{@entry.isSaving}}>
+            {{fa-icon "trash"}} Delete
+          </UiButton>
+        </div>
+      {{else}}
+        <UiCancelButton @disabled={{@entry.isSaving}} @onClick={{@cancelEntryAction}} />
+      {{/if}}
+    </Modal.footer>
+  </ChForm>
+</ModalDialog>

--- a/app/components/person/timesheet-edit-modal.js
+++ b/app/components/person/timesheet-edit-modal.js
@@ -1,0 +1,50 @@
+import Component from '@glimmer/component';
+import validateDateTime from "clubhouse/validators/datetime";
+import {validatePresence} from 'ember-changeset-validations/validators';
+import {isEmpty} from '@ember/utils';
+import dayjs from 'dayjs';
+
+export default class PersonTimesheetEditModalComponent extends Component {
+  reviewOptions = [
+    ['Correction approved', 'approved'],
+    ['Correction rejected', 'rejected'],
+    ['Correction requested', 'pending'],
+    ['Entry verified', 'verified'],
+    ['Entry unverified', 'unverified']
+  ];
+
+  timesheetValidations = {
+    on_duty: [validateDateTime({before: 'off_duty'}), validatePresence({presence: true})],
+    off_duty: [validateDateTime({after: 'on_duty'})],
+  };
+
+  /**
+   * Return the duration in hours & minutes. Takes into account invalid or blank dates.
+   *
+   * @param model
+   * @returns {string}
+   */
+
+  entryDuration(model) {
+    if (isEmpty(model.on_duty) || isEmpty(model.off_duty)) {
+      return '-';
+    }
+
+    const start = dayjs(model.on_duty), end = dayjs(model.off_duty);
+    if (!start.isValid() || !end.isValid()) {
+      return '-';
+    }
+
+    const duration = end.diff(start, 's');
+    const minutes = Math.floor((duration / 60) % 60);
+    const hours = Math.floor(duration / 3600);
+
+    let time = `${minutes} min${minutes === 1 ? '' : 's'}`;
+
+    if (hours) {
+      time = `${hours} hour${hours === 1 ? '' : 's'} ${time}`;
+    }
+
+    return time;
+  }
+}

--- a/app/components/person/timesheet-log.hbs
+++ b/app/components/person/timesheet-log.hbs
@@ -101,7 +101,7 @@
                   {{/if}}
                   {{#if data.reviewer_notes}}
                     <div>
-                      Reviewer notes:<br>
+                      Wrangler Notes:<br>
                       {{data.reviewer_notes}}
                     </div>
                   {{/if}}

--- a/app/components/person/timesheet-manage.hbs
+++ b/app/components/person/timesheet-manage.hbs
@@ -1,326 +1,154 @@
-<UiSection>
-  <:title>{{@year}} Timesheet Entries</:title>
-  <:body>
+{{#if this.editEntry}}
+  <Person::TimesheetEditModal @entry={{this.editEntry}}
+                              @person={{@person}}
+                              @saveEntryAction={{this.saveEntryAction}}
+                              @canManageTimesheets={{this.canManageTimesheets}}
+                              @positionOptions={{this.positionOptions}}
+                              @showDeleteDialogAction={{this.showDeleteDialogAction}}
+                              @cancelEntryAction={{this.cancelEntryAction}}
+  />
+{{else}}
+  <UiSection>
+    <:title>{{@year}} Timesheet Entries</:title>
+    <:body>
     <span class="me-2">
     <b>Credits:</b> {{credits-format @timesheetSummary.total_credits}}
     </span>
-    <span class="me-2">
+      <span class="me-2">
     <b>Counted Hours Towards Appreciations:</b>
-      {{hour-minute-format @timesheetSummary.counted_duration}}
+        {{hour-minute-format @timesheetSummary.counted_duration}}
     </span>
-    <b>Total Hours:</b>
-    {{hour-minute-format @timesheetSummary.total_duration}}
-    <div class="d-flex mt-1">
-      <div>
-        <NoAppreciateIcon/>
-        = the shift hours do not count towards provisions and appreciations.
-      </div>
-      {{#if this.hasOverlapping}}
-        <div class="ms-2">
-          {{fa-icon "flag" color="danger"}} = entry's time overlaps with another entry.
+      <b>Total Hours:</b>
+      {{hour-minute-format @timesheetSummary.total_duration}}
+      <div class="d-flex mt-1">
+        <div>
+          <NoAppreciateIcon/>
+          = the shift hours do not count towards provisions and appreciations.
         </div>
-      {{/if}}
-    </div>
-    <table class="table table-hover table-striped table-width-auto">
-      <thead>
-      <tr>
-        <th>&nbsp;</th>
-        <th>Time</th>
-        <th class="text-end">Duration</th>
-        <th class="text-end">Credits</th>
-        <th>Position</th>
-        <th class="text-center">Status</th>
-        <th>Action</th>
-      </tr>
-      </thead>
-      <tbody>
-      {{#each @timesheets key="id" as |ts|}}
-        <tr class="align-middle">
-          <td>
-            {{#if (is-empty ts.off_duty)}}
-              {{fa-icon "person-walking"}}
-            {{else if ts.isVerified}}
-              {{fa-icon "check" color="success"}}
-            {{else if ts.isUnverified}}
-              {{fa-icon "question"}}
-            {{else if ts.isPending}}
-              {{fa-icon "arrow-right" color="danger"}}
-            {{else if ts.isRejected}}
-              {{fa-icon "times"}}
-            {{else if ts.isApproved}}
-              {{fa-icon "thumbs-up" type="far"}}
-            {{else}}
-              &nbsp;
-            {{/if}}
-          </td>
-          <td>
-            {{#if ts.isOverlapping}}
-              {{fa-icon "flag" color="danger"}} &nbsp;
-            {{/if}}
-            {{#if ts.off_duty}}
-              {{shift-format ts.on_duty ts.off_duty}}
-            {{else}}
-              {{shift-format ts.on_duty}}
-            {{/if}}
-            {{#unless ts.suppress_duration_warning}}
-              {{#if ts.isTooShort}}
-                <div class="text-danger">
-                  Entry might be too short.
-                </div>
-              {{else if ts.isTooLong}}
-                <div class="text-danger">
-                  Entry might be too long.
-                </div>
+        {{#if this.hasOverlapping}}
+          <div class="ms-2">
+            {{fa-icon "flag" color="danger"}} = entry's time overlaps with another entry.
+          </div>
+        {{/if}}
+      </div>
+      <table class="table table-hover table-striped table-width-auto">
+        <thead>
+        <tr>
+          <th>&nbsp;</th>
+          <th>Time</th>
+          <th class="text-end">Duration</th>
+          <th class="text-end">Credits</th>
+          <th>Position</th>
+          <th class="text-center">Status</th>
+          <th>Action</th>
+        </tr>
+        </thead>
+        <tbody>
+        {{#each @timesheets key="id" as |ts|}}
+          <tr class="align-middle">
+            <td>
+              {{#if (is-empty ts.off_duty)}}
+                {{fa-icon "person-walking"}}
+              {{else if ts.isVerified}}
+                {{fa-icon "check" color="success"}}
+              {{else if ts.isUnverified}}
+                {{fa-icon "question"}}
+              {{else if ts.isPending}}
+                {{fa-icon "arrow-right" color="danger"}}
+              {{else if ts.isRejected}}
+                {{fa-icon "times"}}
+              {{else if ts.isApproved}}
+                {{fa-icon "thumbs-up" type="far"}}
+              {{else}}
+                &nbsp;
               {{/if}}
-            {{/unless}}
-          </td>
-          <td class="text-end">
-            {{#unless ts.position.count_hours}}
-              <NoAppreciateIcon/>
-            {{/unless}}
-            {{hour-minute-format ts.duration}}
-          </td>
-          <td class="text-end">
-            {{credits-format ts.credits}}
-          </td>
-          <td>
-            {{ts.position.title}}
-            {{#if ts.is_non_ranger}}
-              <br><i>(as non ranger volunteer)</i>
-            {{/if}}
-          </td>
-          <td class="text-center">
-            {{#if (is-empty ts.off_duty)}}
-              {{badge "warning" "Still On Duty"}}
-            {{else if ts.isVerified}}
-              {{badge "success" "Verified"}}
-            {{else if ts.isApproved}}
+            </td>
+            <td>
+              {{#if ts.isOverlapping}}
+                {{fa-icon "flag" color="danger"}} &nbsp;
+              {{/if}}
+              {{#if ts.off_duty}}
+                {{shift-format ts.on_duty ts.off_duty}}
+              {{else}}
+                {{shift-format ts.on_duty}}
+              {{/if}}
+              {{#unless ts.suppress_duration_warning}}
+                {{#if ts.isTooShort}}
+                  <div class="text-danger">
+                    Entry might be too short.
+                  </div>
+                {{else if ts.isTooLong}}
+                  <div class="text-danger">
+                    Entry might be too long.
+                  </div>
+                {{/if}}
+              {{/unless}}
+            </td>
+            <td class="text-end">
+              {{#unless ts.position.count_hours}}
+                <NoAppreciateIcon/>
+              {{/unless}}
+              {{hour-minute-format ts.duration}}
+            </td>
+            <td class="text-end">
+              {{credits-format ts.credits}}
+            </td>
+            <td>
+              {{ts.position.title}}
+              {{#if ts.is_non_ranger}}
+                <br><i>(as non ranger volunteer)</i>
+              {{/if}}
+            </td>
+            <td class="text-center">
+              {{#if (is-empty ts.off_duty)}}
+                {{badge "warning" "Still On Duty"}}
+              {{else if ts.isVerified}}
+                {{badge "success" "Verified"}}
+              {{else if ts.isApproved}}
                 {{badge "success" "Correction Approved"}}<br>
                 {{badge "secondary" "Verification still needed"}}
-            {{else if ts.isUnverified}}
-              {{badge "secondary" "Unverified"}}
-            {{else if ts.isPending}}
-              {{badge "danger" "Correction Requested"}}
-            {{else if ts.isRejected}}
-              {{badge "warning" "Correction Rejected"}}
-             {{else}}
-              &nbsp;
-            {{/if}}
-          </td>
-          <td>
-            {{#if (is-empty ts.off_duty)}}
-              <UiButton @type="danger" @size="sm" @onClick={{fn this.signoffAction ts}}>
-                End Shift
-              </UiButton>
-            {{else}}
-              <UiButton @type={{if ts.isPending "danger" "primary"}}
-                        @size="sm"
-                        @onClick={{fn this.editEntryAction ts}}
-                        @disabled={{ts.isReloading}}>
-                {{#if this.canManageTimesheets}}
-                  {{fa-icon "edit"}} {{if ts.isPending "Review" "Edit"}}
-                {{else}}
-                  {{fa-icon "magnifying-glass"}} View
-                {{/if}}
-              </UiButton>
-            {{/if}}
-            {{#if ts.isReloading}}
-              <SpinIcon/>
-            {{/if}}
-          </td>
-        </tr>
-      {{else}}
-        <tr>
-          <td>&nbsp;</td>
-          <td colspan="6"><b class="mt-2 text-danger">No timesheet entries found for {{@year}}</b></td>
-        </tr>
-      {{/each}}
-      </tbody>
-    </table>
-  </:body>
-</UiSection>
-
-{{#if this.editEntry}}
-  <ModalDialog
-    @title="{{if this.canManageTimesheets "Edit" "View"}} Timesheet #{{this.editEntry.id}}"
-    @onEscape={{this.cancelEntryAction}}
-    as |Modal|>
-    <ChForm @formId="entry" @formFor={{this.editEntry}}
-            @validator={{this.timesheetValidations}}
-            @onSubmit={{this.saveEntryAction}}
-            as |f|>
-      <Modal.body>
-        {{#if this.editEntry.stillOnDuty}}
-          <UiNotice @type="danger" @icon="hand" @title="Still On Duty">
-            {{@person.callsign}} is still on duty. Please do not touch the entry until the shift has ended.
-          </UiNotice>
-        {{else if this.editEntry.isPending}}
-          <UiNotice @type="danger" @icon="arrow-right" @title="Correction Request Review Required">
-            Entry has a correction request and needs to be reviewed.
-          </UiNotice>
-        {{else if this.editEntry.isUnverified}}
-          <UiNotice @type="danger" @title="Unverified - No Review Required" @icon="hourglass">
-            No review action required at this time.
-            Verification required by {{@person.callsign}}.
-          </UiNotice>
-        {{else if this.editEntry.isVerified}}
-          <UiNotice @type="success" @icon="check" @title="Entry Verified - No Review Required">
-            Review is not needed at this time.
-            Entry verified on {{shift-format this.editEntry.verified_at}}
-            by {{this.editEntry.verified_person.callsign}}.
-          </UiNotice>
-        {{else if this.editEntry.isApproved}}
-          <UiNotice @type="danger" @title="Verification Needed - No Review Required" @icon="hourglass">
-            Review is not needed at this time. The correction request was approved.
-            However, the correction still needs to be reviewed by {{@person.callsign}}.
-          </UiNotice>
-        {{/if}}
-
-        <fieldset>
-          <legend>Message(s) from {{@person.callsign}}:</legend>
-          <p>
-            {{#if this.editEntry.notes}}
-              {{nl2br this.editEntry.notes}}
-            {{else}}
-              <i>No notes were given.</i>
-            {{/if}}
-          </p>
-        </fieldset>
-        <fieldset>
-          <legend>Time &amp; Position</legend>
-          <span class="fw-bold me-2">Entry Duration</span> {{this.entryDuration f.model}}
-          {{#if this.editEntry.isTooShort}}
-            <div class="text-danger">
-              Warning: Entry might be too short. Duration is less than 15 minutes.
-            </div>
-          {{else if this.editEntry.isTooLong}}
-            <div class="text-danger">
-              Warning: Entry might be too long. Duration is over 1.5x the scheduled shift of
-              {{hour-minute-words this.editEntry.slot.duration}}.
-            </div>
-          {{/if}}
-          <div class="my-1">
-            {{#if this.editEntry.slot}}
-              For reference, the scheduled sign-up is:
-              <div class="my-1">
-                <b>Time</b> {{shift-format this.editEntry.slot.begins this.editEntry.slot.ends}}.
-                <b>Duration</b> {{hour-minute-words this.editEntry.slot.duration}} (slot #{{this.editEntry.slot.id}}).
-              </div>
-              The actual time worked might be longer or shorter than the scheduled sign-up.
-            {{else}}
-              Entry does not appear to be associated with a scheduled signed-up.
-            {{/if}}
-          </div>
-
-          {{#if this.canManageTimesheets}}
-            <FormRow>
-              <f.datetime @name="on_duty"
-                          @label="On Duty"
-                          @size={{20}}
-              />
-              <f.datetime @name="off_duty"
-                          @label="Off Duty"
-                          @size={{20}}
-              />
-              <f.select @name="position_id"
-                        @label="Position"
-                        @options={{this.positionOptions}}
-              />
-            </FormRow>
-          {{else}}
-            <dl class="row">
-              <dt class="col-2">Position:</dt>
-              <dd class="col-10">
-                {{this.editEntry.position.title}}
-                {{#if this.editEntry.is_non_ranger}}
-                  (as non ranger volunteer)
-                {{/if}}
-              </dd>
-
-              <dt class="col-2">Time:</dt>
-              <dd class="col-10">
-                {{shift-format this.editEntry.on_duty this.editEntry.off_duty}}
-              </dd>
-
-              <dt class="col-2">Duration:</dt>
-              <dd class="col-10">{{hour-minute-format this.editEntry.duration}}</dd>
-
-              <dt class="col-2">Credits:</dt>
-              <dd class="col-10">{{credits-format this.editEntry.credits}}</dd>
-            </dl>
-          {{/if}}
-        </fieldset>
-        {{#if this.canManageTimesheets}}
-          <fieldset>
-            <legend>Attributes</legend>
-            <FormRow class="mt-3">
-              <div class="col-auto">
-                <f.checkbox @name="is_non_ranger"
-                            @label="Entry is for a dept volunteer (non-ranger status) - time will not count towards service years"/>
-              </div>
-            </FormRow>
-            <FormRow>
-              <div class="col-auto">
-                <f.checkbox @name="suppress_duration_warning"
-                            @label="Supress duration warnings (too short / too long). Duration confirmed correct."/>
-              </div>
-            </FormRow>
-          </fieldset>
-        {{/if}}
-        <fieldset>
-          <legend>Reviewer message(s) to {{@person.callsign}}:</legend>
-          <p>
-            {{#if this.editEntry.reviewer_notes}}
-              {{nl2br this.editEntry.reviewer_notes}}
-            {{else}}
-              <i>No reviewer messages have been entered so far.</i>
-            {{/if}}
-          </p>
-          {{#if this.canManageTimesheets}}
-            <FormRow>
-              <f.textarea @name="additional_reviewer_notes"
-                          @label="Reviewer message to {{@person.callsign}}:"
-                          @cols={{80}}
-                          @rows={{2}}/>
-            </FormRow>
-            <FormRow>
-              <f.radioGroup @name="review_status"
-                            @label="Review status:"
-                            @options={{this.reviewOptions}}
-                            @inline={{true}}
-              />
-            </FormRow>
-          {{else}}
-            <dl class="row">
-              <dt class="col-2">
-                Review Status:
-              </dt>
-              <dd class="col-10">
-                {{this.editEntry.review_status}}
-              </dd>
-            </dl>
-          {{/if}}
-        </fieldset>
-      </Modal.body>
-      <Modal.footer @noAlign={{true}}>
-        {{#if this.canManageTimesheets}}
-          <f.submit @label="Update" @disabled={{this.editEntry.isSaving}} />
-          <UiCancelButton @disabled={{this.editEntry.isSaving}} @onClick={{this.cancelEntryAction}} />
-          {{#if this.editEntry.isSaving}}
-            <LoadingIndicator/>
-          {{/if}}
-          <div class="ms-auto">
-            <UiButton @type="danger" @onClick={{fn this.showDeleteDialogAction f.model}}
-                      @disabled={{this.editEntry.isSaving}}>
-              {{fa-icon "trash"}} Delete
-            </UiButton>
-          </div>
+              {{else if ts.isUnverified}}
+                {{badge "secondary" "Unverified"}}
+              {{else if ts.isPending}}
+                {{badge "danger" "Correction Requested"}}
+              {{else if ts.isRejected}}
+                {{badge "warning" "Correction Rejected"}}
+              {{else}}
+                &nbsp;
+              {{/if}}
+            </td>
+            <td>
+              {{#if (is-empty ts.off_duty)}}
+                <UiButton @type="danger" @size="sm" @onClick={{fn this.signoffAction ts}}>
+                  End Shift
+                </UiButton>
+              {{else}}
+                <UiButton @type={{if ts.isPending "danger" "primary"}}
+                          @size="sm"
+                          @onClick={{fn this.editEntryAction ts}}
+                          @disabled={{ts.isReloading}}>
+                  {{#if this.canManageTimesheets}}
+                    {{fa-icon "edit"}} {{if ts.isPending "Review" "Edit"}}
+                  {{else}}
+                    {{fa-icon "magnifying-glass"}} View
+                  {{/if}}
+                </UiButton>
+              {{/if}}
+              {{#if ts.isReloading}}
+                <SpinIcon/>
+              {{/if}}
+            </td>
+          </tr>
         {{else}}
-          <UiCloseButton @onClick={{this.cancelEntryAction}} />
-        {{/if}}
-      </Modal.footer>
-    </ChForm>
-  </ModalDialog>
+          <tr>
+            <td>&nbsp;</td>
+            <td colspan="6"><b class="mt-2 text-danger">No timesheet entries found for {{@year}}</b></td>
+          </tr>
+        {{/each}}
+        </tbody>
+      </table>
+    </:body>
+  </UiSection>
 {{/if}}
 
 {{#if this.deleteEntry}}

--- a/app/components/person/timesheet-missing.hbs
+++ b/app/components/person/timesheet-missing.hbs
@@ -85,38 +85,65 @@
             @validator={{this.newEntryValidations}}
             @onSubmit={{this.createEntryAction}} as |f|>
       <Modal.body>
-        <FormRow>
-          <f.datetime @name="on_duty"
-                      @label="On Duty"
-          />
-          <f.datetime @name="off_duty"
-                      @label="Off Duty"
-          />
-          <f.select @name="position_id"
-                    @label="Position"
-                    @options={{@positions}}/>
-        </FormRow>
-        <FormRow>
-          <f.text @name="partner"
-                  @label="Partner(s) for shift."
-                  @size={{40}}
-                  @maxlength={{60}}/>
-        </FormRow>
-        <FormRow>
-          <f.textarea @name="additional_notes"
-                      @label="Requester note FROM {{@person.callsign}}"
-                      @cols={{80}}
-                      @rows={{4}}
-                      @options={{@positions}} />
-        </FormRow>
-        {{#if this.hasTimesheetManagement}}
+        <fieldset>
+          <legend>Time &amp; Position w/Partners</legend>
           <FormRow>
-            <f.textarea @name="additional_reviewer_notes"
-                        @label="Reviewer note TO {{@person.callsign}}"
-                        @cols={{80}}
-                        @rows={{4}}
-                        @options={{@positions}} />
+            <f.datetime @name="on_duty"
+                        @label="On Duty"
+            />
+            <f.datetime @name="off_duty"
+                        @label="Off Duty"
+            />
+            <f.select @name="position_id"
+                      @label="Position"
+                      @options={{@positions}}/>
           </FormRow>
+          <FormRow>
+            <f.text @name="partner"
+                    @label="Partner(s) for shift."
+                    @size={{40}}
+                    @maxlength={{60}}/>
+          </FormRow>
+        </fieldset>
+        <fieldset>
+          <legend>User Notes</legend>
+          <FormRow>
+            <f.textarea @name="additional_notes"
+                        @label="Note to submit on behalf of {{@person.callsign}} (your callsign & the time will automatically be added):"
+                        @cols={{80}}
+                        @rows={{2}}/>
+          </FormRow>
+        </fieldset>
+        {{#if this.hasTimesheetManagement}}
+          <fieldset>
+            <legend>Timesheet Wrangler Notes</legend>
+            <FormRow>
+              <f.textarea @name="additional_wrangler_notes"
+                          @label="New note to {{@person.callsign}}  (your callsign & the time will automatically be added):"
+                          @cols={{80}}
+                          @rows={{2}}/>
+            </FormRow>
+            <FormRow>
+              <f.textarea @name="additional_admin_notes"
+                          @label="New admin. note (your callsign & the time will automatically be added):"
+                          @cols={{80}}
+                          @rows={{2}}/>
+            </FormRow>
+            <FormRow>
+              <f.radioGroup @name="review_status"
+                            @label="Correction Status:"
+                            @options={{this.reviewOptions}}
+                            @inline={{true}}
+                            @onChange={{this.statusChangeAction}} />
+            </FormRow>
+            <FormRow>
+              <div class="col-auto">
+                <f.checkbox @name="create_entry"
+                            @label="Create new entry (requires request be approved first)"
+                            @disabled={{not-eq f.model.review_status "approved"}}/>
+              </div>
+            </FormRow>
+          </fieldset>
         {{/if}}
       </Modal.body>
       <Modal.footer @noAlign={{true}}>
@@ -147,60 +174,62 @@
             Request was rejected. Review is not needed at this time.
           </UiNotice>
         {{/if}}
-        <dl class="row">
-          <dt class="col-2">Position:</dt>
-          <dd class="col-10">{{this.editEntry.position.title}}</dd>
-
-          <dt class="col-2">Time:</dt>
-          <dd class="col-10">{{shift-format this.editEntry.on_duty}} - {{shift-format this.editEntry.off_duty}}</dd>
-
-          <dt class="col-2">Duration:</dt>
-          <dd class="col-10">{{hour-minute-format this.editEntry.duration}}</dd>
-
-          <dt class="col-2">Credits:</dt>
-          <dd class="col-10">{{credits-format this.editEntry.credits}}</dd>
-          <dt class="col-2">Partner(s):</dt>
-          <dd class="col-10">
-            {{#if (and this.editEntry.partner this.editEntry.partner_info)}}
-              <table class="table table-sm table-striped">
-                <thead>
-                <tr>
-                  <th>Partner</th>
-                  <th>Time</th>
-                  <th>Position</th>
-                  <th>Action</th>
-                </tr>
-                </thead>
-                <tbody>
-                {{#each this.partnerInfo as |pi|}}
-                  <tr>
-                    <td>{{pi.callsign}}</td>
-                    {{#if pi.on_duty}}
-                      <td>{{shift-format pi.on_duty pi.off_duty}}</td>
-                      <td>{{pi.position_title}}</td>
-                    {{else if pi.person_id}}
-                      <td colspan="2" class="text-danger">
-                        no partner shift found within 30 mins of {{shift-format this.editEntry.on_duty}}
-                      </td>
-                    {{else}}
-                      <td colspan="{{if pi.person_pi 3 4}}" class="text-danger">callsign not found</td>
-                    {{/if}}
-                    {{#if pi.person_id}}
-                      <td>
-                        <UiButton @type="secondary" @size="sm" @onClick={{fn this.viewPartnerTimesheetAction pi}}>
-                          View Timesheet
-                        </UiButton>
-                      </td>
-                    {{/if}}
-                  </tr>
-                {{/each}}
-                </tbody>
-              </table>
-            {{else}}
-              <i>No partner name given</i>
-            {{/if}}
-          </dd>
-        </dl>
+        <table class="table table-width-auto">
+          <thead>
+          <tr>
+            <th>Position</th>
+            <th>Time</th>
+            <th>Duration</th>
+            <th>Credits</th>
+          </tr>
+          </thead>
+          <tbody>
+          <tr>
+            <td>{{this.editEntry.position.title}}</td>
+            <td>{{shift-format this.editEntry.on_duty this.editEntry.off_duty}}</td>
+            <td>{{hour-minute-words this.editEntry.duration}}</td>
+            <td class="text-end">{{credits-format this.editEntry.credits}}</td>
+          </tr>
+          </tbody>
+        </table>
+        {{#if (and this.editEntry.partner this.editEntry.partner_info)}}
+          <table class="table table-sm table-striped">
+            <thead>
+            <tr>
+              <th>Partner</th>
+              <th>Time</th>
+              <th>Position</th>
+              <th>Action</th>
+            </tr>
+            </thead>
+            <tbody>
+            {{#each this.partnerInfo as |pi|}}
+              <tr>
+                <td>{{pi.callsign}}</td>
+                {{#if pi.on_duty}}
+                  <td>{{shift-format pi.on_duty pi.off_duty}}</td>
+                  <td>{{pi.position_title}}</td>
+                {{else if pi.person_id}}
+                  <td colspan="2" class="text-danger">
+                    no partner shift found within 30 mins of {{shift-format this.editEntry.on_duty}}
+                  </td>
+                {{else}}
+                  <td colspan="{{if pi.person_pi 3 4}}" class="text-danger">callsign not found</td>
+                {{/if}}
+                {{#if pi.person_id}}
+                  <td>
+                    <UiButton @type="secondary" @size="sm" @onClick={{fn this.viewPartnerTimesheetAction pi}}>
+                      View Timesheet
+                    </UiButton>
+                  </td>
+                {{/if}}
+              </tr>
+            {{/each}}
+            </tbody>
+          </table>
+        {{else}}
+          <i>No partner name given</i>
+        {{/if}}
         {{#if this.havePartnerTimesheet}}
           <fieldset>
             <legend>Timesheet for {{this.partnerCallsign}} </legend>
@@ -239,35 +268,28 @@
           </fieldset>
         {{/if}}
         <fieldset>
-          <legend>Message from {{@person.callsign}}</legend>
-          {{#if this.editEntry.notes}}
-            {{nl2br this.editEntry.notes}}
-          {{else}}
-            <i>No notes or messages from {{@person.callsign}} about this request?!?</i>
+          <legend>User &amp; Timesheet Wrangler Notes</legend>
+          <TimesheetNotes @notes={{this.editEntry.notes}} @showNoNotesMessage={{true}} />
+          {{#if this.canManageTimesheets}}
+            <FormRow>
+              <f.textarea @name="additional_wrangler_notes"
+                          @label="New note to {{@person.callsign}}  (your callsign & the time will automatically be added):"
+                          @cols={{80}}
+                          @rows={{2}}/>
+            </FormRow>
           {{/if}}
         </fieldset>
         <fieldset>
-          <legend>Submission Review</legend>
-          <div class="mb-2">
-            {{#if this.editEntry.reviewer_notes}}
-              {{nl2br this.editEntry.reviewer_notes}}
-            {{else}}
-              <i>No reviewer notes have been left yet.</i>
-            {{/if}}
-            {{#if this.editEntry.reviewed_at}}
-              <FormRow>
-                Last review on {{shift-format this.editEntry.reviewed_at}}
-                by {{this.editEntry.reviewer_person.callsign}}
-              </FormRow>
-            {{/if}}
-          </div>
-          <FormRow>
-            <f.textarea @name="additional_reviewer_notes"
-                        @label="Enter your response to {{@person.callsign}} below. Be clear and concise."
-                        @hint="A timestamp and your callsign will automatically be added."
-                        @cols={{80}}
-                        @rows={{4}}/>
-          </FormRow>
+          <legend>Administration Notes</legend>
+          <TimesheetNotes @notes={{this.editEntry.admin_notes}} @showNoNotesMessage={{true}}  />
+          {{#if this.canManageTimesheets}}
+            <FormRow>
+              <f.textarea @name="additional_admin_notes"
+                          @label="New admin. note (your callsign & the time will automatically be added):"
+                          @cols={{80}}
+                          @rows={{2}}/>
+            </FormRow>
+          {{/if}}
           <FormRow>
             <f.radioGroup @name="review_status"
                           @label="Correction Status:"
@@ -327,42 +349,30 @@
   <ModalDialog @title="Missing Timesheet Request ID #{{this.viewEntry.id}}"
                @onEscape={{this.closeViewEntry}} as |Modal|>
     <Modal.body>
-      <dl class="row">
-        <dt class="col-2">Position:</dt>
-        <dd class="col-10">{{this.viewEntry.position.title}}</dd>
-
-        <dt class="col-2">Time:</dt>
-        <dd class="col-10">{{shift-format this.viewEntry.on_duty this.viewEntry.off_duty}}</dd>
-
-        <dt class="col-2">Duration:</dt>
-        <dd class="col-10">{{hour-minute-format this.viewEntry.duration}}</dd>
-
-        <dt class="col-2">Credits:</dt>
-        <dd class="col-10">{{credits-format this.viewEntry.credits}}</dd>
-        <dt class="col-2">Partner(s):</dt>
-        <dd class="col-10">{{or this.viewEntry.partner "-"}}</dd>
-      </dl>
-      <p>
-        <b>Requester notes FROM {{@person.callsign}}</b><br>
-        {{#if this.viewEntry.notes}}
-          {{nl2br this.viewEntry.notes}}
-        {{else}}
-          <i>No notes or messages from {{@person.callsign}} about this request?!?</i>
-        {{/if}}
-      </p>
-      <p>
-        <b>Reviewer notes TO {{@person.callsign}}</b><br>
-        {{#if this.viewEntry.reviewer_notes}}
-          {{nl2br this.viewEntry.reviewer_notes}}
-        {{else}}
-          <i>No reviewer notes have been left yet.</i>
-        {{/if}}
-        {{#if this.viewEntry.reviewed_at}}
-          <br>
-          Last review on {{shift-format this.viewEntry.reviewed_at}}
-          by {{this.viewEntry.reviewer_person.callsign}}
-        {{/if}}
-      </p>
+      <table class="table table-width-auto">
+        <thead>
+        <tr>
+          <th>Position</th>
+          <th>Time</th>
+          <th>Duration</th>
+          <th>Credits</th>
+          <th>Partners(s)</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr>
+          <td>{{this.viewEntry.position.title}}</td>
+          <td>{{shift-format this.viewEntry.on_duty this.viewEntry.off_duty}}</td>
+          <td>{{hour-minute-words this.viewEntry.duration}}</td>
+          <td>{{credits-format this.viewEntry.credits}}</td>
+          <td>{{or this.viewEntry.partner "-"}}</td>
+        </tr>
+        </tbody>
+      </table>
+      <fieldset>
+        <legend>User &amp; Timesheet Wranglers Notes</legend>
+        <TimesheetNotes @notes={{this.viewEntry.notes}} @showNoNotesMessage={{true}} />
+      </fieldset>
     </Modal.body>
     <Modal.footer>
       <UiCloseButton @onClick={{this.closeViewEntry}} />

--- a/app/components/shift-check-in-out.js
+++ b/app/components/shift-check-in-out.js
@@ -46,7 +46,7 @@ export default class ShiftCheckInOutComponent extends Component {
 
     const {positions} = this.args;
 
-    this.noTrainingRequiredPositions = positions.filter((p) => p.no_training_required);
+    this.noTrainingRequiredPositions = positions.filter((p) => (p.no_training_required && p.id !== TRAINING));
     if (this.noTrainingRequiredPositions.length && this.args.isSelfServe) {
       this.activePositions = this.noTrainingRequiredPositions;
     } else {

--- a/app/components/timesheet-notes.hbs
+++ b/app/components/timesheet-notes.hbs
@@ -1,0 +1,14 @@
+{{#each @notes as |row|}}
+  <div class="mb-2">
+    <div class="mb-1 fw-medium">
+      {{shift-format row.created_at}} {{this.fromLabel row}}:
+    </div>
+    {{nl2br row.note}}
+  </div>
+{{else}}
+  {{#if @showNoNotesMessage}}
+    <div class="mb-2">
+      <i>No notes have been entered</i>
+    </div>
+  {{/if}}
+{{/each}}

--- a/app/components/timesheet-notes.js
+++ b/app/components/timesheet-notes.js
@@ -1,0 +1,33 @@
+import Component from '@glimmer/component';
+import {
+  NOTE_TYPE_ADMIN,
+  NOTE_TYPE_HQ_WORKER,
+  NOTE_TYPE_USER,
+  NOTE_TYPE_WRANGLER,
+  NoteTypeLabels
+} from "clubhouse/models/timesheet";
+import {action} from '@ember/object';
+
+export default class TimesheetNotesComponent extends Component {
+  @action
+  fromLabel(row) {
+    const type = row.type, callsign = row.create_person.callsign;
+
+    if (this.args.isMe) {
+      switch (type) {
+        case NOTE_TYPE_USER:
+          return 'from you';
+        case NOTE_TYPE_HQ_WORKER:
+          return `submitted for you by HQ Worker ${callsign}`;
+        case NOTE_TYPE_WRANGLER:
+          return `from Timesheet Wrangler ${callsign}`;
+      }
+    }
+
+    if (type === NOTE_TYPE_USER || type === NOTE_TYPE_ADMIN) {
+      return callsign;
+    }
+
+    return `${NoteTypeLabels[type] ?? type} ${callsign}`;
+  }
+}

--- a/app/models/timesheet-missing.js
+++ b/app/models/timesheet-missing.js
@@ -1,40 +1,47 @@
-import Model, { attr } from '@ember-data/model';
+import Model, {attr} from '@ember-data/model';
+
+export const APPROVED = 'approved';
+export const REJECTED = 'rejected';
+export const PENDING = 'pending';
 
 export default class TimesheetMissingModel extends Model {
   @attr('number') person_id;
   @attr('number') position_id;
   @attr('shiftdate') off_duty;
   @attr('shiftdate') on_duty;
-  @attr('string', { readOnly: true}) notes;
-  @attr('string') additional_notes;
-
   @attr('string') partner;
-
   @attr('string') review_status;
-  @attr('string', { readOnly: true }) reviewer_notes;
-  @attr('string') additional_reviewer_notes;
-
-  @attr('number', { readOnly: true }) duration;
-  @attr('', { readOnly: true}) position;
-  @attr('', { readOnly: true}) reviewer_person;
-  @attr('number', { readOnly: true }) credits;
-
-  @attr('', { readOnly: true }) partner_info;
 
   @attr('boolean') create_entry;
   @attr('shiftdate') new_on_duty;
   @attr('shiftdate') new_off_duty;
   @attr('number') new_position_id;
 
+  @attr('', {readOnly: true}) admin_notes;
+  @attr('', {readOnly: true}) notes;
+
+  // Pseudo fields -- use to construct the timesheet notes.
+  @attr('string') additional_notes;
+  @attr('string') additional_admin_notes;
+  @attr('string') additional_wrangler_notes;
+  @attr('string') additional_worker_notes;
+
+  @attr('number', {readOnly: true}) duration;
+  @attr('', {readOnly: true}) position;
+  @attr('', {readOnly: true}) reviewer_person;
+  @attr('number', {readOnly: true}) credits;
+
+  @attr('', {readOnly: true}) partner_info;
+
   get isPending() {
-    return this.review_status === 'pending';
+    return this.review_status === PENDING;
   }
 
   get isApproved() {
-    return this.review_status === 'approved';
+    return this.review_status === APPROVED;
   }
 
   get isRejected() {
-    return this.review_status === 'rejected';
+    return this.review_status === REJECTED;
   }
 }

--- a/app/models/timesheet.js
+++ b/app/models/timesheet.js
@@ -1,5 +1,4 @@
 import Model, {attr} from '@ember-data/model';
-import {isEmpty} from '@ember/utils';
 import {tracked} from '@glimmer/tracking';
 import dayjs from 'dayjs';
 
@@ -9,7 +8,19 @@ export const STATUS_REJECTED = 'rejected';
 export const STATUS_VERIFIED = 'verified';
 export const STATUS_UNVERIFIED = 'unverified';
 
+export const NOTE_TYPE_USER = 'user';
+export const NOTE_TYPE_HQ_WORKER = 'hq-worker';
+export const NOTE_TYPE_WRANGLER = 'wrangler';
+export const NOTE_TYPE_ADMIN = 'admin';
+
 export const TOO_SHORT_DURATION = (15 * 60);
+
+export const NoteTypeLabels = {
+  [NOTE_TYPE_USER]: 'User',
+  [NOTE_TYPE_HQ_WORKER]: 'HQ Worker',
+  [NOTE_TYPE_WRANGLER]: 'Timesheet Wrangler',
+  [NOTE_TYPE_ADMIN]: 'Admin',
+};
 
 export default class TimesheetModel extends Model {
   @attr('number') person_id;
@@ -24,10 +35,14 @@ export default class TimesheetModel extends Model {
   @attr('number', {readOnly: true}) duration;
   @attr('number', {readOnly: true}) credits;
 
-  @attr('string', {readOnly: true}) notes;
+  @attr('', {readOnly: true}) admin_notes;
+  @attr('', {readOnly: true}) notes;
+
+  // Pseudo fields -- use to construct the timesheet notes.
   @attr('string') additional_notes;
-  @attr('string', {readOnly: true}) reviewer_notes;
-  @attr('string') additional_reviewer_notes;
+  @attr('string') additional_admin_notes;
+  @attr('string') additional_wrangler_notes;
+  @attr('string') additional_worker_notes;
 
   @attr('', {readOnly: true}) verified_person;
 
@@ -71,11 +86,6 @@ export default class TimesheetModel extends Model {
   // Timesheet has not been reviewed yet
   get isUnverified() {
     return (this.off_duty && this.review_status === STATUS_UNVERIFIED);
-  }
-
-
-  get haveReviewerResponse() {
-    return this.review_status !== STATUS_UNVERIFIED && !isEmpty(this.reviewer_notes);
   }
 
   get stillOnDuty() {

--- a/app/routes/person/timesheet.js
+++ b/app/routes/person/timesheet.js
@@ -1,6 +1,8 @@
 import ClubhouseRoute from 'clubhouse/routes/clubhouse-route';
 import RSVP from 'rsvp';
 import requestYear from 'clubhouse/utils/request-year';
+import {ADMIN, TIMESHEET_MANAGEMENT} from "clubhouse/constants/roles";
+import {TRAINING} from "clubhouse/constants/positions";
 
 export default class PersonTimesheetRoute extends ClubhouseRoute {
   queryParams = {
@@ -18,14 +20,18 @@ export default class PersonTimesheetRoute extends ClubhouseRoute {
     this.store.unloadAll('timesheet');
     this.store.unloadAll('timesheet-missing');
 
+    const timesheetQuery = { person_id, year };
+    if (this.session.hasRole([ ADMIN, TIMESHEET_MANAGEMENT])) {
+      timesheetQuery.include_admin_notes = 1;
+    }
     return RSVP.hash({
       year: year,
-      timesheets: this.store.query('timesheet', queryParams),
+      timesheets: this.store.query('timesheet', timesheetQuery),
       timesheetInfo: this.ajax.request('timesheet/info', { data: { person_id } })
         .then((result) => result.info),
       timesheetMissing: this.store.query('timesheet-missing', queryParams),
       positions: this.ajax.request(`person/${person_id}/positions`,{ data: { include_mentee: 1, include_training: 1, year } })
-        .then((results) => results.positions),
+        .then((results) => results.positions.filter((p) => p.id !== TRAINING)),
       timesheetSummary: this.ajax.request(`person/${person_id}/timesheet-summary`, { data: { year }})
         .then((result) => result.summary),
       eventInfo: this.ajax.request(`person/${person_id}/event-info`, { data: { year } })

--- a/app/styles/timesheet.scss
+++ b/app/styles/timesheet.scss
@@ -48,7 +48,6 @@
   width: 100%;
   margin: -0.125rem -0.25rem;
   padding: 0.125rem 0.25rem;
-
 }
 
 .timesheet-row-header {
@@ -79,7 +78,7 @@
   }
 
   .timesheet-row-header {
-    font-size: 1.1em;
+    font-size: 1em;
   }
 
   .timesheet-row > div {

--- a/app/templates/person/timesheet.hbs
+++ b/app/templates/person/timesheet.hbs
@@ -6,7 +6,7 @@
 <UiTab class="mt-4" as |tab|>
   <tab.pane @title="Timesheet / Missing Entry Requests" @id="timesheet">
     {{#if (or this.timesheetPendingCount this.missingRequestPendingCount)}}
-      <UiNotice @title="Timesheet Entry Review Needed" @icon="arrow-right">
+      <UiNotice @title="Timesheet Wrangler Review Needed" @icon="arrow-right">
         {{#if this.timesheetPendingCount}}
           {{pluralize this.timesheetPendingCount "timesheet entry"}} requires correction review.<br>
         {{/if}}


### PR DESCRIPTION
- Split out notes into four types: 1) from the user, 2) from the HQ worker, 3) the timesheet wrangler, and 4) (private) administration notes.
- Perform an overlapping entry check when creating a new timesheet, or updating an existing one.
- Minor layout cleanup on the me/timesheet pages.
- Do not present Training as a position option for timesheets and shift check-ins.