### PR TITLE
HQ & Timesheet interface work

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -27,7 +27,8 @@ Ember.onerror = (error) => {
     }
 
     didAlertError = true;
-    alert("Ember exception " + error.stack);
+    console.error('Ember exception', error);
+    alert("Ember exception!\n" + error.stack);
     debugger;  // eslint-disable-line no-debugger
   } else {
     logError(error, 'client-ember-error');
@@ -51,6 +52,7 @@ window.onerror = (event, source, lineno, colno, error) => {
     return;
   }
 
+  console.error('Exception', event);
   alert("Uncaught exception " + event.message);
   // eslint-disable-next-line no-debugger
   debugger;

--- a/app/components/asset-checkout-form.hbs
+++ b/app/components/asset-checkout-form.hbs
@@ -21,18 +21,15 @@
   {{#if this.barcodeNotFound}}
     <span class="fw-semibold text-danger">Barcode "{{this.barcodeNotFound}}" was not found.</span>
   {{else if this.barcodeCheckedOut}}
-    <div>
+    <div class="mt-2">
       <span class="fw-semibold text-danger">
-      Asset {{this.barcodeCheckedOut.barcode}} still checked out by
-      <LinkTo @route="person.assets"
-              @model={{this.barcodeCheckedOut.person_id}}>{{this.barcodeCheckedOut.callsign}}</LinkTo>
-      .
+      Asset {{this.barcodeCheckedOut.barcode}} still checked out by {{this.barcodeCheckedOut.callsign}}.
       </span>
       Check out was on {{shift-format this.barcodeCheckedOut.checked_out}}.
     </div>
-    <div class="mb-2">
+    <div class="mt-2 mb-4">
       <UiButton @type="secondary" @onClick={{this.showHistoryAction}}>
-        Show Asset History &amp; Optionally Check Asset Back In
+        Show Asset History
       </UiButton>
     </div>
   {{else}}

--- a/app/components/ch-form/datetime-field.hbs
+++ b/app/components/ch-form/datetime-field.hbs
@@ -18,6 +18,8 @@
                     @onfocus={{@onFocus}}
                     @minDate={{@minDate}}
                     @maxDate={{@maxDate}}
+                    @viewDate={{@viewDate}}
+                    @defaultDate={{@defaultDate}}
                     @onInvalidInput={{this.invalidInput}}
     />
     {{~#if @hint~}}

--- a/app/components/ch-form/select.js
+++ b/app/components/ch-form/select.js
@@ -45,6 +45,8 @@ export default class ChFormSelectComponent extends Component {
       return true;
     } else if (value === 'false') {
       return false;
+    } else if (value === 'null') {
+      return null;
     } else {
       return value;
     }
@@ -58,7 +60,7 @@ export default class ChFormSelectComponent extends Component {
       case 'object':
         // { id: value, title: 'label' }
         label = opt.title ?? opt.label;
-        value = opt.id ?? opt.value;
+        value = ('id' in opt) ? (opt.id === null ? 'null' : opt.id) : opt.value;
         if ('disabled' in opt) {
           disabled = opt.disabled;
         }
@@ -67,6 +69,9 @@ export default class ChFormSelectComponent extends Component {
       case 'array':
         // Simple [ 'label', value ]
         [label, value] = opt;
+        if (value === null) {
+          value = "null";
+        }
         if (opt.length >= 3) {
           disabled = opt[2];
         }

--- a/app/components/datetime-picker.js
+++ b/app/components/datetime-picker.js
@@ -7,7 +7,7 @@ import {later} from '@ember/runloop';
 export default class DatetimePickerComponent extends Component {
   constructor() {
     super(...arguments);
-    let {dateOnly, minDate, maxDate} = this.args;
+    let {dateOnly, minDate, maxDate, viewDate, defaultDate} = this.args;
 
     this.config = {
       allowInputToggle: true,
@@ -42,6 +42,14 @@ export default class DatetimePickerComponent extends Component {
         minutes: false,
         seconds: false
       }
+    }
+
+    if (viewDate) {
+      this.config.viewDate = new Date(viewDate);
+    }
+
+    if (defaultDate) {
+      this.config.defaultDate = new Date(defaultDate);
     }
   }
 

--- a/app/components/hq-asset-table.hbs
+++ b/app/components/hq-asset-table.hbs
@@ -26,7 +26,19 @@
       <td>
         <PresentOrNot @value={{ap.asset.description}} @empty="-"/>
         <br>
-        {{if ap.asset.perm_assign "Permanent" "Temporary"}}
+        {{#if (eq ap.asset.type "radio")}}
+          {{#if ap.asset.perm_assign}}
+            {{badge "gray" "Event Radio"}}
+          {{else}}
+            {{badge "warning" "Shift Radio"}}
+          {{/if}}
+        {{else}}
+          {{#if ap.asset.perm_assign}}
+            {{badge "gray" "Permanent"}}
+          {{else}}
+            {{badge "warning" "Temporary"}}
+          {{/if}}
+        {{/if}}
       </td>
       <td>{{shift-format ap.checked_out}}</td>
       <td>

--- a/app/components/hq-pogs.hbs
+++ b/app/components/hq-pogs.hbs
@@ -79,22 +79,22 @@
     <tbody>
     {{#each this.pogs as |pog|}}
       <tr class="align-middle">
-        <td>{{pog.pogLabel}}</td>
-        <td>
+        <td class="no-wrap">{{pog.pogLabel}}</td>
+        <td class="no-wrap">
           {{#if (and pog.isHalfMealPog pog.isRedeemed)}}
             Redeemed for Full Meal Pog
           {{else}}
             {{pog.statusLabel}}
           {{/if}}
         </td>
-        <td>{{shift-format pog.issued_at}}</td>
-        <td>
+        <td class="no-wrap">{{shift-format pog.issued_at}}</td>
+        <td class="no-wrap">
           <PersonLink @person={{pog.issued_by}} />
         </td>
         <td>
           <PresentOrNot @value={{pog.notes}} @empty="-"/>
         </td>
-        <td>
+        <td class="no-wrap">
           {{#if pog.isCancelled}}
             -
           {{else}}

--- a/app/components/hq-timesheet-verification.hbs
+++ b/app/components/hq-timesheet-verification.hbs
@@ -4,28 +4,30 @@
     The exception is during a very busy time such as the Burn Night check-in, the review can skipped by using
     the <i>Skip Review</i> button.
   </UiNotice>
-{{else}}
-  <div class="d-flex justify-content-between mb-4">
-    <div>
-      If a timesheet entry not listed below requires correction,
-      <span class="d-inline-block">
+{{/if}}
+<div class="d-flex justify-content-between mb-2">
+  <div>
+    If a timesheet entry not listed below requires correction,
+    <span class="d-inline-block">
         click on
       <LinkTo @route="hq.timesheet" @model={{@person.id}}>Timesheet / Corrections</LinkTo>
       .
       </span>
-    </div>
-    <div>
-      <UiButton @type="secondary" @onClick={{this.newTimesheetMissingRequest}} @size="sm">
-        New Missing Timesheet Request
-      </UiButton>
-    </div>
   </div>
-{{/if}}
+  <div>
+    <UiButton @type="secondary" @onClick={{this.newTimesheetMissingRequest}} @size="sm">
+      New Missing Timesheet Request
+    </UiButton>
+  </div>
+</div>
+
 {{#if @unverifiedTimesheets}}
   <p>
-    <UiButton @onClick={{this.skipEntireReview}} @type="secondary">
-      Skip Review For All Entries
-    </UiButton>
+    {{#if this.hasUnreviewedTimesheet}}
+      <UiButton @onClick={{this.skipEntireReview}} @type="secondary">
+        Skip Review For All Entries
+      </UiButton>
+    {{/if}}
   </p>
   <UiTable @normalSize={{true}}>
     <thead>
@@ -60,7 +62,7 @@
             </div>
           {{else if entry.isPending}}
             <div class="text-danger">
-              {{fa-icon "hourglass" fixed=1 right=1}} A correction request submitted.
+              {{fa-icon "hourglass" fixed=1 right=1}} A correction request has been submitted.
             </div>
           {{else if entry.isIgnoring}}
             {{fa-icon "clock" type="r" fixed=1 right=1}} Entry will be reviewed at a later time.
@@ -111,49 +113,13 @@
 {{/if}}
 
 {{#if this.showCorrectionForm}}
-  <ModalDialog @title="Timesheet Entry Correction" @onEscape={{this.cancelEntryCorrection}} as |Modal|>
-    <ChForm @formId="correction" @formFor={{this.entry}}
-            @validator={{this.correctionValidations}}
-            @onSubmit={{this.saveEntryCorrection}} as |f|>
-      <Modal.body>
-        <dl class="row">
-          <dt class="col-sm-2">Position:</dt>
-          <dd class="col-sm-10">{{this.entry.position.title}}</dd>
+  <Me::TimesheetReviewEdit @entry={{this.entry}}
+                           @isMe={{false}}
+                           @onCancel={{this.cancelEntryCorrection}}
+                           @positions={{@positions}}
+                           @onUpdate={{this.savedEntryCorrection}}
+  />
 
-          <dt class="col-sm-2">Time:</dt>
-          <dd class="col-sm-10">{{shift-format this.entry.on_duty}} to {{shift-format this.entry.off_duty}}</dd>
-
-          <dt class="col-sm-2">Duration:</dt>
-          <dd class="col-sm-10">{{hour-minute-format this.entry.duration}}</dd>
-
-          <dt class="col-sm-2">Credits:</dt>
-          <dd class="col-sm-10">{{credits-format this.entry.credits}}</dd>
-        </dl>
-        Provide as much information as possible to help the reviewer understand why this entry should be fixed.
-        <ul>
-          <li>Why does {{this.person.callsign}} think the entry is wrong?</li>
-          <li><b>Wrong times?</b> State the correct times. Don't forget to include the month and day.</li>
-          <li><b>Is the position "{{this.entry.position.title}}" wrong?</b> State the correct position</li>
-          <li><b>Who was their shift partner(s)?</b></li>
-        </ul>
-
-        <FormRow>
-          <f.textarea @name="additional_notes"
-                      @label="Timesheet entry correction note:"
-                      @autofocus={{true}}
-                      @cols={{80}}
-                      @rows={{5}}/>
-        </FormRow>
-      </Modal.body>
-      <Modal.footer @noAlign={{true}}>
-        <f.submit @label="Submit Correction" @disabled={{this.isCorrectionSubmitting}} />
-        <UiCancelButton @disabled={{this.isCorrectionSubmitting}} @onClick={{this.cancelEntryCorrection}} />
-        {{#if this.isCorrectionSubmitting}}
-          <SpinIcon/>
-        {{/if}}
-      </Modal.footer>
-    </ChForm>
-  </ModalDialog>
 {{/if}}
 
 {{#if this.timesheetMissingEntry}}

--- a/app/components/hq-timesheet-verification.js
+++ b/app/components/hq-timesheet-verification.js
@@ -4,6 +4,7 @@ import {action} from '@ember/object';
 import {service} from '@ember/service';
 import {tracked} from '@glimmer/tracking';
 import positionsForTimesheetMissing from "clubhouse/utils/positions-for-timesheet-missing";
+import {STATUS_UNVERIFIED, STATUS_VERIFIED} from "clubhouse/models/timesheet";
 
 export default class HqTimesheetVerificationComponent extends Component {
   @service ajax;
@@ -37,8 +38,8 @@ export default class HqTimesheetVerificationComponent extends Component {
   @action
   async toggleEntryVerified(entry) {
     entry.isIgnoring = false;
-    const isVerified = entry.review_status === 'verified';
-    entry.review_status = (isVerified ? 'unverified' : 'verified');
+    const isVerified = entry.review_status === STATUS_VERIFIED;
+    entry.review_status = (isVerified ? STATUS_UNVERIFIED : STATUS_VERIFIED);
     try {
       await entry.save();
       this.toast.success(`Timesheet was successfully ${isVerified ? 'un-verified' : 'marked as verified'}.`);
@@ -91,21 +92,11 @@ export default class HqTimesheetVerificationComponent extends Component {
    */
 
   @action
-  async saveEntryCorrection(model, isValid) {
-    if (!isValid) {
-      return;
-    }
-
+  savedEntryCorrection() {
+    this.entry.additional_notes = null; // pseudo field, not cleared on save
     this.entry.isIgnoring = false;
-    try {
-      await model.save();
-      this.entry.additional_notes = null; // pseudo field, not cleared on save
-      this.showCorrectionForm = false;
-      this.toast.success('Correction request successfully submitted.');
-      this._finishedCallbacks();
-    } catch (response) {
-      this.house.handleErrorResponse(response)
-    }
+    this.showCorrectionForm = false;
+    this._finishedCallbacks();
   }
 
   _finishedCallbacks() {

--- a/app/components/me/timesheet-missing-common.hbs
+++ b/app/components/me/timesheet-missing-common.hbs
@@ -13,73 +13,75 @@
       <div class="timesheet-position">Position</div>
     </div>
     {{#each @timesheetsMissing as |tsm|}}
-      <div class="timesheet-entry-header {{this.requestClass tsm}}">
-        {{#if tsm.isPending}}
-          {{fa-icon "hourglass" right=1}} The request is pending review.
-        {{else}}
-          {{#if tsm.isApproved}}
-            {{fa-icon "check" right=1}} The request has been APPROVED. The missing shift has been added to your
-            timesheet.
-          {{else if tsm.isRejected}}
-            {{fa-icon "ban" right=1}} The request has been rejected.
-          {{else}}
-            Unknown status [{{tsm.review_status}}].
-          {{/if}}
-        {{/if}}
-      </div>
-      <div class="timesheet-entry">
-        <div class="timesheet-row">
-          <div class="timesheet-time">{{shift-format tsm.on_duty tsm.off_duty}}</div>
-          <div class="timesheet-duration">
-            {{hour-minute-words tsm.duration}}
-          </div>
-          <div class="timesheet-position">{{tsm.position.title}}</div>
-        </div>
-        <div class="timesheet-row-info">
-          {{#if tsm.notes}}
-            {{#if tsm.showNotes}}
-              <div class="border p-2 my-2">
-                <h5 class="mx-n2 mt-n2 p-2 text-bg-gray">Notes from you &amp; the Timesheet Wranglers</h5>
-                <TimesheetNotes @notes={{tsm.notes}} @isMe={{this.isMe}} />
-              </div>
-            {{else}}
-              <div class="p-2">
-                <TimesheetNotes @notes={{tsm.notes}} @isMe={{this.isMe}} @lastInfo={{true}} />
-              </div>
-            {{/if}}
-          {{/if}}
-        </div>
-      </div>
-      <div class="timesheet-row timesheet-actions">
-        <UiButton @type="gray" class="btn-responsive" @onClick={{fn this.toggleNotes tsm}}>
-          {{fa-icon "comments" type="r" right=1}}
-          {{#if tsm.showNotes}}
-            Hide Notes
-          {{else}}
-            Show Notes
-          {{/if}}
-        </UiButton>
-        {{#if (or tsm.isPending tsm.isRejected)}}
+      <div class="timesheet-entry-container">
+        <div class="timesheet-entry-header {{this.requestClass tsm}}">
           {{#if tsm.isPending}}
-            <UiButton @type="danger"
-                      class="btn-responsive"
-                      @onClick={{fn this.deleteAction tsm}}
-                      @disabled={{or tsm.isReloading tsm.isSaving}}>
-              {{fa-icon "trash" right=1}} Delete Request
-            </UiButton>
-          {{/if}}
-          <UiButton @onClick={{fn this.editAction tsm}}
-                    class="btn-responsive"
-                    @disabled={{or tsm.isReloading tsm.isSaving}}>
-            {{#if tsm.isReloading}}
-              <SpinIcon/>
+            {{fa-icon "hourglass" right=1}} The request is pending review.
+          {{else}}
+            {{#if tsm.isApproved}}
+              {{fa-icon "check" right=1}} The request has been APPROVED. The missing shift has been added to your
+              timesheet.
             {{else if tsm.isRejected}}
-              {{fa-icon "redo" right=1}} Submit Appeal
+              {{fa-icon "ban" right=1}} The request has been rejected.
             {{else}}
-              {{fa-icon "edit" right=1}} Edit Request
+              Unknown status [{{tsm.review_status}}].
             {{/if}}
-          </UiButton>
-        {{/if}}
+          {{/if}}
+        </div>
+        <div class="timesheet-entry">
+          <div class="timesheet-row">
+            <div class="timesheet-time">{{shift-format tsm.on_duty tsm.off_duty}}</div>
+            <div class="timesheet-duration">
+              {{hour-minute-words tsm.duration}}
+            </div>
+            <div class="timesheet-position">{{tsm.position.title}}</div>
+          </div>
+          <div class="timesheet-row-info">
+            {{#if tsm.notes}}
+              {{#if tsm.showNotes}}
+                <div class="border p-2 my-2">
+                  <h5 class="mx-n2 mt-n2 p-2 text-bg-gray">Notes from you &amp; the Timesheet Wranglers</h5>
+                  <TimesheetNotes @notes={{tsm.notes}} @isMe={{this.isMe}} />
+                </div>
+              {{else}}
+                <div class="p-2">
+                  <TimesheetNotes @notes={{tsm.notes}} @isMe={{this.isMe}} @lastInfo={{true}} />
+                </div>
+              {{/if}}
+            {{/if}}
+          </div>
+          <div class="timesheet-actions">
+            {{#if (or tsm.isPending tsm.isRejected)}}
+              {{#if tsm.isPending}}
+                <UiButton @type="danger"
+                          class="btn-responsive"
+                          @onClick={{fn this.deleteAction tsm}}
+                          @disabled={{or tsm.isReloading tsm.isSaving}}>
+                  {{fa-icon "trash" right=1}} Delete Request
+                </UiButton>
+              {{/if}}
+              <UiButton @onClick={{fn this.editAction tsm}}
+                        class="btn-responsive"
+                        @disabled={{or tsm.isReloading tsm.isSaving}}>
+                {{#if tsm.isReloading}}
+                  <SpinIcon/>
+                {{else if tsm.isRejected}}
+                  {{fa-icon "redo" right=1}} Submit Appeal
+                {{else}}
+                  {{fa-icon "edit" right=1}} Edit Request
+                {{/if}}
+              </UiButton>
+            {{/if}}
+            <UiButton @type="gray" class="btn-responsive" @onClick={{fn this.toggleNotes tsm}}>
+              {{fa-icon "comments" type="r" right=1}}
+              {{#if tsm.showNotes}}
+                Hide Notes
+              {{else}}
+                Show Notes
+              {{/if}}
+            </UiButton>
+          </div>
+        </div>
       </div>
     {{/each}}
   </div>

--- a/app/components/me/timesheet-review-common.hbs
+++ b/app/components/me/timesheet-review-common.hbs
@@ -27,123 +27,125 @@
         <div class="timesheet-position">Position</div>
       </div>
       {{#each @timesheets key="id" as |ts|}}
-        {{#if this.correctionsEnabled}}
-          <div class="timesheet-entry-header {{this.timesheetEntryHeaderClass ts}}">
-            {{#if ts.stillOnDuty}}
-              {{fa-icon "ban" right=1}} The entry cannot be verified or a correction submitted
-              until after the shift has ended.
-            {{else if ts.isVerified}}
-              {{fa-icon "check" right=1}} Entry was verified as correct on {{shift-format ts.verified_at}} (Pacific)
-            {{else if ts.isUnverified}}
-              {{fa-icon "arrow-right" right=1}} The entry has not been verified as correct or a correction submitted.
-            {{else if ts.isApproved}}
-              {{fa-icon "arrow-right" right=1}} The correction request has been approved. You still need to mark the
-              entry as correct.
-            {{else if ts.isRejected}}
-              {{fa-icon "times" right=1}} The correction request has been denied. An appeal may be submitted.
-            {{else if ts.isPending}}
-              {{fa-icon "hourglass-half" right=1}} The correction request is pending review.
-            {{else}}
-              Unknown state? [{{ts.review_status}}]
-            {{/if}}
-          </div>
-        {{/if}}
-        {{#if (and (not ts.isVerified) ts.isTooShort)}}
-          <div class="timesheet-entry-header">
-            {{fa-icon "hand-point-right" right=1}} The entry is less than 15 minutes. Please verify this is not a
-            mistake.
-          </div>
-        {{/if}}
-        {{#if (and (not ts.isVerified) ts.isTooLong)}}
-          <div class="timesheet-entry-header">
-            <p>
-              {{fa-icon "hand-point-right" right=1}} The entry exceeds the scheduled shift duration by 1.5 times.
-              Please confirm this is not a mistake, or submit a correction.
-            </p>
-            The scheduled shift was {{hour-minute-words ts.slot.duration}} long.
-          </div>
-        {{/if}}
-        <div class="timesheet-entry">
-          <div class="timesheet-row">
-            <div class="timesheet-time">
-              {{#unless ts.position.count_hours}}
-                <NoAppreciateIcon/>
-              {{/unless}}
-              {{#if ts.off_duty}}
-                {{shift-format ts.on_duty ts.off_duty}}
+        <div class="timesheet-entry-container">
+          {{#if this.correctionsEnabled}}
+            <div class="timesheet-entry-header {{this.timesheetEntryHeaderClass ts}}">
+              {{#if ts.stillOnDuty}}
+                {{fa-icon "ban" right=1}} The entry cannot be verified or a correction submitted
+                until after the shift has ended.
+              {{else if ts.isVerified}}
+                {{fa-icon "check" right=1}} Verified as correct on {{shift-format ts.verified_at}} (Pacific)
+              {{else if ts.isUnverified}}
+                {{fa-icon "arrow-right" right=1}} The entry has not been verified as correct or a correction submitted.
+              {{else if ts.isApproved}}
+                {{fa-icon "arrow-right" right=1}} The correction request has been approved. You still need to mark the
+                entry as correct.
+              {{else if ts.isRejected}}
+                {{fa-icon "times" right=1}} The correction request has been denied. An appeal may be submitted.
+              {{else if ts.isPending}}
+                {{fa-icon "hourglass-half" right=1}} The correction request is pending review.
               {{else}}
-                {{shift-format ts.on_duty}} to <i>On Duty</i>
-              {{/if}}<br>
-            </div>
-            <div class="timesheet-duration">
-              {{hour-minute-words ts.duration}}
-            </div>
-            <div class="timesheet-credits">
-              {{credits-format ts.credits}} credits
-            </div>
-            <div class="timesheet-position">
-              {{ts.position.title}}
-              {{#if (and @person.employee_id ts.position.paycode )}}
-                <div class="text-muted small">
-                  {{fa-icon "person-digging" right=1}} Paid position.
-                </div>
+                Unknown state? [{{ts.review_status}}]
               {{/if}}
             </div>
-          </div>
-          {{#if this.correctionsEnabled}}
-            <div class="timesheet-row-info">
-              {{#if ts.notes}}
-                {{#if ts.showNotes}}
-                  <div class="border p-2 my-2">
-                    <h5 class="mx-n2 mt-n2 p-2 text-bg-gray">Notes from you &amp; the Timesheet Wranglers</h5>
-                    <TimesheetNotes @notes={{ts.notes}} @isMe={{this.isMe}} />
-                  </div>
+          {{/if}}
+          {{#if (and (not ts.isVerified) ts.isTooShort)}}
+            <div class="timesheet-entry-header">
+              {{fa-icon "hand-point-right" right=1}} The entry is less than 15 minutes. Please verify this is not a
+              mistake.
+            </div>
+          {{/if}}
+          {{#if (and (not ts.isVerified) ts.isTooLong)}}
+            <div class="timesheet-entry-header">
+              <p>
+                {{fa-icon "hand-point-right" right=1}} The entry exceeds the scheduled shift duration by 1.5 times.
+                Please confirm this is not a mistake, or submit a correction.
+              </p>
+              The scheduled shift was {{hour-minute-words ts.slot.duration}} long.
+            </div>
+          {{/if}}
+          <div class="timesheet-entry">
+            <div class="timesheet-row">
+              <div class="timesheet-time">
+                {{#unless ts.position.count_hours}}
+                  <NoAppreciateIcon/>
+                {{/unless}}
+                {{#if ts.off_duty}}
+                  {{shift-format ts.on_duty ts.off_duty}}
                 {{else}}
-                  <div class="p-2">
-                    <TimesheetNotes @notes={{ts.notes}} @isMe={{this.isMe}} @lastInfo={{true}} />
+                  {{shift-format ts.on_duty}} to <i>On Duty</i>
+                {{/if}}<br>
+              </div>
+              <div class="timesheet-duration">
+                {{hour-minute-words ts.duration}}
+              </div>
+              <div class="timesheet-credits">
+                {{credits-format ts.credits}} credits
+              </div>
+              <div class="timesheet-position">
+                {{ts.position.title}}
+                {{#if (and @person.employee_id ts.position.paycode )}}
+                  <div class="text-muted small">
+                    {{fa-icon "person-digging" right=1}} Paid position.
                   </div>
                 {{/if}}
+              </div>
+            </div>
+            {{#if this.correctionsEnabled}}
+              <div class="timesheet-row-info">
+                {{#if ts.notes}}
+                  {{#if ts.showNotes}}
+                    <div class="border p-2 my-2">
+                      <h5 class="mx-n2 mt-n2 p-2 text-bg-gray">Notes from you &amp; the Timesheet Wranglers</h5>
+                      <TimesheetNotes @notes={{ts.notes}} @isMe={{this.isMe}} />
+                    </div>
+                  {{else}}
+                    <div class="p-2">
+                      <TimesheetNotes @notes={{ts.notes}} @isMe={{this.isMe}} @lastInfo={{true}} />
+                    </div>
+                  {{/if}}
+                {{/if}}
+              </div>
+            {{/if}}
+          </div>
+          {{#if this.correctionsEnabled}}
+            <div class="timesheet-row timesheet-actions">
+              {{#if ts.off_duty}}
+                <UiButton @type="secondary"
+                          @onClick={{fn this.markIncorrectAction ts}}
+                          @disabled={{ts.isLoading}}>
+                  {{#if ts.isPending}}
+                    Add More Info
+                  {{else if ts.isRejected}}
+                    Submit Appeal
+                  {{else}}
+                    Request Correction
+                  {{/if}}
+                </UiButton>
+                {{#unless ts.isVerified}}
+                  <UiButton @type="success"
+                            @onClick={{fn this.markCorrectAction ts}}
+                            @disabled={{ts.isSaving}}>
+                    Mark Correct
+                  </UiButton>
+                {{/unless}}
+                {{#if (or ts.isReloading ts.iSaving)}}
+                  <LoadingIndicator/>
+                {{/if}}
+              {{/if}}
+              {{#if ts.notes}}
+                <UiButton @type="gray" @onClick={{fn this.toggleNotes ts}}>
+                  {{fa-icon "comments" type="r" right=1}}
+                  {{#if ts.showNotes}}
+                    Hide Notes
+                  {{else}}
+                    Show Notes
+                  {{/if}}
+                </UiButton>
               {{/if}}
             </div>
           {{/if}}
         </div>
-        {{#if this.correctionsEnabled}}
-          <div class="timesheet-row timesheet-actions">
-            {{#if ts.notes}}
-              <UiButton @type="gray" @onClick={{fn this.toggleNotes ts}}>
-                {{fa-icon "comments" type="r" right=1}}
-                {{#if ts.showNotes}}
-                  Hide Notes
-                {{else}}
-                  Show Notes
-                {{/if}}
-              </UiButton>
-            {{/if}}
-            {{#if ts.off_duty}}
-              <UiButton @type="secondary"
-                        @onClick={{fn this.markIncorrectAction ts}}
-                        @disabled={{ts.isLoading}}>
-                {{#if ts.isPending}}
-                  Add More Info
-                {{else if ts.isRejected}}
-                  Submit Appeal
-                {{else}}
-                  Request Correction
-                {{/if}}
-              </UiButton>
-              {{#unless ts.isVerified}}
-                <UiButton @type="success"
-                          @onClick={{fn this.markCorrectAction ts}}
-                          @disabled={{ts.isSaving}}>
-                  Mark Correct
-                </UiButton>
-              {{/unless}}
-              {{#if (or ts.isReloading ts.iSaving)}}
-                <LoadingIndicator/>
-              {{/if}}
-            {{/if}}
-          </div>
-        {{/if}}
       {{else}}
         <span class="text-danger">No entries were found for {{@year}}</span>
       {{/each}}
@@ -152,80 +154,10 @@
 </UiSection>
 
 {{#if this.entry}}
-  <ModalDialog @title="Timesheet Correction" as |Modal|>
-    <ChForm @formId="correction"
-            @formFor={{this.entry}}
-            @onSubmit={{this.saveCorrectionAction}} as |f|>
-      <Modal.body>
-        {{#if this.entry.isRejected}}
-          <UiNotice @type="danger" @icon="times" @title="Correction request has been denied">
-          </UiNotice>
-        {{/if}}
-
-        You are requesting a correction for:
-        <div class="mt-2 h5 d-flex flex-column flex-lg-row">
-          <div class="d-inline-block me-2">
-            {{this.entry.position.title}}
-          </div>
-          <div class="d-inline-block me-3">
-            {{credits-format this.entry.credits}} credits
-          </div>
-          <div class="d-inline-block me-3">
-            {{shift-format this.entry.on_duty this.entry.off_duty}}
-          </div>
-          <div class="d-inline-block">
-            {{hour-minute-words this.entry.duration}}
-          </div>
-        </div>
-        {{#if this.entry.notes}}
-          <div class="border p-2 my-2">
-            <h5 class="mx-n2 mt-n2 p-2 bg-secondary text-white">Notes from you &amp; the Timesheet Wranglers</h5>
-            <TimesheetNotes @notes={{this.entry.notes}} @isMe={{true}} />
-          </div>
-        {{/if}}
-        If the position <b>{{this.entry.position.title}}</b> is incorrect, select the correct position below:
-        <FormRow>
-          <f.select @name="desired_position_id"
-                    @options={{this.desiredPositionOptions}}
-                    @inline={{true}}
-          />
-        </FormRow>
-        If the start time of <b>{{shift-format this.entry.on_duty}}</b> is incorrect, enter the correct time below:
-        <FormRow>
-          <f.datetime @name="desired_on_duty" @label="Leave blank if the start time is correct" @size={{20}} />
-        </FormRow>
-        If the END TIME of <b>{{shift-format this.entry.off_duty}}</b> is incorrect, enter the correct time below:
-        <FormRow>
-          <f.datetime @name="desired_off_duty" @label="Leave blank if the end time is correct" @size={{20}} />
-        </FormRow>
-        Please help us understand why this entry should be fixed by providing the following information:
-        <ul class="no-indent">
-          <li><b>Provide a BRIEF &amp; CONCISE explanation</b> in 1 to 3 sentences what needs to be corrected.</li>
-          <li><b>Who was your shift partner or the Shift Lead who can corroborate your story?</b></li>
-        </ul>
-        <FormRow>
-          <f.textarea @name="additional_notes"
-                      @label={{if this.entry.isRejected "Supply additional information for an appeal:"
-                                  "Enter your brief explanation below:"}}
-                      @cols={{80}}
-                      @rows={{3}}
-                      @maxlength={{1000}}
-                      @showCharCount={{true}}
-          />
-        </FormRow>
-        <h6 class="text-danger fw-bold">The request will be denied if:</h6>
-        {{fa-icon "ban" right=1}} You are requesting credit for time you were not on duty due to a late start.<br>
-        {{fa-icon "ban" right=1}} Not enough or incomplete information was provided.<br>
-        {{fa-icon "ban" right=1}} The requested changes cannot be confirmed by your shift partner(s) or the Shift Lead.
-        Yes, we do check!<br>
-      </Modal.body>
-      <Modal.footer @noAlign={{true}}>
-        <f.submit @label="Submit Correction Request" @disabled={{this.entry.isSaving}} />
-        <UiCancelButton @disabled={{this.entry.isSaving}} @onClick={{this.cancelCorrectionAction}} />
-        {{#if this.entry.isSaving}}
-          <LoadingIndicator/>
-        {{/if}}
-      </Modal.footer>
-    </ChForm>
-  </ModalDialog>
+  <Me::TimesheetReviewEdit @entry={{this.entry}}
+                           @isMe={{true}}
+                           @onCancel={{this.cancelCorrectionAction}}
+                           @positions={{@positions}}
+                           @onUpdate={{this.savedEntry}}
+  />
 {{/if}}

--- a/app/components/me/timesheet-review-common.js
+++ b/app/components/me/timesheet-review-common.js
@@ -3,9 +3,8 @@ import {action} from '@ember/object';
 import {tracked} from '@glimmer/tracking';
 import {service} from '@ember/service';
 import {isEmpty} from '@ember/utils';
-import {STATUS_PENDING, STATUS_VERIFIED} from "clubhouse/models/timesheet";
+import {STATUS_VERIFIED} from "clubhouse/models/timesheet";
 import currentYear from 'clubhouse/utils/current-year';
-import dayjs from "dayjs";
 
 export default class MeTimesheetReviewCommonComponent extends Component {
   @service modal;
@@ -50,62 +49,14 @@ export default class MeTimesheetReviewCommonComponent extends Component {
   @action
   markIncorrectAction(timesheet) {
     this.entry = timesheet;
-    this.desiredPositionOptions = this.args.positions.map((p) => [p.title, p.id]);
-    this.desiredPositionOptions.unshift({
-      id: null,
-      title: `${timesheet.position.title} is correct`,
-    })
   }
 
-  // Save correction notes
   @action
-  saveCorrectionAction(model) {
-    if (!model.desired_position_id && !model.desired_on_duty && !model.desired_off_duty) {
-      this.modal.info('No corrections entered',
-        'You did not select a position, and/or enter the correct start or ending times');
-      return;
-    }
-
-    if (isEmpty(model.additional_notes) && !this.entry.notes.length) {
-      model.addError('additional_notes', 'Enter a reason why this entry should be corrected.');
-      return;
-    }
-
-    const positionId = model.desired_position_id ?? model.position_id,
-      onDuty = model.desired_on_duty ?? model.on_duty,
-      offDuty = model.desired_off_duty ?? model.off_duty;
-
-    if (dayjs(offDuty).isBefore(dayjs(onDuty))) {
-      if (model.desired_on_duty) {
-        model.addError('desired_on_duty', 'The on duty time is after the off duty time.');
-      }
-      if (model.desired_off_duty) {
-        model.addError('desired_off_duty', 'The off duty time is before the on duty time.');
-      }
-      return;
-    }
-
-    if (model._changes['desired_position_id']
-      || model._changes['desired_on_duty']
-      || model._changes['desired_off_duty']) {
-      this.shiftManage.checkDateTime(positionId, onDuty, offDuty, () => this._performSave(model))
-    } else {
-      this._performSave(model);
-    }
+  savedEntry() {
+    this.entry = null;
+    this.args.onUpdate?.();
   }
 
-  async _performSave(model) {
-    try {
-      model.review_status = STATUS_PENDING;
-      await model.save();
-      this.entry.additional_notes = null;
-      this.entry = null;
-      this.args.onUpdate?.();
-      this.toast.success('Your correction note has been submitted.');
-    } catch (response) {
-      this.house.handleErrorResponse(response);
-    }
-  }
 
   // Cancel out the correction request - i.e. hide the form
   @action
@@ -119,7 +70,7 @@ export default class MeTimesheetReviewCommonComponent extends Component {
     }
 
     if (ts.isVerified) {
-      return 'text-success'
+      return 'text-bg-success'
     }
 
     if (ts.isUnverified) {

--- a/app/components/me/timesheet-review-edit.hbs
+++ b/app/components/me/timesheet-review-edit.hbs
@@ -1,0 +1,80 @@
+<ModalDialog @title="Timesheet Correction" as |Modal|>
+  <ChForm @formId="correction"
+          @formFor={{@entry}}
+          @onSubmit={{this.save}} as |f|>
+    <Modal.body>
+      {{#if @entry.isRejected}}
+        <UiNotice @type="danger" @icon="times" @title="Correction request has been denied">
+        </UiNotice>
+      {{/if}}
+
+      You are requesting a correction for:
+      <div class="mt-2 h5 d-flex flex-column flex-lg-row">
+        <div class="d-inline-block me-2">
+          {{@entry.position.title}}
+        </div>
+        <div class="d-inline-block me-3">
+          {{credits-format @entry.credits}} credits
+        </div>
+        <div class="d-inline-block me-3">
+          {{shift-format @entry.on_duty @entry.off_duty}}
+        </div>
+        <div class="d-inline-block">
+          {{hour-minute-words @entry.duration}}
+        </div>
+      </div>
+      {{#if @entry.notes}}
+        <div class="border p-2 my-2">
+          <h5 class="mx-n2 mt-n2 p-2 bg-secondary text-white">Notes from you &amp; the Timesheet Wranglers</h5>
+          <TimesheetNotes @notes={{@entry.notes}} @isMe={{@isMe}} />
+        </div>
+      {{/if}}
+      If the position <b>{{@entry.position.title}}</b> is wrong, select the correct position below:
+      <FormRow>
+        <f.select @name="desired_position_id"
+                  @options={{this.desiredPositionOptions}}
+                  @inline={{true}}
+        />
+      </FormRow>
+      If the start time of <b>{{shift-format @entry.on_duty}}</b> is wrong, enter the correct time below:
+      <FormRow>
+        <f.datetime @name="desired_on_duty"
+                    @size={{20}}
+        />
+      </FormRow>
+      If the END TIME of <b>{{shift-format @entry.off_duty}}</b> is wrong, enter the correct time below:
+      <FormRow>
+        <f.datetime @name="desired_off_duty"
+                    @size={{20}}
+        />
+      </FormRow>
+      Please help us understand why this entry should be fixed by providing the following information:
+      <ul class="no-indent">
+        <li><b>Provide a BRIEF &amp; CONCISE explanation</b> in 1 to 3 sentences what needs to be corrected.</li>
+        <li><b>Who was your shift partner or the Shift Lead who can corroborate your story?</b></li>
+      </ul>
+      <FormRow>
+        <f.textarea @name="additional_notes"
+                    @label={{if @entry.isRejected "Supply additional information for an appeal:"
+                                "Enter your brief explanation below:"}}
+                    @cols={{80}}
+                    @rows={{3}}
+                    @maxlength={{1000}}
+                    @showCharCount={{true}}
+        />
+      </FormRow>
+      <h6 class="text-danger fw-bold">The request will be denied if:</h6>
+      {{fa-icon "ban" right=1}} You are requesting credit for time you were not on duty due to a late start.<br>
+      {{fa-icon "ban" right=1}} Not enough or incomplete information was provided.<br>
+      {{fa-icon "ban" right=1}} The requested changes cannot be confirmed by your shift partner(s) or the Shift Lead.
+      Yes, we do check!<br>
+    </Modal.body>
+    <Modal.footer @noAlign={{true}}>
+      <f.submit @label="Submit Correction Request" @disabled={{@entry.isSaving}} />
+      <UiCancelButton @disabled={{@entry.isSaving}} @onClick={{@onCancel}} />
+      {{#if @entry.isSaving}}
+        <LoadingIndicator/>
+      {{/if}}
+    </Modal.footer>
+  </ChForm>
+</ModalDialog>

--- a/app/components/me/timesheet-review-edit.js
+++ b/app/components/me/timesheet-review-edit.js
@@ -1,0 +1,76 @@
+import Component from '@glimmer/component';
+import {tracked} from '@glimmer/tracking';
+import {service} from '@ember/service';
+import {action} from '@ember/object';
+import {STATUS_PENDING} from "clubhouse/models/timesheet";
+import {isEmpty} from 'lodash';
+import dayjs from "dayjs";
+
+export default class MeTimesheetReviewEditComponent extends Component {
+  @service house;
+  @service modal;
+  @service shiftManage;
+  @service toast;
+
+  @tracked isSubmitting = false;
+  @tracked desiredPositionOptions;
+
+  constructor() {
+    super(...arguments);
+    const {entry} = this.args;
+    this.desiredPositionOptions = this.args.positions.map((p) => [p.title, p.id]);
+    this.desiredPositionOptions.unshift({
+      id: null,
+      title: `${entry.position.title} is correct`,
+    })
+  }
+
+  // Save correction notes
+  @action
+  save(model) {
+    if (!model.desired_position_id && !model.desired_on_duty && !model.desired_off_duty) {
+      this.modal.info('No corrections entered',
+        'You did not select a position, and/or enter the correct start or ending times');
+      return;
+    }
+
+    if (isEmpty(model.additional_notes) && !this.args.entry.notes.length) {
+      model.addError('additional_notes', 'Enter a reason why the entry should be corrected.');
+      return;
+    }
+
+    const positionId = isEmpty(model.desired_position_id) ? model.position_id : model.desired_position_id,
+      onDuty = isEmpty(model.desired_on_duty) ? model.on_duty : model.desired_on_duty,
+      offDuty = isEmpty(model.desired_off_duty) ? model.off_duty : model.desired_off_duty;
+
+    if (dayjs(offDuty).isBefore(dayjs(onDuty))) {
+      if (model.desired_on_duty) {
+        model.addError('desired_on_duty', 'The on duty time is after the off duty time.');
+      }
+      if (model.desired_off_duty) {
+        model.addError('desired_off_duty', 'The off duty time is before the on duty time.');
+      }
+      return;
+    }
+
+    if (model._changes['desired_position_id']
+      || model._changes['desired_on_duty']
+      || model._changes['desired_off_duty']) {
+      this.shiftManage.checkDateTime(positionId, onDuty, offDuty, () => this._performSave(model))
+    } else {
+      this._performSave(model);
+    }
+  }
+
+  async _performSave(model) {
+    try {
+      model.review_status = STATUS_PENDING;
+      await model.save();
+      this.args.entry.additional_notes = null;
+      this.args.onUpdate?.();
+      this.toast.success('The correction note has been submitted.');
+    } catch (response) {
+      this.house.handleErrorResponse(response);
+    }
+  }
+}

--- a/app/components/modal-asset-history.hbs
+++ b/app/components/modal-asset-history.hbs
@@ -5,8 +5,10 @@
       <tr>
         <th>Person</th>
         <th>Attachment</th>
-        <th>Checked Out Time /<br>By Person</th>
-        <th>Checked In Time /<br>By Person</th>
+        <th>Checked Out Time</th>
+        <th>By Person</th>
+        <th>Checked In Time</th>
+        <th>By Person</th>
       </tr>
       </thead>
       <tbody>
@@ -20,29 +22,33 @@
         {{#each this.assetHistory as |row|}}
           <tr>
             <td>
-              <PersonLink @person={{row.person}} @page="assets" />
+              <PersonLink @person={{row.person}} @page="assets"/>
             </td>
-            <td><PresentOrNot @value={{row.attachment.description}} @empty="-" /></td>
             <td>
-              {{shift-format row.checked_out}}<br>
+              <PresentOrNot @value={{row.attachment.description}} @empty="-"/>
+            </td>
+            <td>
+              {{shift-format row.checked_out}}
+            </td>
+            <td>
               {{#if row.check_out_person}}
                 <PersonLink @person={{row.check_out_person}} />
               {{else}}
                 -
               {{/if}}
             </td>
-            <td>
-              {{#if row.checked_in}}
-                {{shift-format row.checked_in}}<br>
-                {{#if row.check_in_person}}
-                  <PersonLink @person={{row.check_in_person}} />
-                {{else}}
-                  -
-                {{/if}}
-              {{else}}
+            {{#if row.checked_in}}
+              <td>
+                {{shift-format row.checked_in}}
+              </td>
+              <td>
+                <PersonLink @person={{row.check_in_person}} />
+              </td>
+            {{else}}
+              <td colspan="2" class="text-center">
                 <UiButton @size="sm" @onClick={{fn this.checkin row}}>Check In</UiButton>
-              {{/if}}
-            </td>
+              </td>
+            {{/if}}
           </tr>
         {{else}}
           <tr>

--- a/app/components/person/timesheet-edit-modal.hbs
+++ b/app/components/person/timesheet-edit-modal.hbs
@@ -80,18 +80,21 @@
           {{/if}}
         </div>
         {{#if @entry.isTooShort}}
-          <div class="text-danger">
+          <div class="text-danger mb-1">
             Entry might be too short. Duration is less than 15 minutes.
           </div>
         {{else if @entry.isTooLong}}
-          <div class="text-danger">
+          <div class="text-danger mb-1">
             Entry might be too long. Duration is over 1.5x the scheduled shift of
             {{hour-minute-words @entry.slot.duration}}.
           </div>
         {{/if}}
         {{#if @entry.timesOutsideRange}}
-          <div>
-            The date/times are outside the scheduled sign-up date ranges. This might indicate the date/times were entered incorrectly:
+          <div class="mb-1">
+            <span
+              class="text-danger fw-semibold">The entry's date/times are outside the scheduled sign-up date ranges.</span>
+            A previous correction may have been done incorrectly, an accidental shift
+            start occurred, or the wrong position selected at shift check-in.
             <ul>
               {{this.timeWarningsMessage}}
             </ul>
@@ -151,6 +154,17 @@
               {{/if}}
               </tbody>
             </UiTable>
+            {{#if @entry.desiredOutsideRange}}
+              <div>
+                <span class="text-danger fw-semibold">
+                  The DESIRED date/times are outside the scheduled sign-up date ranges.
+                </span>
+                This might indicate the date/times were entered incorrectly by the person:
+                <ul>
+                  {{this.desiredWarningsMessage}}
+                </ul>
+              </div>
+            {{/if}}
             <UiButton @onClick={{fn this.populatedDesiredChanges f.model}} @size="sm" @type="secondary">
               Use the desired change(s)
             </UiButton>

--- a/app/components/person/timesheet-edit-modal.js
+++ b/app/components/person/timesheet-edit-modal.js
@@ -6,6 +6,7 @@ import dayjs from 'dayjs';
 import {action} from '@ember/object';
 import {shiftFormat} from "clubhouse/helpers/shift-format";
 import {htmlSafe} from '@ember/template';
+import {cached} from '@glimmer/tracking';
 
 export default class PersonTimesheetEditModalComponent extends Component {
   reviewOptions = [
@@ -68,9 +69,19 @@ export default class PersonTimesheetEditModalComponent extends Component {
     }
   }
 
-  @action
-  timeWarningsMessage() {
+  @cached
+  get timeWarningsMessage() {
     const tw = this.args.entry.time_warnings;
+
+    return htmlSafe(
+      this._alertRange('On Duty', tw.start, tw.start_status, tw.begins, tw.ends)
+      + this._alertRange('Off Duty', tw.finished, tw.finished_status, tw.begins, tw.ends)
+    );
+  }
+
+  @cached
+  get desiredWarningsMessage() {
+    const tw = this.args.entry.desired_warnings;
 
     return htmlSafe(
       this._alertRange('On Duty', tw.start, tw.start_status, tw.begins, tw.ends)

--- a/app/components/person/timesheet-manage.hbs
+++ b/app/components/person/timesheet-manage.hbs
@@ -10,16 +10,15 @@
     </span>
     <b>Total Hours:</b>
     {{hour-minute-format @timesheetSummary.total_duration}}
-    <div class="d-flex mt-1">
-      <div>
-        <HoursDoCountLegend />
-      </div>
-      {{#if this.hasOverlapping}}
-        <div class="ms-2">
-          {{fa-icon "flag" color="danger"}} = entry's time overlaps with another entry.
-        </div>
-      {{/if}}
+    <div class="mt-2">
+
     </div>
+    <HoursDoCountLegend/>
+    {{#if this.hasOverlapping}}
+      <div class="mt-2 text-danger">
+        Warning: multiple entries are overlapping in time.
+      </div>
+    {{/if}}
     <UiTable>
       <thead>
       <tr>
@@ -34,7 +33,7 @@
       </thead>
       <tbody>
       {{#each @timesheets key="id" as |ts|}}
-        <tr class="align-middle">
+        <tr class="align-middle {{if ts.isOverlapping "table-danger"}}">
           <td>
             {{#if (is-empty ts.off_duty)}}
               {{fa-icon "person-walking"}}
@@ -53,13 +52,15 @@
             {{/if}}
           </td>
           <td>
-            {{#if ts.isOverlapping}}
-              {{fa-icon "flag" color="danger" right=1}}
-            {{/if}}
             {{#if ts.off_duty}}
               {{shift-format ts.on_duty ts.off_duty}}
             {{else}}
               {{shift-format ts.on_duty}}
+            {{/if}}
+            {{#if ts.isOverlapping}}
+              <div class="text-danger fw-semibold">
+                Time is overlapping.
+              </div>
             {{/if}}
             {{#unless ts.suppress_duration_warning}}
               {{#if ts.isTooShort}}

--- a/app/components/person/timesheet-missing.hbs
+++ b/app/components/person/timesheet-missing.hbs
@@ -1,10 +1,15 @@
 <UiSection id="missing-requests">
   <:title>{{@year}} Missing Timesheet Entry Requests</:title>
   <:body>
-    <p>
-      <UiButton @type="secondary" @onClick={{this.newEntryAction}}>New Request</UiButton>
-    </p>
-    {{pluralize @timesheetMissing.length "missing entry request"}}
+    <div class="align-middle mb-1">
+      {{pluralize @timesheetMissing.length "missing entry request"}}
+      <UiButton @type="secondary"
+                @onClick={{this.newEntryAction}}
+                @size="sm"
+                class="ms-4">
+        {{fa-icon "plus" right=1}} New Request
+      </UiButton>
+    </div>
     {{#if @timesheetMissing}}
       <UiTable>
         <thead>
@@ -192,6 +197,17 @@
           </tr>
           </tbody>
         </UiTable>
+        {{#if this.editEntry.timesOutsideRange}}
+          <div class="my-1">
+            <div class="text-danger fw-semibold">
+              The date/times are outside the scheduled sign-up date ranges.
+            </div>
+            This might indicate the date/times were entered incorrectly by the person, or the wrong position selected:
+            <ul>
+              {{this.timeWarningsMessage}}
+            </ul>
+          </div>
+        {{/if}}
         {{#if (and this.editEntry.partner this.editEntry.partner_info)}}
           <UiTable>
             <thead>
@@ -228,7 +244,9 @@
             </tbody>
           </UiTable>
         {{else}}
-          <i>No partner name given</i>
+          <p class="text-danger">
+            No shift partner name(s) stated.
+          </p>
         {{/if}}
         {{#if this.havePartnerTimesheet}}
           <fieldset>

--- a/app/components/schedule-position-list.hbs
+++ b/app/components/schedule-position-list.hbs
@@ -170,7 +170,7 @@
                 {{! Only allow admins to remove a sign up that has started}}
                   <button type="button"
                     {{on "click" (fn @leaveSlot slot)}}
-                          class="btn btn-danger btn-sm ms-1"
+                          class="btn btn-danger btn-sm"
                           title="Remove from schedule"
                           disabled={{slot.isSubmitting}}>
                     {{#if slot.isSubmitting}}
@@ -186,7 +186,7 @@
                 {{#if slot.slot_active}}
                   {{#if (or this.canForceSignUp (and (not slot.isFull) (not slot.has_started)))}}
                     <button type="button" {{on "click" (fn @joinSlot slot)}}
-                            class="btn btn-primary btn-sm ms-1"
+                            class="btn btn-primary btn-sm"
                             title="Sign up for the shift"
                             disabled={{slot.isSubmitting}}>
                       {{#if slot.isSubmitting}}

--- a/app/components/schedule-table.hbs
+++ b/app/components/schedule-table.hbs
@@ -101,7 +101,7 @@
                   {{else}}
                     {{fa-icon "trash-alt" type="fas" fixed=true right=1}}
                   {{/if}}
-                  &nbsp;Remove
+                  Remove
                 </button>
               {{~/if~}}
               {{#if slot.signUpInfo}}
@@ -119,10 +119,10 @@
                   disabled={{slot.isRetrievingSignUps}}>
                   {{#if slot.isRetrievingSignUps}}
                     <SpinIcon/>
-                    {{~else~}}
+                  {{else}}
                     {{fa-icon "users" type="fas" fixed=true right=1}}
                   {{/if}}
-                  &nbsp;Sign Ups
+                  Sign Ups
                 </button>
               {{/if}}
             </div>

--- a/app/components/shift-check-in-out.hbs
+++ b/app/components/shift-check-in-out.hbs
@@ -48,6 +48,13 @@
         {{/if}}
       </td>
     </tr>
+    {{#if (and @onDutyEntry.slot @onDutyEntry.slot.url)}}
+      <tr>
+        <td colspan="6">
+          <SlotInfoLink @description="Click for more information about this shift" @info={{@onDutyEntry.slot.url}} />
+        </td>
+      </tr>
+    {{/if}}
     </tbody>
   </UiTable>
   {{#unless @onDutyEntry.position.count_hours}}
@@ -63,7 +70,9 @@
   {{else if (not @hasUnreviewedTimesheet)}}
     {{#if this.inPersonTrainingPassed}}
       {{#if @upcomingSlots.imminent}}
-        {{@person.callsign}} can be signed into a scheduled shift OR a different shift (aka position).
+        <div class="mb-2 fw-semibold">
+          {{@person.callsign}} can be signed into a scheduled shift OR a different shift (aka position).
+        </div>
         <UiTable @normalSize={{true}}>
           <thead>
           <tr>
@@ -111,7 +120,11 @@
             {{/unless}}
             <tr>
               <td class="align-middle">
-                {{slot.position_title}}{{#if slot.slot_description}} - {{slot.slot_description}}{{/if}}
+                {{slot.position_title}}
+                {{#if slot.slot_description}}
+                  <br>
+                  <SlotInfoLink @description={{slot.slot_description}} @info={{slot.slot_url}} />
+                {{/if}}
               </td>
               <td class="align-middle">{{shift-format slot.slot_begins slot.slot_ends}}</td>
               <td class="align-middle">
@@ -193,7 +206,8 @@
           </p>
           {{#if this.noTrainingRequiredPositions}}
             <p>
-              The following positions are available to work that do not require passing an In-Person Training. Select the position, and the Start Shift button will
+              The following positions are available to work that do not require passing an In-Person Training. Select
+              the position, and the Start Shift button will
               appear.
             </p>
             <div class="columns-container columns-4">
@@ -349,34 +363,37 @@
       Timesheet entry might be too short
     </Modal.title>
     <Modal.body>
-      <p>
-        <b class="text-danger">The shift has not been ended. The timesheet entry might be too short at
-          {{hour-minute-words @onDutyEntry.duration}}.</b>
+      <p class="text-danger fw-semibold">
+        The shift has not been ended. The timesheet entry might be too short at
+        {{hour-minute-words @onDutyEntry.duration}}.
       </p>
       <p>
         Several options can be taken:
       </p>
-      <p>
-        If you are ending the shift because the position ({{@onDutyEntry.position.title}}) is wrong, just update
-        the position and do not end the shift.<br>
-        <UiButton @onClick={{this.updatePositionInstead}}>
-          Correct Position / Shift
-        </UiButton>
-      </p>
-      <p>
-        If the shift was started by mistake, the entry may be deleted.<br>
-        <UiButton @onClick={{this.deleteEntry}}>
-          Accidental shift start - Delete Entry
-        </UiButton>
-      </p>
-      <p>
-        If the duration is actually correct at {{hour-minute-format @onDutyEntry.duration}}, go ahead and end
-        the shift.<br>
-        <UiButton @onClick={{this.confirmEndShift}}>
-          Duration is correct - End Shift
-        </UiButton>
-      </p>
-
+      <ul>
+        <li>
+          <div class="fw-semibold mb-2">If the position {{@onDutyEntry.position.title}} is wrong, just correct the
+            position:
+          </div>
+          <UiButton @onClick={{this.updatePositionInstead}}>
+            {{fa-icon "edit" right=1}} Correct Position / Shift
+          </UiButton>
+        </li>
+        <li class="mt-4">
+          <div class="fw-semibold mb-2">If the shift was started by mistake:</div>
+          <UiButton @onClick={{this.deleteEntry}}>
+            {{fa-icon "trash" right=1}} Accidental Shift Start - Delete Entry
+          </UiButton>
+        </li>
+        <li class="mt-4">
+          <div class="fw-semibold mb-2">
+            If the duration is actually correct at {{hour-minute-words @onDutyEntry.duration}}:
+          </div>
+          <UiButton @onClick={{this.confirmEndShift}}>
+            {{fa-icon "check" right=1}} Duration is correct - End Shift
+          </UiButton>
+        </li>
+      </ul>
     </Modal.body>
     <Modal.footer>
       <UiCancelButton @onClick={{this.closeTooShortDialog}} />

--- a/app/constants/hq-todo.js
+++ b/app/constants/hq-todo.js
@@ -10,12 +10,14 @@ export const HQ_TODO_NO_RADIO = 'no-radio';
 export const HQ_TODO_START_SHIFT = 'start-shift';
 export const HQ_TODO_VERIFY_TIMESHEET = 'verify-timesheet';
 export const HQ_TODO_OFF_SITE = 'off-site';
+export const HQ_TODO_COLLECT_RADIO_IF_DONE = 'collect-radio-if-done';
 
 export const HqTodoLabels = {
   [HQ_TODO_COLLECT_RADIO]: 'Collect Radio',
+  [HQ_TODO_COLLECT_RADIO_IF_DONE]: 'Collect Radio (if done working)',
   [HQ_TODO_DELIVERY_MESSAGE]: 'Delivery Message(s)',
   [HQ_TODO_END_SHIFT]: 'End The Shift',
-  [HQ_TODO_ISSUE_RADIO]: 'Checkout Shift Radio',
+  [HQ_TODO_ISSUE_RADIO]: 'Checkout Radio',
   [HQ_TODO_MEAL_POG]: 'Issue Meal Pog (if qualified)',
   [HQ_TODO_MEAL_POG_NONE]: 'No Meal Pog - Has Meal Pass',
   [HQ_TODO_NO_RADIO]: 'Working Burn Perimeter - May not need a radio',

--- a/app/models/asset.js
+++ b/app/models/asset.js
@@ -31,14 +31,22 @@ export default class AssetModel extends Model {
   @attr('string', {readOnly: true}) created_at;
 
   get isRadio() {
-    return this.description === TYPE_RADIO;
+    return this.type === TYPE_RADIO;
   }
 
   get isGear() {
-    return this.description === TYPE_GEAR;
+    return this.type === TYPE_GEAR;
   }
 
   get typeLabel() {
     return TypeLabels[this.type] ?? this.type;
+  }
+
+  get assignmentLabel() {
+    if (this.isRadio) {
+      return this.perm_assign ? 'Event' : 'Shift';
+    } else {
+      return this.perm_assign ? 'Permanent' : 'Temporary';
+    }
   }
 }

--- a/app/models/timesheet-missing.js
+++ b/app/models/timesheet-missing.js
@@ -36,6 +36,8 @@ export default class TimesheetMissingModel extends Model {
 
   @attr('', {readOnly: true}) partner_info;
 
+  @attr('', {readOnly: true}) time_warnings;
+
   get isPending() {
     return this.review_status === PENDING;
   }
@@ -46,5 +48,9 @@ export default class TimesheetMissingModel extends Model {
 
   get isRejected() {
     return this.review_status === REJECTED;
+  }
+
+  get timesOutsideRange() {
+    return this.time_warnings?.status === 'out-of-range';
   }
 }

--- a/app/models/timesheet.js
+++ b/app/models/timesheet.js
@@ -65,6 +65,7 @@ export default class TimesheetModel extends Model {
   @attr('boolean', {readOnly: true}) was_signin_forced;
 
   @attr('', {readOnly: true}) time_warnings;
+  @attr('', {readOnly: true}) desired_warnings;
 
 
   @tracked isIgnoring = false; // Used by the HQ window interface
@@ -120,7 +121,10 @@ export default class TimesheetModel extends Model {
   }
 
   get timesOutsideRange() {
-    console.log('TIMES ', this.time_warnings);
     return this.time_warnings?.status === 'out-of-range';
+  }
+
+  get desiredOutsideRange() {
+    return this.desired_warnings?.status === 'out-of-range';
   }
 }

--- a/app/routes/admin.js
+++ b/app/routes/admin.js
@@ -1,26 +1,6 @@
 import ClubhouseRoute from 'clubhouse/routes/clubhouse-route';
-import {
-  ADMIN,
-  ANNOUNCEMENT_MANAGEMENT,
-  EDIT_ASSETS,
-  EDIT_SLOTS,
-  EDIT_SWAG,
-  MEGAPHONE, MEGAPHONE_EMERGENCY_ONPLAYA, MEGAPHONE_TEAM_ONPLAYA,
-  SURVEY_MANAGEMENT,
-  TIMESHEET_MANAGEMENT
-} from 'clubhouse/constants/roles';
+import {ADMIN} from 'clubhouse/constants/roles';
 
 export default class AdminRoute extends ClubhouseRoute {
-  roleRequired = [
-    ADMIN,
-    ANNOUNCEMENT_MANAGEMENT,
-    EDIT_ASSETS,
-    EDIT_SLOTS,
-    EDIT_SWAG,
-    MEGAPHONE,
-    MEGAPHONE_EMERGENCY_ONPLAYA,
-    MEGAPHONE_TEAM_ONPLAYA,
-    SURVEY_MANAGEMENT,
-    TIMESHEET_MANAGEMENT
-  ];
+  roleRequired = ADMIN
 }

--- a/app/routes/ops.js
+++ b/app/routes/ops.js
@@ -1,3 +1,6 @@
-import Route from '@ember/routing/route';
+import ClubhouseRoute from 'clubhouse/routes/clubhouse-route';
+import {MANAGE} from 'clubhouse/constants/roles';
 
-export default class OpsRoute extends Route {}
+export default class OpsRoute extends ClubhouseRoute {
+  roleRequired = MANAGE;
+}

--- a/app/routes/person/timesheet.js
+++ b/app/routes/person/timesheet.js
@@ -1,5 +1,4 @@
 import ClubhouseRoute from 'clubhouse/routes/clubhouse-route';
-import RSVP from 'rsvp';
 import requestYear from 'clubhouse/utils/request-year';
 import {ADMIN, TIMESHEET_MANAGEMENT} from "clubhouse/constants/roles";
 import {TRAINING} from "clubhouse/constants/positions";
@@ -9,13 +8,9 @@ export default class PersonTimesheetRoute extends ClubhouseRoute {
     year: { refreshModel: true }
   };
 
-  model(params) {
+  async model(params) {
     const year = requestYear(params);
     const person_id = this.modelFor('person').id;
-    const queryParams = {
-      person_id,
-      year,
-    };
 
     this.store.unloadAll('timesheet');
     this.store.unloadAll('timesheet-missing');
@@ -24,19 +19,20 @@ export default class PersonTimesheetRoute extends ClubhouseRoute {
     if (this.session.hasRole([ ADMIN, TIMESHEET_MANAGEMENT])) {
       timesheetQuery.include_admin_notes = 1;
     }
-    return RSVP.hash({
+
+    return {
       year: year,
-      timesheets: this.store.query('timesheet', timesheetQuery),
-      timesheetInfo: this.ajax.request('timesheet/info', { data: { person_id } })
+      timesheets: await this.store.query('timesheet', timesheetQuery),
+      timesheetInfo: await this.ajax.request('timesheet/info', { data: { person_id } })
         .then((result) => result.info),
-      timesheetMissing: this.store.query('timesheet-missing', queryParams),
-      positions: this.ajax.request(`person/${person_id}/positions`,{ data: { include_mentee: 1, include_training: 1, year } })
+      timesheetMissing: await this.store.query('timesheet-missing', { person_id, year, check_times: 1}),
+      positions: await this.ajax.request(`person/${person_id}/positions`,{ data: { include_mentee: 1, include_training: 1, year } })
         .then((results) => results.positions.filter((p) => p.id !== TRAINING)),
-      timesheetSummary: this.ajax.request(`person/${person_id}/timesheet-summary`, { data: { year }})
+      timesheetSummary: await this.ajax.request(`person/${person_id}/timesheet-summary`, { data: { year }})
         .then((result) => result.summary),
-      eventInfo: this.ajax.request(`person/${person_id}/event-info`, { data: { year } })
+      eventInfo: await this.ajax.request(`person/${person_id}/event-info`, { data: { year } })
         .then((result) => result.event_info)
-    });
+    };
   }
 
   setupController(controller, model) {

--- a/app/routes/vc.js
+++ b/app/routes/vc.js
@@ -1,6 +1,6 @@
 import ClubhouseRoute from 'clubhouse/routes/clubhouse-route';
-import { ADMIN, EDIT_BMIDS, VC } from 'clubhouse/constants/roles';
+import {ADMIN, EDIT_ACCESS_DOCS, EDIT_BMIDS, VC} from 'clubhouse/constants/roles';
 
 export default class VcRoute extends ClubhouseRoute {
-  roleRequired = [ ADMIN, EDIT_BMIDS, VC];
+  roleRequired = [ ADMIN, EDIT_BMIDS, EDIT_ACCESS_DOCS, VC];
 }

--- a/app/styles/schedule.scss
+++ b/app/styles/schedule.scss
@@ -169,11 +169,16 @@
     .schedule-actions {
       order: 7;
       width: 100%;
+      display: flex;
+      justify-content: space-between;
+      button {
+        display: inline-block;
+      }
     }
 
     .schedule-row button {
       display: inline-block;
-      width: 49%;
+      width: 48%;
     }
 
     .schedule-sm-label {

--- a/app/styles/timesheet.scss
+++ b/app/styles/timesheet.scss
@@ -16,19 +16,22 @@
   border-color: $table-border-color;
   font-weight: bold;
   padding: 0.125rem 0.25rem;
-}
+ }
 
 .timesheet-overlapping {
   background-color: #fbd3d3;
 }
 
 .timesheet-entry {
-  border-top: 1px solid #ddd;
   padding: 0.125rem 0.25rem;
-  margin-bottom: 1vh;
 }
 
-.timesheet-entry:nth-child(odd) {
+.timesheet-entry-container {
+  padding: 2px;
+  border: #c0dcf6 1px solid;
+  margin-bottom: 1vh;
+}
+.timesheet-entry-container:nth-child(odd) {
   background-color: $table-striped-bg;
 }
 
@@ -47,7 +50,6 @@
 
 .timesheet-actions {
   width: 100%;
-  padding: 0.125rem 0;
 }
 
 .timesheet-entry-header {
@@ -57,6 +59,7 @@
 
 .timesheet-actions {
   margin-top: 1vh;
+  margin-bottom: 0.5vh;
 
   button {
     display: inline-block;
@@ -89,6 +92,10 @@
 
   .timesheet-time {
     width: 30%;
+  }
+
+  .timesheet-header .timesheet-time {
+    margin-left: 5px;
   }
 
   .timesheet-duration {

--- a/app/templates/hq/shift.hbs
+++ b/app/templates/hq/shift.hbs
@@ -35,7 +35,7 @@
   {{/if}}
 
   <div class="d-flex justify-content-start">
-    <div class="flex-shrink-0 me-4 {{unless this.todoCount "text-success"}}">
+    <div class="flex-shrink-0 me-2 {{unless this.todoCount "text-success"}}">
       {{pluralize this.todoCount "suggested task"}}:
     </div>
     <div class="d-flex justify-content-start flex-wrap flex-shrink-1">
@@ -70,7 +70,7 @@
     {{/if}}
   </:title>
   <:body>
-    <HqTimesheetVerification @unverifiedTimesheets={{this.unverifiedTimesheets}}
+    <HqTimesheetVerification @unverifiedTimesheets={{this.timesheetsToReview}}
                              @completeTodo={{this.completeTodo}}
                              @onFinished={{this.afterShiftReview}}
                              @positions={{this.positions}}
@@ -100,9 +100,9 @@
   <:body>
     {{#unless this.personEvent.asset_authorized}}
       <UiNotice @type="danger" @title="Radio Agreement Not Signed - Do Not Issue Radios or Gear" @icon="ban">
-          The Radio Checkout Agreement has not been signed. {{this.person.callsign}} may not receive
-          radios or other gear until this is resolved. Direct {{this.person.callsign}} to the kiosk
-          shack, so they can log in into the Clubhouse, review, and sign the agreement.
+        The Radio Checkout Agreement has not been signed. {{this.person.callsign}} may not receive
+        radios or other gear until this is resolved. Direct {{this.person.callsign}} to the kiosk
+        shack, so they can log in into the Clubhouse, review, and sign the agreement.
       </UiNotice>
     {{/unless}}
 
@@ -133,10 +133,10 @@
       </ul>
     {{/if}}
 
-    <div class="mb-3">
+    <div class="mb-2">
       {{#if this.eventInfo.radio_eligible}}
-        {{this.person.callsign}} is authorized for <span class="fw-semibold">{{pluralize this.eventInfo.radio_max
-                                                                                         "event radio"}}</span>.
+        {{this.person.callsign}} is authorized for
+        <span class="fw-semibold">{{pluralize this.eventInfo.radio_max "event radio"}}</span>.
       {{else}}
         {{this.person.callsign}} is only authorized for <span class="fw-semibold">SHIFT RADIOS.</span>
       {{/if}}
@@ -203,8 +203,8 @@
                 {{pluralize this.assetsCheckedOut.length "asset"}} (radios, gear, etc.) not collected.
               </li>
             {{/if}}
-            {{#if this.unverifiedTimesheets}}
-              <li>{{pluralize this.unverifiedTimesheets.length "timesheet entry"}} not reviewed.</li>
+            {{#if this.timesheetsToReview}}
+              <li>{{pluralize this.timesheetsToReview.length "timesheet entry"}} not reviewed.</li>
             {{/if}}
           </ul>
           You may choose to ignore this warning and proceed to mark this person off site. However, you

--- a/app/templates/ops/assets.hbs
+++ b/app/templates/ops/assets.hbs
@@ -42,20 +42,17 @@
     {{#each this.viewAssets key="id" as |asset|}}
       <tr>
         <td>{{asset.barcode}}</td>
-        <td>{{this.typeLabel asset.type}}</td>
+        <td>{{asset.typeLabel}}</td>
         <td>
           <PresentOrNot @value={{asset.description}} @empty="-"/>
         </td>
-        <td>{{if asset.perm_assign "Perm" "Temp"}}</td>
+        <td class="text-center">{{asset.assignmentLabel}}</td>
         <td>
           <UiButton @type="secondary" @size="sm" @onClick={{fn this.assetHistoryAction asset}}>
-            History
+            {{fa-icon "rectangle-list" right=1}} History
           </UiButton>
-          <UiButton @type="danger" @size="sm" @onClick={{fn this.deleteAsset asset}}>
-            {{fa-icon "trash"}} Delete
-          </UiButton>
-          <UiButton @size="sm" @onClick={{fn this.editAsset asset}}>
-            {{fa-icon "edit"}}Edit
+           <UiButton @size="sm" @onClick={{fn this.editAsset asset}}>
+            {{fa-icon "edit" right=1}} Edit
           </UiButton>
         </td>
       </tr>
@@ -134,6 +131,11 @@
           {{#if this.isSubmitting}}
             <LoadingIndicator/>
           {{/if}}
+          <div class="ms-auto">
+            <UiButton @type="danger" @onClick={{this.deleteAsset}} @disabled={{this.isSubmitting}}>
+              {{fa-icon "trash" right=1}} Delete
+            </UiButton>
+          </div>
         </Modal.footer>
       </ChForm>
     </ModalDialog>

--- a/app/templates/person/timesheet.hbs
+++ b/app/templates/person/timesheet.hbs
@@ -5,27 +5,30 @@
             @subheader={{true}} />
 <UiTab class="mt-4" as |tab|>
   <tab.pane @title="Timesheet / Missing Entry Requests" @id="timesheet">
-    {{#if (or this.timesheetPendingCount this.missingRequestPendingCount)}}
-      <UiNotice @title="Timesheet Wrangler Review Needed" @icon="arrow-right">
-        {{#if this.timesheetPendingCount}}
-          {{pluralize this.timesheetPendingCount "timesheet entry"}} requires correction review.<br>
-        {{/if}}
-        {{#if this.missingRequestPendingCount}}
-          {{pluralize this.missingRequestPendingCount "Missing Timesheet Entry Request"}} requires attention.
-        {{/if}}
-      </UiNotice>
+    {{#if this.timesheetPendingCount}}
+      <UiAlert @icon="arrow-right" @type="warning">
+        {{pluralize this.timesheetPendingCount "timesheet entry"}} requires correction review.
+      </UiAlert>
     {{/if}}
+
+    {{#if this.missingRequestPendingCount}}
+      <UiAlert @icon="arrow-right" @type="warning">
+        {{pluralize this.missingRequestPendingCount "Missing Timesheet Entry Request"}} requires attention.
+          Jump to <a href="#missing-requests">Missing Timesheet Entry Requests</a>
+      </UiAlert>
+    {{/if}}
+
     {{#if (is-current-year this.year)}}
       {{#if this.timesheetInfo.timesheet_confirmed}}
-        <UiNotice @title="Timesheet Confirmed" @icon="check" @type="success">
-          The {{this.year}} timesheet was confirmed correct on
+        <UiAlert @icon="check" @type="success">
+          Timesheet confirmed correct on
           {{shift-format this.timesheetInfo.timesheet_confirmed_at year=true}} (Pacific). Any further updates to the
           entries will un-confirm the entire timesheet.
-        </UiNotice>
+        </UiAlert>
       {{else}}
-        <UiNotice @title="Timesheet Not Confirmed" @icon="hand">
+        <UiAlert @icon="hand" @type="secondary">
           {{this.person.callsign}} has not yet confirmed the {{this.year}} timesheet is correct.
-        </UiNotice>
+        </UiAlert>
       {{/if}}
       {{#if this.canForceConfirmation}}
         <p>
@@ -42,9 +45,6 @@
         placeholders and do not represent the actual volunteer work performed.
       </p>
     {{/if}}
-    <p>
-      Jump to <a href="#missing-requests">Missing Timesheet Entry Requests</a>
-    </p>
 
     <Person::TimesheetManage @timesheets={{this.timesheets}}
                              @person={{this.person}}


### PR DESCRIPTION
- HQ: Determine the collection method for radios when hitting the shift manage. Collect extra, collect none, or collect event radios if done working for the year.
- HQ: UI tweaks to the asset check in/out section
- HQ: State if the asset is an event or shift radio. Other display permanent or temporary labels.
- HQ: Provide the same correction dialog as what the end user sees. i.e., able to entered desired position, and start/stop times.
- HQ: Show the shift information is available upon shift start, or position correction.
- Cleaned up the asset history dialog.
- Person > Timesheet: Tighten up the UI.
- Person > Timesheet: Be very clear on shift overlaps.
- Person > Timesheet: Show desired correction warnings.
- Person > Timesheet: Warn when the entry was changed but the review status was left as pending review. -