### PR TITLE
Language restructuring.

### DIFF
--- a/app/components/editable-section.hbs
+++ b/app/components/editable-section.hbs
@@ -19,19 +19,23 @@
   </:title>
   <:body>
     {{#if this.isEditing}}
-      <ChForm @formId={{@formId}}
-              @formFor={{@formFor}}
-              @autocomplete="on"
-              @validator={{@validator}}
-              @onSubmit={{this.onSubmit}}
-              @onFormInit={{@onFormInit}}
-              as |f|>
-        {{yield f to="edit"}}
-        <div class="mt-4">
-          <f.submit/>
-          <UiCancelButton @onClick={{this.cancelEdit}} />
-        </div>
-      </ChForm>
+      {{#if @formFor}}
+        <ChForm @formId={{@formId}}
+                @formFor={{@formFor}}
+                @autocomplete="on"
+                @validator={{@validator}}
+                @onSubmit={{this.onSubmit}}
+                @onFormInit={{@onFormInit}}
+                as |f|>
+          {{yield f to="edit"}}
+          <div class="mt-4">
+            <f.submit/>
+            <UiCancelButton @onClick={{this.cancelEdit}} />
+          </div>
+        </ChForm>
+      {{else}}
+        {{yield this.cancelEdit to="edit"}}
+      {{/if}}
     {{else}}
       {{yield to="view"}}
     {{/if}}

--- a/app/components/language-speaker-table.hbs
+++ b/app/components/language-speaker-table.hbs
@@ -1,6 +1,10 @@
 <UiSection>
   <:title>{{@name}} ({{@speakers}})</:title>
   <:body>
+    Legend:
+    <div class="d-inline-block">basic = knows common phrases &amp; words.</div>
+    <div class="d-inline-block ms-2">intermediate = able to hold a causal conversation.</div>
+    <div class="d-inline-block ms-2">fluent = very proficient or native speaker</div>
     <UiTable class="mt-2">
       <thead>
       <tr>
@@ -14,9 +18,21 @@
           <td class="w-10">{{group.language_name}}</td>
           <td class="callsign-list">
             {{#each group.items as |person|}}
-              <LinkTo @route="person.index" @model={{person.person_id}}>
-                {{person.callsign}}
-              </LinkTo>
+              <div class="mb-1">
+                <LinkTo @route="person.index" @model={{person.person_id}}>
+                  {{person.callsign}}
+                </LinkTo>
+                <div>
+                  {{#if (eq person.proficiency "unknown")}}
+                    -
+                  {{else}}
+                    {{person.proficiency}}
+                  {{/if}}
+                </div>
+                {{#if @isOnDuty}}
+                  <small>{{person.position_title}}</small>
+                {{/if}}
+              </div>
             {{/each}}
           </td>
         </tr>

--- a/app/components/me/pii-languages-form.hbs
+++ b/app/components/me/pii-languages-form.hbs
@@ -1,18 +1,98 @@
 <p>
-  List the English names of the languages you are comfortable speaking with the fluency level in parentheses,
-  each separated by a comma.
+  On rare occasion, Khaki might need a Ranger to help out with translation during a shift. Could you let us know which
+  languages you'd feel comfortable acting as a translator for?
 </p>
 <p>
-  Example: <b><i>"japanese (basic), spanish (fluent)"</i></b>
-</p>
-<p>
-  Keep the list simple:<br>
-  GOOD: "french (fluent), italian (written only), spanish (basic)"<br>
-  BAD: "French - I taught in Paris and can only write in Italian. Took 1 year of high school spanish"<br>
+  You don't need to list English. We assume you already have some basic knowledge of the language.
 </p>
 
-<FormRow>
-  <@f.text @name="languages"
-          @label="Languages Spoken"
-          @size={{80}}/>
-</FormRow>
+{{#if @languages}}
+  <UiTable class="mb-2">
+    <thead>
+    <tr>
+      <th>Language</th>
+      <th>Proficiency</th>
+      <th>Action</th>
+    </tr>
+    </thead>
+    <tbody>
+    {{#each @languages as |language|}}
+      <tr>
+        <td>{{language.actualName}}</td>
+        <td>{{language.proficiencyLabel}}</td>
+        <td>
+          <UiButton @onClick={{fn this.editLanguage language}} @type="secondary" @size="sm">
+            Edit
+          </UiButton>
+          <UiButton @onClick={{fn this.deleteLanguage language}} @type="secondary" @size="sm">
+            Delete
+          </UiButton>
+        </td>
+      </tr>
+    {{/each}}
+    </tbody>
+  </UiTable>
+{{else}}
+  <p>
+    No languages have been stated.
+  </p>
+{{/if}}
+
+<UiButton @onClick={{this.newLanguage}}>
+  {{fa-icon "plus" right=1}} Add Language
+</UiButton>
+
+{{#if this.entry}}
+  <ModalDialog as |Modal|>
+    <ChForm @formId="language"
+            @formFor={{this.entry}}
+            @validator={{this.validations}}
+            @onSubmit={{this.save}} as |f|>
+      <Modal.title>
+        {{#if this.entry.isNew}}
+          Add Language
+        {{else}}
+          Update Language
+        {{/if}}
+      </Modal.title>
+      <Modal.body>
+        <p>
+          The languages encountered most on playa are available to select. In case a language
+          is not in the list, use the "Something Else" option to add a different language.
+        </p>
+        <p>
+          You don't need to list English. We assume you already have some basic knowledge of the language.
+        </p>
+        <FormRow>
+          <f.select @name="language_name"
+                    @label="Language"
+                    @options={{this.languageOptions}}/>
+          {{#if (eq f.model.language_name "custom")}}
+            <f.text @name="language_custom"
+                    @label="What is the English name of the Language?"
+                    @size={{32}}
+                    @maxlength={{32}}
+                    @showCharCount={{true}}
+            />
+          {{/if}}
+        </FormRow>
+        <FormRow>
+          <f.radioGroup @name="proficiency"
+                        @label="What is your proficiency level?"
+                        @options={{this.proficiencyOptions}}
+          />
+        </FormRow>
+      </Modal.body>
+      <Modal.footer @noAlign={{true}}>
+        <f.submit/>
+        <UiCancelButton @onClick={{this.cancelEdit}} />
+      </Modal.footer>
+    </ChForm>
+  </ModalDialog>
+{{/if}}
+
+{{#if this.isSubmitting}}
+  <LoadingDialog>
+    Loading your request
+  </LoadingDialog>
+{{/if}}

--- a/app/components/me/pii-languages-form.js
+++ b/app/components/me/pii-languages-form.js
@@ -1,0 +1,119 @@
+import Component from '@glimmer/component';
+import {service} from '@ember/service';
+import {action} from '@ember/object';
+import {tracked} from '@glimmer/tracking';
+import {validatePresence} from 'ember-changeset-validations/validators';
+import validateCustom from "clubhouse/validators/custom";
+import {LANGUAGE_CUSTOM, ProficiencyOptions} from "clubhouse/models/person-language";
+
+export default class MePiiLanguagesFormComponent extends Component {
+  @service ajax;
+  @service house;
+  @service modal;
+  @service store;
+  @service toast;
+
+  @tracked isSubmitting = false;
+  @tracked languageOptions = [];
+
+  @tracked entry;
+
+  validations = {
+    language_name: [validatePresence({presence: true, message: 'Select a language'})],
+    language_custom: [validateCustom({field: 'language_name'})]
+  };
+
+  proficiencyOptions = ProficiencyOptions;
+
+  constructor() {
+    super(...arguments);
+
+    this._loadCommonOptions();
+  }
+
+  async _loadCommonOptions() {
+    this.isSubmitting = true;
+    try {
+      const {languages} = await this.ajax.request('person-language/common-languages');
+      this.commonLanguages = languages;
+    } catch (response) {
+      this.house.handleErrorResponse(response);
+    } finally {
+      this.isSubmitting = false;
+    }
+  }
+
+  @action
+  newLanguage() {
+    this.entry = this.store.createRecord('person-language', {person_id: this.args.person.id});
+    this._setupOptions();
+  }
+
+  @action
+  editLanguage(language) {
+    this.entry = language;
+    this._setupOptions();
+  }
+
+  _setupOptions() {
+    const names = {};
+    let options;
+    if (this.entry.language_name === LANGUAGE_CUSTOM) {
+      options = [...this.commonLanguages];
+    } else {
+      this.args.languages.forEach((l) => {
+        if (this.entry.id === l.id) {
+          return;
+        }
+        names[l.language_name] = true;
+      });
+      options = this.commonLanguages.filter((name) => !names[name]);
+    }
+    options.unshift(['--', '']);
+    options.push(['Something Else', LANGUAGE_CUSTOM]);
+    this.languageOptions = options;
+  }
+
+  @action
+  cancelEdit() {
+    this.entry = null;
+  }
+
+  @action
+  async save(model, isValid) {
+    if (!isValid) {
+      return;
+    }
+    const {isNew} = this.entry;
+    try {
+      this.isSubmitting = true;
+      await model.save();
+      if (isNew) {
+        this.args.languages.update();
+      }
+      this.toast.success(`The language was successfully ${isNew ? 'added' : 'updated'}.`);
+      this.entry = null;
+    } catch (response) {
+      this.house.handleErrorResponse(response);
+    } finally {
+      this.isSubmitting = false;
+    }
+  }
+
+  @action
+  deleteLanguage(language) {
+    this.modal.confirm('Confirm Deletion', `Are you sure want to delete ${language.actualName}?`,
+      async () => {
+        try {
+          this.isSubmitting = true;
+          await language.destroyRecord();
+          await this.args.languages.update();
+          this.toast.success = 'The language has been deleted';
+        } catch (response) {
+          this.house.handleErrorResponse(response);
+        } finally {
+          this.isSubmitting = false;
+        }
+      });
+  }
+}

--- a/app/components/me/pii-languages-section.hbs
+++ b/app/components/me/pii-languages-section.hbs
@@ -1,18 +1,17 @@
-<EditableSection
-  @formId="person"
-  @sectionId="languages"
-  @formFor={{@person}}
-  @validator={{@personInfoValidations}}
-  @onSubmit={{@onSubmit}}>
+<EditableSection>
   <:title>Languages (optional)</:title>
   <:view>
-    {{#if @person.languages}}
-      {{@person.languages}}
+    {{#each @languages as |language idx|}}
+      {{#if idx}}<br>{{/if}}
+      {{language.actualName}}
+      {{#if language.haveProficiency}}
+        ({{language.proficiencyLabel}})
+      {{/if}}
     {{else}}
       <i>No languages stated.</i>
-    {{/if}}
+    {{/each}}
   </:view>
-  <:edit as |f|>
-    <Me::PiiLanguagesForm @f={{f}} />
+  <:edit as |onFinished|>
+    <Me::PiiLanguagesForm @languages={{@languages}} @person={{@person}} @onFinished={{onFinished}} />
   </:edit>
 </EditableSection>

--- a/app/components/person/timesheet-log.hbs
+++ b/app/components/person/timesheet-log.hbs
@@ -25,7 +25,7 @@
       </Accordion.title>
 
       <Accordion.body>
-        <UiTable class="max-width-900">
+        <UiTable class="max-width-1200">
           <thead>
           <tr>
             <th class="timesheetlog-time">Timestamp</th>
@@ -129,7 +129,7 @@
     <UiAccordion as |Accordion|>
       <Accordion.title>Other Timesheet Actions</Accordion.title>
       <Accordion.body>
-        <UiTable class="max-width-900">
+        <UiTable class="max-width-1200">
           <thead>
           <tr>
             <th class="timesheetlog-time">Time</th>

--- a/app/components/personal-info-edit.hbs
+++ b/app/components/personal-info-edit.hbs
@@ -1,51 +1,64 @@
 <UiTab class="mt-4" as |tab|>
   <tab.pane @title="Name, Gender &amp; Pronouns" @id="name">
-    <Me::PiiGeneralSection @person={{@person}}
-                           @personInfoValidations={{this.personInfoValidations}}
-                           @onSubmit={{@savePerson}}
-                           @pronounOptions={{this.pronounOptions}}
-                           @genderIdentityOptions={{this.genderIdentityOptions}}
-    />
+    <div class="max-width-800">
+      <Me::PiiGeneralSection @person={{@person}}
+                             @personInfoValidations={{this.personInfoValidations}}
+                             @onSubmit={{@savePerson}}
+                             @pronounOptions={{this.pronounOptions}}
+                             @genderIdentityOptions={{this.genderIdentityOptions}}
+      />
+    </div>
   </tab.pane>
   <tab.pane @title="Email & Phone" @id="contact">
-    <Me::PiiContactInfoSection @person={{@person}}
-                               @personInfoValidations={{this.personInfoValidations}}
-                               @onSubmit={{@savePerson}}
-    />
+    <div class="max-width-800">
+      <Me::PiiContactInfoSection @person={{@person}}
+                                 @personInfoValidations={{this.personInfoValidations}}
+                                 @onSubmit={{@savePerson}}
+      />
+    </div>
 
   </tab.pane>
   <tab.pane @title="Camp Info" @id="camp">
-    <Me::PiiCampInfoSection @person={{@person}}
-                            @personInfoValidations={{this.personInfoValidations}}
-                            @onSubmit={{@savePerson}}
-    />
+    <div class="max-width-800">
+      <Me::PiiCampInfoSection @person={{@person}}
+                              @personInfoValidations={{this.personInfoValidations}}
+                              @onSubmit={{@savePerson}}
+      />
+    </div>
   </tab.pane>
   <tab.pane @title="Callsign Pronunciation" @id="pronounce">
-    <Me::PiiPronunciationSection @person={{@person}}
-                            @personInfoValidations={{this.personInfoValidations}}
-                            @onSubmit={{@savePerson}}
-    />
+    <div class="max-width-800">
+      <Me::PiiPronunciationSection @person={{@person}}
+                                   @personInfoValidations={{this.personInfoValidations}}
+                                   @onSubmit={{@savePerson}}
+      />
+    </div>
   </tab.pane>
   <tab.pane @title="Languages" @id="languages">
-    <Me::PiiLanguagesSection @person={{@person}}
-                             @personInfoValidations={{this.personInfoValidations}}
-                             @onSubmit={{@savePerson}}
-    />
+    <div class="max-width-800">
+      <Me::PiiLanguagesSection @person={{@person}}
+                               @languages={{@languages}}
+      />
+    </div>
   </tab.pane>
   <tab.pane @title="Clothing" @id="clothing">
-    <Me::PiiClothingSection @person={{@person}}
-                            @personInfoValidations={{this.personInfoValidations}}
-                            @onSubmit={{@savePerson}}
-                            @tshirtOptions={{@tshirtOptions}}
-                            @longSleeveOptions={{@longSleeveOptions}}
-    />
+    <div class="max-width-800">
+      <Me::PiiClothingSection @person={{@person}}
+                              @personInfoValidations={{this.personInfoValidations}}
+                              @onSubmit={{@savePerson}}
+                              @tshirtOptions={{@tshirtOptions}}
+                              @longSleeveOptions={{@longSleeveOptions}}
+      />
+    </div>
   </tab.pane>
   <tab.pane @title="Home Address" @id="home">
+    <div class="max-width-800">
 
-    <Me::PiiAddressSection @person={{@person}}
-                           @personInfoValidations={{this.personInfoValidations}}
-                           @onSubmit={{@savePerson}}
-    />
+      <Me::PiiAddressSection @person={{@person}}
+                             @personInfoValidations={{this.personInfoValidations}}
+                             @onSubmit={{@savePerson}}
+      />
+    </div>
   </tab.pane>
 </UiTab>
 {{#if @person.isSaving}}

--- a/app/components/personal-info-view.hbs
+++ b/app/components/personal-info-view.hbs
@@ -66,7 +66,13 @@
         Languages
     </div>
     <div>
-        <PresentOrNot @value={{@person.languages}} />
+      {{#each @languages as |language idx|}}
+        {{#if idx}}<br>{{/if}}
+        {{language.actualName}}
+        {{#if language.haveProficiency}}
+          ({{language.proficiencyLabel}})
+        {{/if}}
+      {{/each}}
     </div>
 
     <div class="grid-table-label">

--- a/app/components/ui-wizard-step.hbs
+++ b/app/components/ui-wizard-step.hbs
@@ -16,8 +16,8 @@
       {{/if}}
       {{#if (or (not @isLast) @includeCancel)}}
         <div>
-          <UiButton @onClick={{this.wizard.cancelAction}} @type="secondary">
-            {{fa-icon "ban"}} Cancel
+          <UiButton @onClick={{this.wizard.cancelAction}} @type="gray" class="btn-link">
+            Cancel
           </UiButton>
         </div>
       {{/if}}

--- a/app/controllers/search/languages.js
+++ b/app/controllers/search/languages.js
@@ -52,7 +52,7 @@ export default class SearchLanguagesController extends ClubhouseController {
   }
 
   // Build up a request and fire off a search
-  _performSearch() {
+  async _performSearch() {
     if (this.isLoading) {
       return; // in progress
     }
@@ -74,18 +74,20 @@ export default class SearchLanguagesController extends ClubhouseController {
 
     this.searchLanguage = language;
     this.isLoading = true;
-    this.ajax.request('language/speakers', {data: params})
-      .then((results) => {
-        this.onDuty = results.on_duty;
-        this.offDuty = results.off_duty;
-        this.hasRadio = results.has_radio;
-      }).catch((response) => {
+    try {
+      const results = await this.ajax.request('person-language/search', {data: params})
+      this.onDuty = results.on_duty;
+      this.offDuty = results.off_duty;
+      this.hasRadio = results.has_radio;
+    } catch (response) {
       if (response.status === 404) {
         this.notFound = language;
       } else {
         this.house.handleErrorResponse(response);
       }
-    }).finally(() => this.isLoading = false);
+    } finally {
+      this.isLoading = false;
+    }
   }
 
   @action

--- a/app/models/person-language.js
+++ b/app/models/person-language.js
@@ -1,0 +1,44 @@
+import Model, {attr} from '@ember-data/model';
+
+export const PROFICIENCY_UNKNOWN = 'unknown';
+export const PROFICIENCY_BASIC = 'basic';
+export const PROFICIENCY_INTERMEDIATE = 'intermediate';
+export const PROFICIENCY_FLUENT = 'fluent';
+
+export const LANGUAGE_CUSTOM = 'custom';
+
+export const ProficiencyLabels = {
+  [PROFICIENCY_UNKNOWN]: 'Not Stated',
+  [PROFICIENCY_BASIC]: 'Basic',
+  [PROFICIENCY_INTERMEDIATE]: 'Intermediate',
+  [PROFICIENCY_FLUENT]: 'Fluent',
+};
+
+export const ProficiencyOptions = [
+  ['Not Stated', PROFICIENCY_UNKNOWN],
+  ['Basic: You can answer basic questions using some common phrases and words.', PROFICIENCY_BASIC],
+  ['Intermediate: You can hold a causal conversation.', PROFICIENCY_INTERMEDIATE],
+  [ 'Fluent/Native: You can have an in-depth conversation.', PROFICIENCY_FLUENT]
+]
+
+export default class PersonLanguageModel extends Model {
+  @attr('number') person_id;
+  @attr('string') language_name;
+  @attr('string') language_custom;
+  @attr('string', {defaultValue: PROFICIENCY_UNKNOWN}) proficiency;
+
+  get actualName() {
+    return this.language_name === LANGUAGE_CUSTOM ? this.language_custom : this.language_name;
+  }
+
+  get haveProficiency() {
+    return this.proficiency !== PROFICIENCY_UNKNOWN;
+  }
+
+  get proficiencyLabel() {
+    if (this.proficiency === PROFICIENCY_UNKNOWN) {
+      return '-';
+    }
+    return ProficiencyLabels[this.proficiency] ?? `Unknown: ${this.proficiency}`;
+  }
+}

--- a/app/routes/me/personal-info.js
+++ b/app/routes/me/personal-info.js
@@ -8,12 +8,14 @@ export default class MePersonInfoRoute extends ClubhouseRoute {
     return RSVP.hash({
       shirts: this.ajax.request('swag/shirts').then(({shirts}) => shirts),
       personEvent: this.store.findRecord('person-event', `${this.session.userId}-${this.house.currentYear()}`, {reload: true}),
-      dashboardPeriod: this.ajax.request('config/dashboard-period').then(({period}) => period)
+      dashboardPeriod: this.ajax.request('config/dashboard-period').then(({period}) => period),
+      languages: this.store.query('person-language', { person_id: this.session.userId })
     });
   }
 
-  setupController(controller, {shirts, personEvent, dashboardPeriod}) {
+  setupController(controller, {shirts, personEvent, dashboardPeriod, languages}) {
     controller.set('person', this.modelFor('me'));
+    controller.set('languages', languages)
     controller.set('isSaved', false);
     controller.set('showUpdateMailingListsDialog', false);
     controller.set('isReviewing', this.isReviewing);

--- a/app/routes/person/personal-info.js
+++ b/app/routes/person/personal-info.js
@@ -6,12 +6,16 @@ export default class PersonPersonalInfoRoute extends ClubhouseRoute {
   // User has to be an Admin or have Login Manage AND View Personal Info
   roleRequired = [ADMIN, [MANAGE, VIEW_PII]];
 
-  model() {
-    return this.ajax.request('swag/shirts');
+  async model() {
+    return {
+      shirts: await this.ajax.request('swag/shirts').then(({shirts}) => shirts),
+      languages: await this.store.query('person-language', { person_id: this.modelFor('person').id })
+    };
   }
 
-  setupController(controller, {shirts}) {
+  setupController(controller, model) {
     controller.person = this.modelFor('person');
-    controller.setProperties(shirtOptions(shirts));
+    controller.setProperties(shirtOptions(model.shirts));
+    controller.set('languages', model.languages)
   }
 }

--- a/app/routes/reports/languages.js
+++ b/app/routes/reports/languages.js
@@ -2,10 +2,13 @@ import ClubhouseRoute from 'clubhouse/routes/clubhouse-route';
 
 export default class ReportsLanguagesRoute extends ClubhouseRoute {
   model() {
-    return this.ajax.request('person/languages');
+    return this.ajax.request('person-language/on-site-report');
   }
 
-  setupController(controller, model) {
-    controller.set('languages', model.languages);
+  setupController(controller, {languages}) {
+    controller.languageGroups = [
+      {title: 'Common Languages Encountered On Playa', languages: languages.common},
+      {title: 'Other Languages', languages: languages.other},
+    ]
   }
 }

--- a/app/routes/search/languages.js
+++ b/app/routes/search/languages.js
@@ -1,12 +1,17 @@
 import ClubhouseRoute from 'clubhouse/routes/clubhouse-route';
 
 export default class SearchLanguagesRoute extends ClubhouseRoute {
-  setupController(controller) {
-    controller.set('searchForm', {
+  model() {
+    return this.ajax.request('person-language/common-languages');
+  }
+
+  setupController(controller, model) {
+    controller.searchForm = {
       language: '',
       offSite: false
-    });
-    controller.set('isLoading', false);
-    controller.set('searchingOffSite', false);
+    };
+    controller.isLoading = false;
+    controller.searchingOffSite = false;
+    controller.commonLanguages = model.languages;
   }
 }

--- a/app/styles/timesheet-log.scss
+++ b/app/styles/timesheet-log.scss
@@ -2,5 +2,5 @@
  * Timesheet log table layout
  */
 
-.timesheetlog-time { width: 150px; }
-.timesheetlog-user { width: 125px; }
+.timesheetlog-time { min-width: 175px; }
+.timesheetlog-user { min-width: 125px; }

--- a/app/templates/me/personal-info.hbs
+++ b/app/templates/me/personal-info.hbs
@@ -37,8 +37,7 @@
 
   {{#unless (or this.person.isAuditor this.person.isPastProspective)}}
     <Me::PiiLanguagesSection @person={{this.person}}
-                             @personInfoValidations={{this.personInfoValidations}}
-                             @onSubmit={{this.onSubmit}}
+                             @languages={{this.languages}}
     />
     <Me::PiiPronunciationSection @person={{this.person}}
                                  @personInfoValidations={{this.personInfoValidations}}
@@ -81,8 +80,8 @@
         <Me::PiiCampInfoForm @f={{f}} />
       </w.step>
       {{#unless this.person.isAuditor}}
-        <w.step @title="Languages">
-          <Me::PiiLanguagesForm @f={{f}} />
+        <w.step @title="Languages" @nextLabel="Next">
+          <Me::PiiLanguagesForm @languages={{this.languages}} @person={{this.person}} />
         </w.step>
         <w.step @title="Callsign Pronunciation">
           <Me::PiiPronunciationForm @f={{f}} />

--- a/app/templates/person/personal-info.hbs
+++ b/app/templates/person/personal-info.hbs
@@ -1,28 +1,31 @@
 <h3>Personal Information for {{this.person.callsign}}</h3>
 <p>
-    {{#if this.person.reviewed_pi_at}}
-        Last updated their PII on {{timestamp-format this.person.reviewed_pi_at "MMM DD, YYYY @ HH:mm"}} (Pacific)
-    {{else}}
-        Has not updated their PII yet.
-    {{/if}}
-    <br>
-    {{#if this.person.pi_reviewed_for_dashboard_at}}
-        Last reviewed their PII for the dashboard PII step on
-        {{timestamp-format this.person.pi_reviewed_for_dashboard_at "MMM DD, YYYY @ HH:mm"}} (Pacific).
-    {{else}}
-        Has not yet reviewed their PII for the dashboard PII step.
-    {{/if}}
+  {{#if this.person.reviewed_pi_at}}
+    Last updated their PII on {{timestamp-format this.person.reviewed_pi_at "MMM DD, YYYY @ HH:mm"}} (Pacific)
+  {{else}}
+    Has not updated their PII yet.
+  {{/if}}
+  <br>
+  {{#if this.person.pi_reviewed_for_dashboard_at}}
+    Last reviewed their PII for the dashboard PII step on
+    {{timestamp-format this.person.pi_reviewed_for_dashboard_at "MMM DD, YYYY @ HH:mm"}} (Pacific).
+  {{else}}
+    Has not yet reviewed their PII for the dashboard PII step.
+  {{/if}}
 </p>
 {{#if this.canEditPersonalInfo}}
-    <PersonalInfoEdit @person={{this.person}}
-                      @savePerson={{this.savePerson}}
-                      @tshirtOptions={{this.tshirtOptions}}
-                      @longSleeveOptions={{this.longSleeveOptions}}/>
+  <PersonalInfoEdit @person={{this.person}}
+                    @savePerson={{this.savePerson}}
+                    @tshirtOptions={{this.tshirtOptions}}
+                    @longSleeveOptions={{this.longSleeveOptions}}
+                    @languages={{this.languages}}
+  />
 {{else}}
-    <PersonalInfoView @person={{this.person}}
-                      @savePerson={{this.savePerson}}
-                      @tshirtOptions={{this.tshirtOptions}}
-                      @longSleeveOptions={{this.longSleeveOptions}}
-                      @shirtsById={{this.shirtsById}}
-    />
+  <PersonalInfoView @person={{this.person}}
+                    @savePerson={{this.savePerson}}
+                    @tshirtOptions={{this.tshirtOptions}}
+                    @longSleeveOptions={{this.longSleeveOptions}}
+                    @shirtsById={{this.shirtsById}}
+                    @languages={{this.languages}}
+  />
 {{/if}}

--- a/app/templates/reports/languages.hbs
+++ b/app/templates/reports/languages.hbs
@@ -1,7 +1,7 @@
 <h1>Languages Spoken</h1>
 
 <p>
-  This page will show all languages spoken by people marked as on site.
+  This page will show all languages spoken by Rangers marked as on site.
 </p>
 <p>
   Use the
@@ -9,24 +9,27 @@
   page to search for people who speak a specific language and whom may or may not be on site, have a radio, etc.
 </p>
 
-{{#each this.languages as |language|}}
-  <UiAccordion as |Accordion|>
-    <Accordion.title>{{language.language}} ({{language.people.length}})</Accordion.title>
-    <Accordion.body>
-      <div class="callsign-list">
-        {{#each language.people key="id" as |person|}}
-          <PersonLink @person={{person}} />
-        {{/each}}
-      </div>
-    </Accordion.body>
-  </UiAccordion>
-{{else}}
-  <p class="text-danger">
-    <b>
-      It appears there are no people marked as on site.
-      Try using the
-      <LinkTo @route="search.languages">Search Languages</LinkTo>
-      to find the language.
-    </b>
-  </p>
+{{#each this.languageGroups as |group idx|}}
+  <h3 class="border-bottom border-bottom-2 {{if idx "mt-4"}}">{{group.title}}</h3>
+  {{#each group.languages as |language|}}
+    <UiAccordion as |Accordion|>
+      <Accordion.title>{{language.name}} ({{language.people.length}})</Accordion.title>
+      <Accordion.body>
+        <div class="callsign-list">
+          {{#each language.people key="id" as |person|}}
+            <PersonLink @person={{person}} />
+          {{/each}}
+        </div>
+      </Accordion.body>
+    </UiAccordion>
+  {{else}}
+    <p class="text-danger">
+      <b>
+        It appears there are no people marked as on site.
+        Try using the
+        <LinkTo @route="search.languages">Search Languages</LinkTo>
+        to find the language.
+      </b>
+    </p>
+  {{/each}}
 {{/each}}

--- a/app/templates/search/languages.hbs
+++ b/app/templates/search/languages.hbs
@@ -1,20 +1,17 @@
 <h1>Language Search</h1>
 
-<ChForm @formId="search" @formFor={{this.searchForm}} @changeSet={{false}}
+<ChForm @formId="search"
+        @formFor={{this.searchForm}}
+        @changeSet={{false}}
         @onSubmit={{this.submit}} as |f|>
-  <FormRow>
-    <label class="col-auto mt-1">Quick Search:</label>
-    <div class="col-auto">
-    <UiButton @type="secondary" @size="sm" @onClick={{action this.setLanguage "spanish"}}>Spanish</UiButton>
-    <UiButton @type="secondary" @size="sm" @onClick={{action this.setLanguage "chinese"}}>Chinese</UiButton>
-    <UiButton @type="secondary" @size="sm" @onClick={{action this.setLanguage "dutch"}}>Dutch</UiButton>
-    <UiButton @type="secondary" @size="sm" @onClick={{action this.setLanguage "french"}}>French</UiButton>
-    <UiButton @type="secondary" @size="sm" @onClick={{action this.setLanguage "german"}}>German</UiButton>
-    <UiButton @type="secondary" @size="sm" @onClick={{action this.setLanguage "hebrew"}}>Hebrew</UiButton>
-    <UiButton @type="secondary" @size="sm" @onClick={{action this.setLanguage "italian"}}>Italian</UiButton>
-    <UiButton @type="secondary" @size="sm" @onClick={{action this.setLanguage "russian"}}>Russian</UiButton>
-    </div>
-  </FormRow>
+  <div>Quick Search:</div>
+  <div class="masonry-container masonry-col-6 my-2">
+    {{#each this.commonLanguages as |name|}}
+      <a href class="small masonry-item" {{action this.setLanguage name}}>
+        {{name}}
+      </a>
+    {{/each}}
+  </div>
   <FormRow>
     <f.text @label="Enter a language to search for:"
             @name="language"
@@ -38,11 +35,15 @@
 {{#if this.isLoading}}
   <LoadingPane @item="languages"/>
 {{else}}
-  <h3 class="mb-4">Reporting on Rangers who are <span class="text-danger">{{if this.searchingOffSite "ON and OFF SITE" "ON SITE ONLY"}}</span></h3>
+  <h3 class="mb-4">
+    Reporting on Rangers who are
+    <span class="text-danger">{{if this.searchingOffSite "ON and OFF SITE" "ON SITE ONLY"}}</span>
+  </h3>
   <LanguageSpeakerTable @name="On Duty Rangers"
                         @speakers={{this.onDuty.length}}
                         @group={{this.onDutyGroup}}
                         @searchLanguage={{this.searchLanguage}}
+                        @isOnDuty={{true}}
   />
   <LanguageSpeakerTable @name="Rangers With Radios"
                         @speakers={{this.hasRadio.length}}

--- a/app/validations/person-info.js
+++ b/app/validations/person-info.js
@@ -2,7 +2,7 @@ import {
   validatePresence,  validateFormat
 } from 'ember-changeset-validations/validators';
 import validateState from 'clubhouse/validators/state';
-import validatePronouns from 'clubhouse/validators/pronouns';
+import validateCustom from 'clubhouse/validators/custom';
 
 export const REQUIRED_PII_VALIDATIONS = {
   first_name: [
@@ -46,6 +46,6 @@ export default {
   ],
 
   pronouns_custom: [
-    validatePronouns()
+    validateCustom({ field: 'pronouns' })
   ]
 };

--- a/app/validations/person-info.js
+++ b/app/validations/person-info.js
@@ -47,5 +47,8 @@ export default {
 
   pronouns_custom: [
     validateCustom({ field: 'pronouns' })
+  ],
+  gender_custom: [
+    validateCustom({ field: 'gender_identity' })
   ]
 };

--- a/app/validators/custom.js
+++ b/app/validators/custom.js
@@ -5,10 +5,11 @@ function getProperty(name, changes, content) {
   return (name in changes) ? changes[name] : get(content, name);
 }
 
-export default function validatePronouns(/* options = {} */) {
+export default function validateCustom({field}) {
   return (key, newValue, oldValue, changes, content) => {
-    const pronouns = getProperty('pronouns', changes, content);
-    if (pronouns !== 'custom') {
+    const baseValue = getProperty(field, changes, content);
+
+    if (baseValue !== 'custom') {
       return true;
     }
 

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -310,6 +310,10 @@ function routes() {
     };
   });
 
+  this.get('/api/person-language', () => {
+    return { person_language: [ ]};
+  });
+
   this.get('/api/vehicle/:id', () => {
     return {
       vehicle: {


### PR DESCRIPTION
- Split the common languages on playa from the lesser heard, and the "unhelpful" languages (e.g., snark, hippy, love, python, reiki.)
- Replaced the language freeform field with a table.