### PR TITLE
Various UI tweaks

### DIFF
--- a/app/components/position-edit.hbs
+++ b/app/components/position-edit.hbs
@@ -53,26 +53,21 @@
 
   <fieldset>
     <legend>Active &amp; Grant Flags</legend>
+    <UiAlert @type="warning" @icon="hand-point-right">
+      The "Position Sanity Checker" has be run after deactivating a position, setting <i>All Rangers</i>, and/or
+      checking <i>Grant to new Prospective accounts</i> in order to adjust the effected accounts. No accounts
+      will be automatically updated after adjusting these checkboxes.
+    </UiAlert>
     <p class="text-danger">
-      The "Position Sanity Checker" needs be run after deactivating a position in order to revoke the position
-      from all accounts. Revocation is not automatic.
     </p>
     <FormRow>
       <div class="col-12">
         <f.checkbox @name="active" @label="Active"/>
       </div>
-    </FormRow>
-    <p class="text-danger">
-      After setting the <i>"All Rangers"</i> and/or <i>"Grant to new Prospective accounts"</i> flags,
-      the maintenance "Set Ranger Positions" function has to be run to grant the position to existing accounts.
-    </p>
-    <FormRow>
       <div class="col-12">
         <f.checkbox @name="all_rangers"
                     @label="Grant to All Rangers (status active / inactive / inactive extension / retired)"/>
       </div>
-    </FormRow>
-    <FormRow>
       <div class="col-12">
         <f.checkbox @name="new_user_eligible"
                     @label="Grant to new accounts (Rangers, Applications, etc)"/>
@@ -81,10 +76,10 @@
   </fieldset>
   <fieldset>
     <legend>Team &amp; Team Position Flags</legend>
-    <p class="text-danger">
+    <UiAlert @type="warning" @icon="hand-point-right">
       After adjusting the team position category, run the Position Sanity Checker to bulk grant or revoke the
       team positions to team members.
-    </p>
+    </UiAlert>
     <FormRow>
       <f.select @name="team_id"
                 @label="Belongs To Team"
@@ -118,17 +113,20 @@
         <f.checkbox @name="on_trainer_report"
                     @label="For the Trainer's Report: indicates the position is relevant to trainers"/>
         <f.checkbox @name="no_training_required"
-                    @label="In-Person training not required to check-in for this position"/>
+                    @label="In-Person training not required to check-in for this position (note, all positions with type Training automatically do not require passing an In-Person training) "/>
       </div>
     </FormRow>
   </fieldset>
 
   <fieldset>
     <legend>Position Role Grants</legend>
+    <p>
+      Adjustments to role associations will take immediate effect upon pushing the Save button.
+    </p>
     <FormRow>
       <div class="col-12">
         <f.checkbox @name="require_training_for_roles"
-                    @label="ART training must be passed before roles are assigned"/>
+                    @label="ART training must be passed each year before roles are granted"/>
       </div>
     </FormRow>
     <FormRow>
@@ -153,26 +151,31 @@
     </fieldset>
   {{/unless}}
   <fieldset>
-    <legend>Misc.</legend>
+    <legend>Driving</legend>
     <FormRow>
-      <div class="col-auto">
+      <div class="col-12">
         <f.checkbox @name="mvr_eligible"
                     @inline={{true}}
                     @label="The person will become MVR eligible when granted the position AND signs up for a shift"
         />
       </div>
-    </FormRow>
-    <FormRow>
-      <div class="col-auto">
+      <div class="col-12">
         <f.checkbox @name="pvr_eligible"
                     @inline={{true}}
                     @label="The person will become Personal Vehicle Request eligible when granted the position AND signs up for a shift"
         />
       </div>
     </FormRow>
+  </fieldset>
+  <fieldset>
+    <legend>Payroll</legend>
+    <p>
+      Any position with a paycode will appear in the Payroll interface, and all timesheet entries will
+      have a paid position indicator.
+    </p>
     <FormRow class="align-items-end">
-      <f.text @name="paycode" @label="Paycom employee code" @size={{20}} @maxlength={{20}} />
-      <div class="col-auto">
+      <f.text @name="paycode" @label="Paycom employee code" @size={{20}} @maxlength={{20}} @inline={{true}} />
+      <div class="col-auto align-self-center">
         <f.checkbox @name="no_payroll_hours_adjustment"
                     @label="Hours will not be adjusted during payroll export"/>
       </div>
