### PR TITLE
Shift work.

### DIFF
--- a/app/components/admin/slot-form.hbs
+++ b/app/components/admin/slot-form.hbs
@@ -11,17 +11,21 @@
     <FormRow>
       <f.select @name="position_id"
                 @label="Position"
+                @fixedLabel={{true}}
+                @inline={{true}}
                 @options={{this.positionOptions}}
       />
     </FormRow>
-    <p>
+    <div class="my-2">
       When filling out the description, please avoid using "Click For More Info", or similar, phrasing.
-      The text entered in the Additional Information field will automatically be shown when the user
+      The text entered in the Additional Information field will be displayed automatically when the user
       signs up for the shift.
-    </p>
+    </div>
     <FormRow>
       <f.text @name="description"
               @label="Description"
+              @fixedLabel={{true}}
+              @inline={{true}}
               @size={{40}}
               @maxlength={{40}}
               @showCharCount={{true}}
@@ -29,7 +33,8 @@
     </FormRow>
     <FormRow>
       <f.datetime @name="begins"
-                  @label="Beginning Time"
+                  @label="Start Time"
+                  @fixedLabel={{true}}
                   @size={{16}}
                   @maxlength={{16}}
                   @inline={{true}}
@@ -40,18 +45,23 @@
                   @maxlength={{16}}
                   @inline={{true}}
       />
-    </FormRow>
-    <FormRow>
       <f.select @name="timezone"
                 @label="Timezone"
                 @options={{this.timezoneOptions}}
                 @inline={{true}}
       />
     </FormRow>
+  </fieldset>
+  <fieldset class="mt-2">
+    <legend>Additional Shift Information</legend>
     <div class="my-2">
-      Additional information may be given about the shift in the below area.
-      e.g., Women of Khaki will meet at Tokyo before shift. More info at http://women.khaki/meetup or email
-      women@khaki.rangers
+      Remember to provide additional information about the shift in the area below. Any url and emails will be
+      hyperlinked automatically. When the user signs up for this shift, the following information will be displayed
+      automatically.
+    </div>
+    <div class="my-2">
+      Example: <i>Women of Khaki will meet at Tokyo before shift. More info at
+      http://women.khaki/meetup or email women@khaki.rangers</i>
     </div>
     <FormRow>
       <f.textarea @name="url"
@@ -65,43 +75,57 @@
   </fieldset>
   <fieldset>
     <legend>Sign-Up Multiplier &amp; Parent Slot Assoc.</legend>
