### PR TITLE
Sort the training sessions based on if the session is past the day it…

### DIFF
--- a/app/routes/training/index.js
+++ b/app/routes/training/index.js
@@ -34,8 +34,8 @@ export default class TrainingIndexRoute extends ClubhouseRoute {
     });
 
 
-    controller.set('upcomingSessions', trainingSessions.filter((t) => (!t.slot.has_started || !t.slot.has_ended)));
-    controller.set('pastSessions', trainingSessions.filter((t) => t.slot.has_ended));
+    controller.set('upcomingSessions', trainingSessions.filter((t) => (!t.slot.has_started || !t.slot.has_day_ended)));
+    controller.set('pastSessions', trainingSessions.filter((t) => t.slot.has_day_ended));
   }
 
   // Don't allow the year parameter to bleed over to other routes.


### PR DESCRIPTION
… ends on, not absolute time.

e.g., if the training slot ends on May 1st @ 16:45, it will be moved to the Past Sessions section on May 2nd @ midnight. Check is relative to the timezone it occurs in.