@@ -183,17 +186,20 @@
     <legend>Auto Sign Out</legend>
     A timesheet entry can be automatically signed out of when the hour cap is reached. A note will be left in
     the timesheet audit trail, and an email sent to the contact email (set below).
-    <FormRow class="align-items-end">
-      <div class="col-auto align-self-center">
+    <FormRow>
+      <div class="col-auto">
         <f.checkbox @label="Auto sign out timesheet"
                     @name="auto_sign_out"
         />
       </div>
+    </FormRow>
+    <FormRow>
       <f.number @label="Hours Cap"
                 @name="sign_out_hour_cap"
                 @size={{10}}
                 @maxlength={{10}}
-                @hint="Partial hours are supported. (e.g., 10.5, 5.3, etc.)"
+                @hint="Fractional hours are supported. (e.g., 10.5, 6.3, etc.)"
+                @inline={{true}}
                 @disabled={{not f.model.auto_sign_out}}
       />
     </FormRow>

--- a/app/controllers/admin/teams.js
+++ b/app/controllers/admin/teams.js
@@ -22,8 +22,10 @@ export default class AdminTeamsController extends ClubhouseController {
 
   mvrEligibleOptions = [
     {id: 'all', title: 'All'},
-    {id: 'eligible', title: 'Eligible'},
-    {id: 'ineligible', title: 'Ineligible'},
+    {id: 'mvr-eligible', title: 'MVR Eligible'},
+    {id: 'mvr-ineligible', title: 'MVR Ineligible'},
+    {id: 'pvr-eligible', title: 'Personal Vehicle Eligible'},
+    {id: 'pvr-ineligible', title: 'Personal Vehicle Ineligible'},
   ];
 
   typeOptions = [
@@ -49,11 +51,17 @@ export default class AdminTeamsController extends ClubhouseController {
     }
 
     switch (this.mvrEligibilityFilter) {
-      case 'eligible':
+      case 'mvr-eligible':
         teams = teams.filter((t) => t.mvr_eligible);
         break;
-      case 'ineligible':
+      case 'mvr-ineligible':
         teams = teams.filter((t) => !t.mvr_eligible);
+        break;
+      case 'pvr-eligible':
+        teams = teams.filter((t) => t.pvr_eligible);
+        break;
+      case 'pvr-ineligible':
+        teams = teams.filter((t) => !t.pvr_eligible);
         break;
     }
 

--- a/app/controllers/ops/payroll.js
+++ b/app/controllers/ops/payroll.js
@@ -57,6 +57,10 @@ export default class OpsPayrollController extends ClubhouseController {
 
   @tracked mealBreak;
 
+  @tracked defaultWeekLabel;
+  @tracked payrollWeekStart;
+  @tracked payrollWeekEnd;
+
   datesValidation = {
     start_time: [
       validatePresence({presence: true, message: 'Enter a starting date and time.'}),

--- a/app/routes/not-found.js
+++ b/app/routes/not-found.js
@@ -5,4 +5,9 @@ import ClubhouseRoute from 'clubhouse/routes/clubhouse-route';
  */
 
 export default class NotFoundRoute extends ClubhouseRoute {
+  setupController(controller) {
+    const href = window.location.href;
+    controller.url = href
+    controller.isOldURL = href.match(/\/clubhouse\//);
+  }
 }

--- a/app/routes/ops/payroll.js
+++ b/app/routes/ops/payroll.js
@@ -2,6 +2,7 @@ import ClubhouseRoute from "clubhouse/routes/clubhouse-route";
 import {PAYROLL} from "clubhouse/constants/roles";
 import EmberObject from '@ember/object';
 import _ from 'lodash';
+import dayjs from 'dayjs';
 
 export default class OpsPayrollRoute extends ClubhouseRoute {
   roleRequired = PAYROLL;
@@ -16,9 +17,16 @@ export default class OpsPayrollRoute extends ClubhouseRoute {
     paycodes.sort();
     controller.paycodeOptions = paycodes;
     controller.positionOptions = model.position.map((p) => [ `${p.title} (code ${p.paycode})`, p.id ]);
+    const today = dayjs(), payrollWeekEnd = today.startOf('w');
+    const payrollWeekStart = payrollWeekEnd.subtract(1, 'week');
+
+    controller.payrollWeekStart = this._buildWeek(payrollWeekStart);
+    controller.payrollWeekEnd = this._buildWeek(payrollWeekEnd);
+    controller.defaultWeekLabel = `${payrollWeekStart.format('ddd MMM D')} 00:00 to ${payrollWeekEnd.format('ddd MMM D')} @ 00:00`;
+
     controller.datesForm = EmberObject.create({
-      start_time: '',
-      end_time: '',
+      start_time: controller.payrollWeekStart,
+      end_time: controller.payrollWeekEnd,
       break_duration: 60,
       position_ids: model.position.map((p) => p.id),
       hour_cap: 8,
@@ -26,5 +34,9 @@ export default class OpsPayrollRoute extends ClubhouseRoute {
     });
     controller.people = [];
     controller.reportWasRun = false;
+  }
+
+  _buildWeek(week) {
+    return `${week.format('YYYY-MM-DD')} 00:00`;
   }
 }

--- a/app/templates/admin/teams.hbs
+++ b/app/templates/admin/teams.hbs
@@ -24,7 +24,7 @@
                       @options={{this.activeOptions}}
                       @onChange={{action (mut this.activeFilter)}} />
     </div>
-    <FormLabel @auto={{true}}>MVR Eligibility Filter</FormLabel>
+    <FormLabel @auto={{true}}>Vehicle Eligibility Filter</FormLabel>
     <div class="col-auto">
       <ChForm::Select @name="mvrEligibilityFilter"
                       @value={{this.mvrEligibilityFilter}}
@@ -95,6 +95,12 @@
           </td>
         {{/if}}
       </tr>
+    {{else}}
+    <tr>
+      <td colspan="{{if this.canManageTeams 9 8}}" class="text-danger">
+        No teams found.
+      </td>
+    </tr>
     {{/each}}
     </tbody>
   </UiTable>

--- a/app/templates/me/event-info.hbs
+++ b/app/templates/me/event-info.hbs
@@ -189,51 +189,25 @@
             {{/if}}
           </:body>
         </UiSection>
-        <UiSection>
-          <:title>{{fa-icon "truck-pickup"}} Motor Vehicle Record (MVR)</:title>
-          <:body>
-            {{#if (or this.person.isRanger this.person.isNonRanger)}}
-            <p>
-              {{#if this.eventInfo.mvr_eligible}}
-                {{badge "success" "MVR Eligible"}}
-                {{#if (or this.eventInfo.mvr_eligible_teams this.eventInfo.mvr_eligible_positions)}}
-                  You are eligible to submit a MVR request because you are a member of the following team(s), and/or have the following position(s):
-                  {{#if this.eventInfo.mvr_eligible_teams}}
-                    <div class="mt-2">
-                      {{pluralize this.eventInfo.mvr_eligible_teams.length "team"}}:
-                      {{#each this.eventInfo.mvr_eligible_teams as |team idx|}}
-                        {{if idx ", "}}{{team.title}}
-                      {{/each}}
-                    </div>
-                  {{/if}}
-                  {{#if this.eventInfo.mvr_eligible_positions}}
-                    <div class="mt-2">
-                      {{pluralize this.eventInfo.mvr_eligible_positions.length "position"}}:
-                      {{#each this.eventInfo.mvr_eligible_positions as |position idx|}}
-                        {{if idx ", "}}{{position.title}}
-                      {{/each}}
-                    </div>
-                  {{/if}}
-                {{else}}
-                  You are eligible to submit a MVR request.
-                {{/if}}
+        {{#if (or this.person.isRanger this.person.isNonRanger)}}
+          <UiSection>
+            <:title>{{fa-icon "truck-pickup"}} Motor Vehicle Record (MVR)</:title>
+            <:body>
+              {{#if this.personEvent.org_vehicle_insurance}}
+                {{badge "success" "Authorized" }} You are authorized to operate cars and trucks (including your own
+                personal vehicle, provided you have an approved Personal Vehicle Request) on the playa for Ranger
+                business. The vehicle must be equipped with a valid Burning Man driving sticker issued for the
+                current event. Please note that stickers are not transferable from year to year.
+              {{else if this.eventInfo.mvr_eligible}}
+                {{badge "success" "MVR Eligible"}} You are eligible to submit a MVR request.
               {{else}}
-                {{badge "secondary" "MVR Ineligible"}} You are currently ineligible to submit a MVR request.
+                {{badge "warning" "Not Authorized" }} You are NOT authorized to operate cars and trucks (including
+                your own personal vehicle) on the playa for Ranger business. If you believe this capability is
+                necessary for your Ranger duties on the playa, please contact your team lead.
               {{/if}}
-              </p>
-            {{/if}}
-            {{#if this.personEvent.org_vehicle_insurance}}
-              {{badge "success" "Authorized" }} You are authorized to drive cars and
-              trucks (including your own personal vehicle) on playa for Ranger business.
-              Vehicle must have a valid Burning Man driving sticker.
-            {{else}}
-              {{badge "warning" "Not Authorized" }} You are NOT authorized to drive cars
-              and trucks (including your own personal vehicle) on playa for Ranger
-              business. If you think you need this to do your job on playa, please
-              contact your manager or team lead.
-            {{/if}}
-          </:body>
-        </UiSection>
+            </:body>
+          </UiSection>
+        {{/if}}
       {{/if}}
     </tab.pane>
   {{/if}}

--- a/app/templates/not-found.hbs
+++ b/app/templates/not-found.hbs
@@ -1,16 +1,38 @@
 <main>
   <h1>Khaki, Khaki, Clubhouse - I need to report a 404 error. The page cannot be found.</h1>
 
-  <p>
-    Sorry, the Clubhouse could not find the page you asked for. There could be a few reasons
-    for this:
+  {{#if this.isOldURL}}
+    <p>
+      It appears you are trying to access an outdated Clubhouse link:
+    </p>
+    <p>
+      {{this.url}}
+    </p>
+    <p>
+      Please update your browser's bookmarks, and any documentation that references the above, to
+      use the following link:
+    </p>
+    <p>
+      <a href="https://ranger-clubhouse.burningman.org">https://ranger-clubhouse.burningman.org</a>
+    </p>
+  {{else}}
+    <p>
+      Sorry, the Clubhouse could not find the link you asked for:
+    </p>
+    <p>
+      {{this.url}}
+    </p>
+    There could be a few reasons for this:
 
     <ul>
-      <li>The page address (aka URL) entered was mistyped. Check for any typos.</li>
+      <li>The URL (aka link or page) entered was mistyped. Check for any typos.</li>
       <li>The page has been moved somewhere else.</li>
       <li>The Clubhouse has a bug.</li>
     </ul>
 
-    <LinkTo @route="me.homepage">Back To The Home Page</LinkTo>
+  {{/if}}
+  <p>
+    Reach out to the Tech Team at <TechSupportEmail/> if you need help.
   </p>
+  <LinkTo @route="me.homepage" class="mt-2">Back To The Home Page</LinkTo>
 </main>

--- a/app/templates/ops/bulk-positions.hbs
+++ b/app/templates/ops/bulk-positions.hbs
@@ -3,6 +3,14 @@
   <p>
     Use this page to grant or revoke a position for a list of callsigns.
   </p>
+  <p>
+    <span class="text-danger">Please note, granting or revoking positions will not add or remove a team's
+      membership.</span>
+    When you want to grant the recommended team positions (not public team positions), and wish to add
+    the person to the team's roster, use the
+    <LinkTo @route="ops.bulk-teams">Ops &gt; Bulk Grant/Revoke Team</LinkTo>
+    interface instead. The interface will add a person to roster, and grant the recommended team positions in one go.
+  </p>
 
   {{#if this.positions}}
     {{#if this.people}}

--- a/app/templates/ops/payroll.hbs
+++ b/app/templates/ops/payroll.hbs
@@ -20,6 +20,11 @@
         </:selectors>
       </f.checkboxGroup>
     </FormRow>
+    <FormRow class="mt-4">
+      <div class="col">
+        Default date &amp; time range is {{this.defaultWeekLabel}}
+      </div>
+    </FormRow>
     <FormRow>
       <f.datetime @name="start_time"
                   @label="Start Date & Time:"

--- a/app/templates/person.hbs
+++ b/app/templates/person.hbs
@@ -33,7 +33,6 @@
   {{#if (has-role "intake" "regional")}}
     <s.group @title="Vol Coords">
       <s.link @route="person.unified-flagging" @title="Unified Flagging" @icon="flag"/>
-      <s.link @route="person.applications" @title="Applications" @icon="pencil" @iconType="s"/>
     </s.group>
   {{/if}}
 


### PR DESCRIPTION
- Provide default date/times ranges on payroll export.

- Fixed MVR eligible vs approval on Me > Event Info

- Indicate on the not-found page if the user tried an old Clubhouse 1 url (where are people finding these?!?)

- Warn the user team rosters will not be adjusted when granting or revoking positions thru the bulk interface.

- Added PVR filters to Admin > Team.