### PR TITLE
Fix some mentor interface bugs.

### DIFF
--- a/app/components/acceptance-sheets-print.hbs
+++ b/app/components/acceptance-sheets-print.hbs
@@ -50,10 +50,11 @@
       </div>
       <div class="alpha-sheet-column">
         <div class="alpha-sheet-column-label">Schedule Shift:</div>
-        <div class="alpha-sheet-column-{{if alpha.alpha_slot "field" "input"}}">
-          {{#if alpha.alpha_slot}}
-            {{shift-format alpha.alpha_slot.begins}}
-          {{/if}}
+        <div class="alpha-sheet-column-{{if alpha.alpha_slots "field" "input"}}">
+          {{#each  alpha.alpha_slots as |slot idx|}}
+            {{#if idx}}<br>{{/if}}
+            {{shift-format slot.begins}}
+          {{/each}}
         </div>
       </div>
       <div class="alpha-sheet-column">

--- a/app/controllers/mentor/acceptance-sheets.js
+++ b/app/controllers/mentor/acceptance-sheets.js
@@ -1,29 +1,25 @@
 import ClubhouseController from 'clubhouse/controllers/clubhouse-controller';
-import {action, set} from '@ember/object';
-import dayjs from 'dayjs';
-import {tracked} from '@glimmer/tracking';
-import _ from 'lodash';
+import {action} from '@ember/object';
+import {cached, tracked} from '@glimmer/tracking';
 
 export default class MentorAcceptanceSheetsController extends ClubhouseController {
   @tracked filter;
   @tracked alphas;
   @tracked viewAlphas;
-  @tracked printAlphas;
   @tracked isPrinting;
   @tracked selectAll;
+  @tracked filterOptions;
 
   @action
   toggleAll(event) {
     const selected = event.target.checked;
-    this.alphas.forEach((alpha) => set(alpha, 'selected', selected));
-    this._buildPrintAlphas();
+    this.alphas.forEach((alpha) => alpha.selected = selected);
   }
 
   @action
-  toggleAlpha(alpha) {
-    set(alpha, 'selected', !alpha.selected);
+  toggleAlpha() {
     this.selectAll = false;
-    this._buildPrintAlphas();
+    return true;
   }
 
   @action
@@ -37,31 +33,16 @@ export default class MentorAcceptanceSheetsController extends ClubhouseControlle
     if (filter === 'all') {
       this.viewAlphas = this.alphas;
     } else if (filter === 'no-signup') {
-      this.viewAlphas = this.alphas.filter((a) => !a.alpha_slot);
+      this.viewAlphas = this.alphas.filter((a) => !a.alpha_slots);
     } else {
-      this.viewAlphas = this.alphas.filter((a) => (a.alpha_slot && this.filter === a.alpha_slot.begins));
+      this.viewAlphas = this.alphas.filter((a) => a.alpha_slots?.find((s) => this.filter === s.begins));
     }
-
-    this._buildPrintAlphas()
   }
 
-  get filterOptions() {
-    const dates = _.uniqBy(this.alphas.filter((a) => a.alpha_slot != null), (a) => a.alpha_slot.begins)
-      .map((a) => a.alpha_slot.begins)
-      .sort();
 
-    const options = dates.map((date) => {
-      return [dayjs(date).format('ddd MMM DD [@] HH:mm'), date];
-    });
-
-    options.unshift(['No Mentor Shift', 'no-signup']);
-    options.unshift(['All', 'all']);
-
-    return options;
-  }
-
-  _buildPrintAlphas() {
-    this.printAlphas = this.viewAlphas.filter((a) => a.selected);
+  @cached
+  get printAlphas() {
+    return this.viewAlphas.filter((a) => a.selected);
   }
 
   @action

--- a/app/controllers/mentor/alpha-signout.js
+++ b/app/controllers/mentor/alpha-signout.js
@@ -17,7 +17,7 @@ export default class MentorAlphaSignoutController extends ClubhouseController {
   @tracked alphaSignoutCount = 0;
 
   @action
-  changeSlot(value) {
+  async changeSlot(value) {
     if (value === '') {
       return; // Do nothing
     }
@@ -31,22 +31,25 @@ export default class MentorAlphaSignoutController extends ClubhouseController {
 
     if (this.shiftDate !== 'all') {
       data.on_duty_start = dayjs(value).subtract(1, 'hours').format(DT_FORMAT);
-      data.on_duty_end = dayjs(value).add(1, 'hours').format(DT_FORMAT);
+      data.on_duty_end = dayjs(value).add(2, 'hours').format(DT_FORMAT);
     }
 
-    this.ajax.request('timesheet', {data})
-      .then((result) => {
-        this.alphas = result.timesheet.map((t) => ({
-          id: t.person_id,
-          callsign: t.person.callsign,
-          selected: true,
-          on_duty: t.on_duty,
-          duration: t.duration,
-          timesheet_id: t.id
-        }));
-        this.selectAll = true;
-      }).catch((response) => this.house.handleErrorResponse(response))
-      .finally(() => this.isLoading = false);
+    try {
+      const result = await this.ajax.request('timesheet', {data});
+      this.alphas = result.timesheet.map((t) => ({
+        id: t.person_id,
+        callsign: t.person.callsign,
+        selected: true,
+        on_duty: t.on_duty,
+        duration: t.duration,
+        timesheet_id: t.id
+      }));
+      this.selectAll = true;
+    } catch (response) {
+      this.house.handleErrorResponse(response);
+    } finally {
+      this.isLoading = false;
+    }
   }
 
   @action

--- a/app/controllers/mentor/post-season-summary.js
+++ b/app/controllers/mentor/post-season-summary.js
@@ -64,7 +64,7 @@ export default class MentorPostSeasonSummaryController extends ClubhouseControll
       case 'no-walk':
         return mentees.filter((m) => (m.mentor_status === 'pending' && !m.alpha_shift));
       case 'no-shift':
-        return mentees.filter((m) => (m.mentor_status === 'pending') && !m.alpha_slot)
+        return mentees.filter((m) => (m.mentor_status === 'pending') && !m.alpha_slots)
       case 'self-bonked':
         return mentees.filter((m) => m.mentor_status === 'self-bonk')
       case 'uberbonked':

--- a/app/routes/mentor/acceptance-sheets.js
+++ b/app/routes/mentor/acceptance-sheets.js
@@ -1,20 +1,38 @@
 import ClubhouseRoute from 'clubhouse/routes/clubhouse-route';
+import {ALPHA} from "clubhouse/constants/positions";
+import Selectable from "clubhouse/utils/selectable";
+import dayjs from "dayjs";
+
 
 export default class MentorAcceptanceSheetsRoute extends ClubhouseRoute {
-  model() {
-    return this.ajax.request('mentor/alphas');
+  async model() {
+    return {
+      alphas: await this.ajax.request('mentor/alphas').then((result) => result.alphas),
+      slots: await this.ajax.request('slot', {
+        data: {
+          position_id: ALPHA,
+          year: this.house.currentYear(),
+          active: true
+        }
+      }).then((result) => result.slot)
+    }
   }
 
-  setupController(controller, model) {
-    const alphas = model.alphas;
-
+  setupController(controller, {alphas, slots}) {
     alphas.forEach((a) => a.selected = true);
-    controller.set('alphas', alphas);
-    controller.set('filter', 'all');
-    controller.set('selectAll', true);
-    controller.set('year', this.house.currentYear());
-    controller.set('isPrinting', false);
+    controller.alphas =  alphas.map((a) => new Selectable(a));
+    controller.filter ='all';
+    controller.selectAll = true;
+    controller.year =  this.house.currentYear();
+    controller.isPrinting = false;
     controller._buildViewAlphas();
-    controller._buildPrintAlphas();
+
+    const options = slots.map((date) => [dayjs(date.begins).format('ddd MMM DD [@] HH:mm'), date.begins]);
+
+    options.unshift(['No Mentor Shift', 'no-signup']);
+    options.unshift(['All', 'all']);
+
+    controller.filterOptions = options;
+
   }
 }

--- a/app/templates/mentor/acceptance-sheets.hbs
+++ b/app/templates/mentor/acceptance-sheets.hbs
@@ -13,7 +13,7 @@
     </div>
     <div class="col-auto">
       <UiButton @onClick={{this.printAction}}>
-        Print Selected ({{this.printAlphas.length}}
+        Print Selected ({{this.printAlphas.length}})
       </UiButton>
     </div>
   </FormRow>
@@ -48,14 +48,15 @@
           {{/each}}
         </td>
         <td>
-          {{#if alpha.alpha_slot}}
-            {{shift-format alpha.alpha_slot.begins}}
+          {{#each alpha.alpha_slots as |slot idx|}}
+            {{#if idx}}<br>{{/if}}
+            {{shift-format slot.begins}}
           {{else}}
             none
-          {{/if}}
+          {{/each}}
         </td>
         <td>
-          {{#if (and alpha.trainings alpha.trained alpha.alpha_slot)}}
+          {{#if (and alpha.trainings alpha.trained alpha.alpha_slots)}}
             <span class="text-success">{{fa-icon "check"}} none</span>
           {{else}}
             <b class="text-danger">
@@ -66,7 +67,7 @@
               {{#unless alpha.trained}}
                 Did not pass training<br>
               {{/unless}}
-              {{#unless alpha.alpha_slot}}
+              {{#unless alpha.alpha_slots}}
                 No mentor shift
               {{/unless}}
             </b>

--- a/app/templates/mentor/assignment.hbs
+++ b/app/templates/mentor/assignment.hbs
@@ -22,11 +22,12 @@
         </td>
         <td>{{person.first_name}} {{person.last_name}}</td>
         <td>
-          {{#if person.alpha_slot}}
-            {{shift-format person.alpha_slot.begins}}
+          {{#each  person.alpha_slots as |slot idx|}}
+            {{#if idx}}<br>{{/if}}
+            {{shift-format slot.begins}}
           {{else}}
             -
-          {{/if}}
+          {{/each}}
         </td>
         <td>
           {{this.mentorName person 0}}
@@ -65,7 +66,7 @@
       <ChForm::Select @name="shiftFilter"
                       @value={{this.shiftFilter}}
                       @options={{this.shiftFilterOptions}}
-                      @onChange={{action (mut this.shiftFilter)}} />
+                      @onChange={{this.updateShiftFilter}} />
     </div>
     <div class="col-auto">
       <UiButton @type="secondary" @class="mb-2" @onClick={{this.togglePrinting}}>
@@ -77,10 +78,27 @@
     <MentorAssignmentFromPod @alphas={{this.viewAlphas}} @year={{this.year}} />
   </p>
   <p>
-    Legend: Mentor shift = Shift Alpha is signed up for. On Shift = Is the Alpha currently signed into an Alpha shift?
+    Legend: Mentor shift = Shift Alpha is signed up for. On Shift = Is the Alpha currently signed in to an Alpha
+    shift?<br>
+    for.
   </p>
+  {{#if this.walkingUnknown}}
+    <UiAlert @type="warning" @icon="hand">
+      The following Alphas were found who are checked in, yet it cannot be determined which shift they are walking.
+      This might be a result of a very early, or late check in.
+      <div class="my-2">The Mentor Assignment From Pod button will probably not work for these.</div>
+      <div class="mt-2">
+        {{#each this.walkingUnknown as |person idx|}}
+          {{if idx ", "~}}{{person.callsign~}}
+        {{/each}}
+      </div>
+    </UiAlert>
+  {{/if}}
   <UiSection>
-    <:title>Showing {{this.viewAlphas.length}} of {{pluralize this.alphas.length "Alpha"}}</:title>
+    <:title>
+      Showing {{this.viewAlphas.length}} of {{pluralize this.alphas.length "Alpha"}}
+      {{this.titleLabel}}
+    </:title>
     <:body>
       <p>
         <UiButton @disabled={{not this.selectedAlphas}} @onClick={{this.updateToPassed}}>
@@ -93,8 +111,8 @@
           <th><Input @type="checkbox" @checked={{this.selectAll}} {{on "change" this.toggleAll}} /></th>
           <th>Callsign</th>
           <th>Name</th>
-          <th>Mentor Shift</th>
-          <th>On Shift</th>
+          <th>Signed Up For</th>
+          <th>Checked In For</th>
           <th>Mentor 1</th>
           <th>Mentor 2</th>
           <th>Mentor 3</th>
@@ -113,14 +131,19 @@
             </td>
             <td>{{person.first_name}} {{person.last_name}}</td>
             <td>
-              {{#if person.alpha_slot}}
-                {{shift-format person.alpha_slot.begins}}
+              {{#each person.alpha_slots as |slot idx|}}
+                {{#if idx}}<br>{{/if}}
+                {{shift-format slot.begins}}
+              {{else}}
+                -
+              {{/each}}
+            </td>
+            <td>
+              {{#if person.on_alpha_shift}}
+                {{shift-format person.on_alpha_shift.begins}}
               {{else}}
                 -
               {{/if}}
-            </td>
-            <td class="text-center">
-              {{yesno person.on_alpha_shift}}
             </td>
             <td>
               <ChForm::Select @name="mentor1_{{person.id}}"

--- a/app/templates/mentor/post-season-summary.hbs
+++ b/app/templates/mentor/post-season-summary.hbs
@@ -60,7 +60,7 @@ bonked.
       <td class="w-15">
         {{#if (eq mentee.status "uberbonked")}}
           <b class="text-danger">{{fa-icon "bell"}} UBERBONKED</b><br>
-        {{else if (and (eq mentee.mentor_status 'pending') (not mentee.alpha_slot))}}
+        {{else if (and (eq mentee.mentor_status 'pending') (not mentee.alpha_slots))}}
           <span class="text-danger">{{fa-icon "question"}} No Alpha shift</span>
         {{else}}
           {{#if (eq mentee.mentor_status "pass")}}


### PR DESCRIPTION
- Show all signed-up for shifts on various pages.
- Provide a checked-into (versus signed-up for) filters on mentor assignment.
- Confirm with the user they're passing all selected alphas.
- Warn if an alpha checked into a shift can not be associated with a schedule sign up.