-    <FormRow>
-      <div class="col-12">
-        By setting the "Sign Up Multiplier Mentor/Trainer's Slot," the sign-up limit of this mentee/trainee slot will be
-        dynamically adjusted based on the number of Mentors/Trainers signed up. The max count of this slot will become a
-        multiplier. (For example, if the max count on this mentee shift is 2 and 3 mentors sign up, then 6 mentees will
-        be allowed to sign up.)
-      </div>
-    </FormRow>
-    <FormRow>
-      <f.select @name="trainer_slot_id"
-                @label="Sign Up Multiplier Mentor/Trainer's Slot"
-                @options={{this.trainerSlotsOptions}}
-                @includeBlank={{true}}
-                @inline={{true}}
-      />
-    </FormRow>
-    {{#if f.model.trainer_slot_id}}
+    <p>
+      By selecting a slot below, the sign-up limit of this mentee/trainee slot will be dynamically adjusted based
+      on the number of Mentors/Trainers signed up. The max count of this slot will become a multiplier.
+      (For example, if the max count on this mentee shift is 2 and 3 mentors sign up, then 6 mentees will
+      be allowed to sign up.) <span class="fw-semibold">It is recommended to use the <i>Link To Multiplier Slots</i>
+      button on the slots listing to set the slots in bulk</span> instead of trying to do this by hand.
+    </p>
+    {{#if f.model.parent_slot_id}}
+      <div class="col-12">A parent slot has been set. A multiple slot cannot be used.</div>
+    {{else if (or @slot.trainer_slot_id (this.hasParentPosition f.model.position_id))}}
+      <FormRow>
+        <f.select @name="trainer_slot_id"
+                  @label="Sign Up Multiplier Mentor/Trainer's Slot"
+                  @options={{this.slotOptions f.model.position_id}}
+                  @includeBlank={{true}}
+                  @inline={{true}}
+        />
+      </FormRow>
       <p>
         Warning: DO NOT link back the mentor/trainer slot to this slot. An infinite recursion loop will happen.
       </p>
+
+    {{else}}
+      <p>The selected position is not a child position.</p>
     {{/if}}
   </fieldset>
   <fieldset>
     <legend>Parent Sign-Up Count Adjustments</legend>
     <p>
-      When a parent sign up slot is set, the parent's and this slot's sign ups counts work together.
-      The signups for this shift are counted against the parent's signup count.
-      (e.g., if the parent has 3 signups, and this slot has 2, then parent's signup count will effectively be 5.)
+      When this slot is linked to a "parent" slot, this slot's signup counts are combined with the parent's
+      signup count. (e.g., if the parent shift has 3 signups, and this shift has 2, then parent's signup count
+      will effectively be 5.) The combined count may not exceed the parent's signup limit.
+      <span class="fw-semibold">It is recommended to use the <i>Link To Parent Slots</i>
+      button on the slots listing to set the slots in bulk</span> instead of trying to do this by hand.
     </p>
-    <FormRow>
-      <f.select @name="parent_signup_slot_id"
-                @label="Parent Sign-Up Slot"
-                @options={{this.parentSlotOptions f.model.position_id}}
-                @includeBlank={{true}}
-                @inline={{true}}
-      />
-    </FormRow>
+    {{#if f.model.trainer_slot_id}}
+      A trainer multiple slot has been set. A parent slot cannot be set at the same time.
+    {{else if (or @slot.parent_signup_slot_id (this.hasParentPosition f.model.position_id))}}
+      <FormRow>
+        <f.select @name="parent_signup_slot_id"
+                  @label="Link to parent slot"
+                  @options={{this.slotOptions f.model.position_id}}
+                  @includeBlank={{true}}
+                  @inline={{true}}
+        />
+      </FormRow>
+    {{else}}
+      <p>
+        The select position is not a child position.
+      </p>
+    {{/if}}
   </fieldset>
   <fieldset>
     <legend>Max Sign-Ups &amp; Activation</legend>

--- a/app/components/position-edit.hbs
+++ b/app/components/position-edit.hbs
@@ -43,11 +43,15 @@
       <f.number @name="min"
                 @label="Min"
                 @size={{3}}
-                @maxlength={{3}} />
+                @maxlength={{3}}
+                @inline={{true}}
+      />
       <f.number @name="max"
                 @label="Max"
                 @size={{3}}
-                @maxlength={{3}} />
+                @maxlength={{3}}
+                @inline={{true}}
+      />
     </FormRow>
   </fieldset>
 
@@ -82,12 +86,14 @@
     </UiAlert>
     <FormRow>
       <f.select @name="team_id"
-                @label="Belongs To Team"
+                @label="Team"
                 @options={{this.teamPositionOptions}}
+                @inline={{true}}
       />
       <f.select @name="team_category"
                 @label="Team Position Category"
                 @options={{this.categoryOptions}}
+                @inline={{true}}
                 @disabled={{not f.model.team_id}}
       />
     </FormRow>
@@ -145,11 +151,30 @@
       <FormRow>
         <f.select @name="training_position_id"
                   @label="Training Position"
+                  @inline={{true}}
+                  @fixedLabel={{true}}
                   @options={{this.trainingOptions}}
         />
       </FormRow>
     </fieldset>
   {{/unless}}
+  <fieldset>
+    <legend>Parent Position</legend>
+    <p>
+      Certain Mentor/Mentee (e.g., GD Mentor &amp; Mentee) shifts, and shifts where a child shift's signup count will
+      count against the parent's signups (e.g., "prime" Troubleshooter shifts &amp; TS Mentor) can be defined. The
+      parent position
+      info will be used by the slot interface to help link shifts together.
+    </p>
+    <FormRow>
+      <f.select @name="parent_position_id"
+                @label="Parent Position"
+                @inline={{true}}
+                @options={{this.parentPositionOptions}}
+      />
+    </FormRow>
+  </fieldset>
+
   <fieldset>
     <legend>Driving</legend>
     <FormRow>
@@ -227,17 +252,18 @@
       </div>
     </FormRow>
   </fieldset>
-  <div class="mt-4">
+  <div class="hstack gap-3 mt-4">
     <f.submit @disabled={{@position.isSaving}} />
     <UiCancelButton @onClick={{@cancelAction}} />
     {{#unless @position.isNew}}
-      <span class="ms-4">
+      <div class="ms-auto">
         <UiButton @type="danger" @onClick={{@deleteAction}}>
           {{fa-icon "trash"}} Delete Position
         </UiButton>
-      </span>
+      </div>
     {{/unless}}
   </div>
+
 </ChForm>
 
 {{#if @position.isSaving}}

--- a/app/components/position-edit.js
+++ b/app/components/position-edit.js
@@ -7,7 +7,7 @@ import {
   TEAM_CATEGORY_PUBLIC,
   TYPE_TRAINING
 } from "clubhouse/models/position";
-import { service } from '@ember/service';
+import {service} from '@ember/service';
 
 export default class PositionEditComponent extends Component {
   @service house;
@@ -24,6 +24,8 @@ export default class PositionEditComponent extends Component {
   constructor() {
     super(...arguments);
 
+    const {positions} = this.args;
+
     this.teamPositionOptions = [
       ['-', null]
     ];
@@ -34,11 +36,21 @@ export default class PositionEditComponent extends Component {
       ['-', '']
     ];
 
-    this.args.positions.forEach((position) => {
+    positions.forEach((position) => {
       if (position.type === TYPE_TRAINING && !position.title.match(/\btrainer\b/i)) {
         this.trainingOptions.push([position.title, position.id]);
       }
     });
+
+    this.parentPositionOptions = [
+      ['-', null]
+    ];
+
+    positions.forEach((position) => {
+      if (!position.parent_position_id) {
+        this.parentPositionOptions.push([position.title, position.id]);
+      }
+    })
 
     this.house.scrollToTop();
   }

--- a/app/components/position-table.hbs
+++ b/app/components/position-table.hbs
@@ -35,8 +35,10 @@
       <td class="text-center">{{position.min}} / {{position.max}}</td>
       <td>
         {{#if position.training_position_id}}
-          Training position:
-          <div class="ms-3">{{pluck position.training_position_id @positions "title" "-"}}</div>
+          Training position: {{pluck position.training_position_id @positions "title" "-"}}<br>
+        {{/if}}
+        {{#if position.parent_position_id}}
+          Parent position: {{pluck position.parent_position_id @positions "title" "-"}}<br>
         {{/if}}
         {{#if position.require_training_for_roles}}
           {{fa-icon "user-graduate" fixed=true}} Requires ART to be passed before roles are granted.<br>

--- a/app/components/schedule-table.hbs
+++ b/app/components/schedule-table.hbs
@@ -94,7 +94,7 @@
               {{#if (or (not slot.has_started) @isAdmin)}}
               {{! Note: magic here -  by not using onclick, no event argument will be passed to leaveSlot. That tells the method to allow the page to scroll.}}
                 <button type="button" {{on "click" (fn @leaveSlot slot)}}
-                        class="btn btn-danger btn-sm me-1"
+                        class="btn btn-danger btn-sm"
                         disabled={{slot.isSubmitting}}>
                   {{#if slot.isSubmitting}}
                     <SpinIcon/>

--- a/app/components/slot-link-shifts.hbs
+++ b/app/components/slot-link-shifts.hbs
@@ -1,0 +1,96 @@
+<h1>Link Slots to {{this.typeLabel}}</h1>
+<div class="my-2">
+  <a href {{action @onFinish}}>Back To Slots Listing</a>
+</div>
+
+<p>
+  {{#if this.didCommit}}
+    <b class="text-success">The slots have been updated.</b>
+  {{else}}
+    <b>This is a preview of what will be done.</b> If you are happy with how the shifts will be linked together, use the Commit
+    button. Any slots with errors will be skipped over.
+  {{/if}}
+</p>
+
+{{#if this.didCommit}}Updated{{else}}Previewing{{/if}} {{pluralize this.results.length "slot"}}.
+{{#if this.errorCount}}
+  <span class="fw-semibold text-danger ms-2">{{pluralize this.errorCount "error"}} encountered.</span>
+{{else}}
+  <span class="text-success ms-2">No errors encountered.</span>
+{{/if}}
+<UiTable>
+  <thead>
+  <tr>
+    <th>ID #</th>
+    <th>Position</th>
+    <th>Begins</th>
+    <th>Description</th>
+    <th>Link ID</th>
+    <th>Position</th>
+    <th>Description</th>
+    <th>&nbsp;</th>
+  </tr>
+  </thead>
+  <tbody>
+  {{#each this.results as |row|}}
+    <tr class={{if (not-eq row.status "success") "table-warning"}}>
+      <td class="text-end">{{row.id}}</td>
+      <td>{{@position.title}}</td>
+      <td>{{shift-format row.begins}}</td>
+      <td>{{row.description}}</td>
+      {{#if (eq row.status "success")}}
+        <td class="text-end">{{row.linked_slot.id}}</td>
+        <td>{{row.linked_slot.position_title}}</td>
+        <td>{{row.linked_slot.description}}</td>
+      {{else}}
+        <td colspan="3">-</td>
+      {{/if}}
+      <td>
+        {{#if (eq row.status "success")}}
+          <span class="text-success fw-semibold">
+            {{#if this.didCommit}}
+              Successfully linked.
+            {{else}}
+              Will be linked.
+            {{/if}}
+          </span>
+        {{else}}
+          {{this.errorLabel row.status}}
+          {{#if row.slots}}
+            <table>
+              <thead>
+              <tr>
+                <th>Slot #</th>
+                <th>Position</th>
+                <th>Description</th>
+              </tr>
+              </thead>
+              <tbody>
+              {{#each row.slots as |slot|}}
+                <tr>
+                  <td class="text-end">{{slot.id}}</td>
+                  <td>{{slot.position_title}}</td>
+                  <td>{{slot.description}}</td>
+                </tr>
+              {{/each}}
+              </tbody>
+            </table>
+          {{/if}}
+        {{/if}}
+      </td>
+    </tr>
+  {{/each}}
+  </tbody>
+</UiTable>
+
+{{#unless this.didCommit}}
+  <p>
+    <UiButton @onClick={{this.commit}}>Commit</UiButton>
+  </p>
+{{/unless}}
+
+<a href {{action @onFinish}}>Back To Slots Listing</a>
+
+{{#if this.isSubmitting}}
+  <LoadingDialog>Submitting the request</LoadingDialog>
+{{/if}}

--- a/app/components/slot-link-shifts.js
+++ b/app/components/slot-link-shifts.js
@@ -1,0 +1,77 @@
+import Component from '@glimmer/component';
+import {service} from '@ember/service';
+import {action} from '@ember/object';
+import {tracked} from '@glimmer/tracking';
+
+const STATUS_SUCCESS = 'success';
+const STATUS_NOT_CHILD = 'not-child';
+const STATUS_NO_PARENT_SLOT = 'no-parent-slot';
+const STATUS_MULTIPLE_SLOTS_FOUND = 'multiple-slots';
+
+const TYPE_MULTIPLIER = 'multiplier';
+const TYPE_PARENT = 'parent';
+
+const StatusLabels = {
+  [STATUS_SUCCESS]: 'success',
+  [STATUS_NOT_CHILD]: 'Position is not a child of another position',
+  [STATUS_NO_PARENT_SLOT]: 'No parent / mentor slot could be found',
+  [STATUS_MULTIPLE_SLOTS_FOUND]: 'Multiple parent / mentor slots found. Automated linking not possible.',
+}
+export default class SlotLinkShiftsComponent extends Component {
+  @service ajax;
+  @service house;
+  @service modal;
+  @service toast;
+
+  @tracked results = [];
+  @tracked didPreview;
+  @tracked isSubmitting;
+  @tracked didCommit;
+
+  constructor() {
+    super(...arguments);
+
+    this.slotIds = this.args.slots.map((s) => +s.id);
+    this.typeLabel = this.args.type === TYPE_MULTIPLIER ? "Sign-Up Multiplier" : "Link To Parent Shift";
+    this._execute(false);
+  }
+
+  @action
+  commit() {
+    this.modal.confirm('Confirm Linking',
+      `You are about to link the slots to their ${this.args.type === TYPE_PARENT ? 'parent' : 'sign-up multiplier'} slots. Are you sure you want to continue?`,
+      () => this._execute(true));
+  }
+
+  async _execute(commit) {
+    this.isSubmitting = true;
+    try {
+      const {slots} = await this.ajax.post(`slot/link-slots`, {
+        data: {
+          slot_ids: this.slotIds,
+          commit: commit ? 1 : 0,
+          type: this.args.type,
+        }
+      });
+      this.results = slots;
+      this.didCommit = commit;
+      if (commit) {
+        this.toast.success('The slots have been linked');
+        this.house.scrollToTop();
+      }
+    } catch (response) {
+      this.house.handleErrorResponse(response);
+    } finally {
+      this.isSubmitting = false;
+    }
+  }
+
+  get errorCount() {
+    return this.results.filter((r) => r.status !== STATUS_SUCCESS).length;
+  }
+
+  @action
+  errorLabel(status) {
+    return StatusLabels[status] ?? `Unknown status: ${status}`;
+  }
+}

--- a/app/controllers/ops/slots.js
+++ b/app/controllers/ops/slots.js
@@ -38,6 +38,9 @@ export default class OpsSlotsController extends ClubhouseController {
 
   @tracked bulkEditPosition;
 
+  @tracked linkGroup;
+  @tracked linkType;
+
   @action
   changeActiveFilter(value) {
     this.activeFilter = value;
@@ -95,16 +98,15 @@ export default class OpsSlotsController extends ClubhouseController {
   _buildPositionSlots() {
     const groups = [];
 
-    this.viewSlots.forEach(function (slot) {
-      const title = slot.position_title;
-      let group = groups.find((g) => g.title === title);
+    this.viewSlots.forEach((slot) => {
+      const position = this.positionsById[slot.position_id];
+      let group = groups.find((g) => slot.position_id === +g.position.id);
 
       if (group) {
         group.slots.push(slot);
       } else {
         group = {
-          title,
-          position_id: slot.position_id,
+          position,
           slots: [slot],
           inactive: 0,
           showing: false
@@ -117,11 +119,11 @@ export default class OpsSlotsController extends ClubhouseController {
       }
     });
 
-    this.positionSlots = _.sortBy(groups, 'title');
+    this.positionSlots = _.sortBy(groups, (g) => g.position.title);
   }
 
   get positionsScrollList() {
-    return this.positionSlots.map((p) => ({id: `position-${p.position_id}`, title: p.title}));
+    return this.positionSlots.map((p) => ({id: `position-${p.position.id}`, title: p.position.title}));
   }
 
   @action
@@ -324,5 +326,17 @@ export default class OpsSlotsController extends ClubhouseController {
   bulkEditPositionUpdatedAction() {
     this._buildPositionSlots();
     this.showBulkEditDialog = false;
+  }
+
+  @action
+  openLinkSlots(group, type) {
+    this.linkGroup = group;
+    this.linkType = type;
+  }
+
+  @action
+  closeLinkSlots() {
+    this.linkGroup = null;
+    this.linkType = null;
   }
 }

--- a/app/models/position.js
+++ b/app/models/position.js
@@ -29,7 +29,7 @@ export default class PositionModel extends Model {
 
   @attr('boolean', {defaultValue: false}) require_training_for_roles;
 
-  @attr('boolean', { defaultValue: false }) no_training_required;
+  @attr('boolean', {defaultValue: false}) no_training_required;
 
   @attr('') role_ids;
 
@@ -40,6 +40,7 @@ export default class PositionModel extends Model {
   @attr('string') short_title;
   @attr('string') type;
   @attr('number') training_position_id;
+  @attr('number') parent_position_id;
   @attr('boolean') prevent_multiple_enrollments;
   @attr('string') contact_email;
   @attr('boolean', {defaultValue: true}) active;
@@ -52,8 +53,8 @@ export default class PositionModel extends Model {
 
   @attr('string') resource_tag;
 
-  @attr('boolean', { defaultValue: false}) auto_sign_out;
-  @attr('number', {defaultValue: 0.0 }) sign_out_hour_cap;
+  @attr('boolean', {defaultValue: false}) auto_sign_out;
+  @attr('number', {defaultValue: 0.0}) sign_out_hour_cap;
 
   // Paycom employee paycode
   @attr('string') paycode;

--- a/app/routes/ops/slots.js
+++ b/app/routes/ops/slots.js
@@ -4,7 +4,7 @@ import RSVP from 'rsvp';
 
 export default class OpsSlotsRoute extends ClubhouseRoute {
   queryParams = {
-    year: { refreshModel: true }
+    year: {refreshModel: true}
   };
 
   model(params) {
@@ -14,20 +14,24 @@ export default class OpsSlotsRoute extends ClubhouseRoute {
     this.store.unloadAll('position');
 
     return RSVP.hash({
-      slots: this.store.query('slot', { year }),
+      slots: this.store.query('slot', {year}),
       positions: this.store.query('position', {}),
       year,
       yearList: this.ajax.request('slot/years').then((result) => result.years),
-      eventDate: this.ajax.request('event-dates/year', { data: { year }}).then((result) => result.event_date)
+      eventDate: this.ajax.request('event-dates/year', {data: {year}}).then((result) => result.event_date)
     });
   }
 
   setupController(controller, model) {
-    controller.set('slot', null);
     controller.setProperties(model)
-    controller.set('dayFilter', 'all');
-    controller.set('activeFilter', 'all');
-    controller.set('positionsOpened', {});
+    controller.slot = null;
+    controller.dayFilter = 'all';
+    controller.activeFilter = 'all';
+    controller.positionsOpened = {};
+    controller.positionsById = model.positions.reduce((hash, row) => {
+      hash[+row.id] = row;
+      return hash
+    }, {})
     controller._buildDisplay();
   }
 }

--- a/app/styles/schedule.scss
+++ b/app/styles/schedule.scss
@@ -1,5 +1,5 @@
 .schedule-table {
-  margin-bottom: 10px;
+  margin-bottom: 1vh;
   font-size: 0.95em;
   max-width: 1200px;
 }
@@ -21,8 +21,8 @@
   background-color: #fff3cd;
   width: 100%;
   vertical-align: middle;
-  padding-top: 5px !important;
-  padding-bottom: 10px !important;
+  padding-top: 0.5vh !important;
+  padding-bottom: 1vh !important;
 }
 
 .schedule-overlapping {
@@ -33,19 +33,19 @@
   display: flex;
   flex-wrap: wrap;
   border-top: 1px solid #ddd;
-  padding: 0 5px 10px 5px;
+  padding: 0 0.5vw 1vh 0.5vw;
   width: 100%;
   align-items: center;
 
   > div {
     display: inline-block;
-    margin-top: 5px;
+    margin-top: 0.5vh;
     align-self: center;
   }
 }
 
 .schedule-signup-row {
-  padding: 0 5px 10px 35px;
+  margin: 1vh 1vw;
   width: 100%;
 }
 
@@ -61,9 +61,13 @@
   font-size: 0.9rem;
 }
 
+.schedule-actions button:not(:last-child) {
+    margin-right: 0.75vw;
+}
+
 @media print, (min-width: map-get($grid-breakpoints, "lg")) {
   .schedule-row > div {
-    padding-right: 5px;
+    padding-right: 0.5vw;
   }
 
   .schedule-icon {
@@ -92,17 +96,12 @@
 
 
   .schedule-sub-header-text {
-    margin-left: 30px;
-    margin-right: 5px;
+    margin-left: 1.5vw;
+    margin-right: 1vw;
   }
 
   .schedule-sm-label {
     display: none;
-  }
-
-  .schedule-actions {
-    margin-left: 10px;
-    //align-self: center;
   }
 }
 
@@ -133,8 +132,8 @@
     }
 
     .schedule-sub-header {
-      padding-left: 10px;
-      padding-right: 10px;
+      padding-left: 1vw;
+      padding-right: 1vw;
     }
 
     .schedule-time-description {
@@ -161,8 +160,8 @@
     .schedule-signups {
       order: 6;
       width: 100%;
-      margin-top: 15px !important;
-      margin-bottom: 10px !important;
+      margin-top: 2vh !important;
+      margin-bottom: 1.5vh !important;
     }
 
 
@@ -183,7 +182,7 @@
 
     .schedule-sm-label {
       display: inline-block;
-      margin-right: 5px;
+      margin-right: 0.5vw;
     }
   }
 }

--- a/app/templates/ops/slots.hbs
+++ b/app/templates/ops/slots.hbs
@@ -1,5 +1,5 @@
 <main>
-  <div class={{if (or this.showSlotCopyDialog this.slot this.showBulkEditDialog) "d-none"}}>
+  <div class={{if (or this.showSlotCopyDialog this.slot this.showBulkEditDialog this.linkGroup) "d-none"}}>
     <YearSelect @title="Clubhouse Slots"
                 @year={{this.year}}
                 @years={{this.yearList}}
@@ -32,7 +32,7 @@
                         @onChange={{this.changeActiveFilter}} />
       </div>
       <FormLabel @auto={{true}}>Actions</FormLabel>
-      <div class="col-auto">
+      <div class="col-auto hstack gap-3">
         <UiButton @onClick={{this.newSlot}}>New Slot</UiButton>
         {{#if this.slots.length}}
           <UiButton @onClick={{fn this.openSlotCopy null}} @type="secondary">Copy Slots</UiButton>
@@ -57,28 +57,36 @@
     {{/if}}
 
 
-    {{#each this.positionSlots as |position|}}
-      <UiAccordion id="position-{{position.position_id}}"
-                   @isInitOpen={{get this.positionsOpened position.position_id}}
-                   @onClick={{action this.positionClicked position}} as |box|>
+    {{#each this.positionSlots as |group|}}
+      <UiAccordion id="position-{{group.position.id}}"
+                   @isInitOpen={{get this.positionsOpened group.position.id}}
+                   @onClick={{action this.positionClicked group}} as |box|>
         <box.title>
-          {{position.title}} ({{position.slots.length}}
-          {{~#if position.inactive}}
-            / <span class="text-danger">{{position.inactive}} inactive</span>
+          {{group.position.title}} ({{group.slots.length}}
+          {{~#if group.inactive}}
+            / <span class="text-danger">{{group.inactive}} inactive</span>
           {{~/if}})
         </box.title>
         <box.body>
           {{#if box.isOpen}}
-            <p>
-              <UiButton @size="sm" @onClick={{fn this.activate position}}>Activate All</UiButton>
-              <UiButton @size="sm" @onClick={{fn this.deactivate position}}>Deactivate All</UiButton>
-              <UiButton @type="secondary" @size="sm" @onClick={{fn this.openSlotCopy position.position_id}}>
+            <div class="hstack gap-2 mb-2">
+              <UiButton @size="sm" @onClick={{fn this.activate group}}>Activate All</UiButton>
+              <UiButton @size="sm" @onClick={{fn this.deactivate group}}>Deactivate All</UiButton>
+              <UiButton @type="secondary" @size="sm" @onClick={{fn this.openSlotCopy group.position.id}}>
                 Bulk Copy
               </UiButton>
-              <UiButton @type="secondary" @size="sm" @onClick={{fn this.bulkEditOpenAction position}}>
+              <UiButton @type="secondary" @size="sm" @onClick={{fn this.bulkEditOpenAction group}}>
                 Bulk Edit
               </UiButton>
-            </p>
+              {{#if group.position.parent_position_id}}
+                <UiButton @type="secondary" @size="sm" @onClick={{fn this.openLinkSlots group "multiplier"}}>
+                  Link To Multiplier Slots
+                </UiButton>
+                <UiButton @type="secondary" @size="sm" @onClick={{fn this.openLinkSlots group "parent"}}>
+                  Link to Parent Slots
+                </UiButton>
+              {{/if}}
+            </div>
             <UiTable>
               <thead>
               <tr>
@@ -93,18 +101,32 @@
               </tr>
               </thead>
               <tbody>
-              {{#each position.slots key="id" as |slot|}}
+              {{#each group.slots key="id" as |slot|}}
                 <tr id="slot-{{slot.id}}">
                   <td class="text-end">{{slot.id}}</td>
                   <td>
                     {{shift-format slot.begins slot.ends timezone=slot.timezone_abbr}}
+                    {{#if slot.trainer_slot}}
+                      <div class="mt-1">
+                        Multiplier
+                        #{{slot.trainer_slot.id}} {{slot.trainer_slot.position.title}} {{slot.trainer_slot.description}}
+                        {{shift-format slot.trainer_slot.begins}}
+                      </div>
+                    {{/if}}
+                    {{#if slot.parent_signup_slot}}
+                      <div class="mt-1">
+                        Parent
+                        #{{slot.parent_signup_slot.id}} {{slot.parent_signup_slot.position.title}} {{slot.parent_signup_slot.description}}
+                        {{shift-format slot.parent_signup_slot.begins}}
+                      </div>
+                    {{/if}}
                   </td>
                   <td class="text-end">{{slot.max}}</td>
                   <td class="text-end">{{slot.signed_up}}</td>
                   <td class="text-end">{{credits-format slot.credits}}</td>
                   <td>
                     <SlotInfoLink @description={{slot.description}} @info={{slot.url}} />
-                  </td>
+                    </td>
                   <td class="text-center">
                     {{#if slot.active}}
                       {{fa-icon "check" color="success"}}
@@ -127,17 +149,6 @@
                     </UiButton>
                   </td>
                 </tr>
-                {{#if slot.trainer_slot}}
-                  <tr class="{{if slot.trainer_slot "tr-no-border"}}">
-                    <td colspan="8">
-                      Multiplier slot:
-                      <a href="#slot-{{slot.trainer_slot.id}}">
-                        #{{slot.trainer_slot.id}} {{slot.trainer_slot_title}} {{slot.trainer_slot.description}}
-                        {{shift-format slot.trainer_slot.begins}}
-                      </a>
-                    </td>
-                  </tr>
-                {{/if}}
               {{/each}}
               </tbody>
             </UiTable>
@@ -175,6 +186,14 @@
                          @position={{this.bulkEditPosition}}
                          @onPositionUpdate={{this.bulkEditPositionUpdatedAction}}
                          @onClose={{this.bulkEditCloseAction}}
+    />
+  {{/if}}
+
+  {{#if this.linkGroup}}
+    <SlotLinkShifts @slots={{this.linkGroup.slots}}
+                    @position={{this.linkGroup.position}}
+                    @type={{this.linkType}}
+                    @onFinish={{this.closeLinkSlots}}
     />
   {{/if}}
 </main>


### PR DESCRIPTION
- Use viewpoint percentages instead of pixel units in the schedule css.
- Fixed button layout on schedule page.
- New slot administration features Link To Multiplier Slots, and Link To Parent Slots. No more hand feeding of SQL commands trying to link the multiplier slots together in bulk.
- New Parent Position to aid the above features.