### PR TITLE
Alter VP references to avoid free in ambiguous cases

### DIFF
--- a/app/components/ticket-vp-info.hbs
+++ b/app/components/ticket-vp-info.hbs
@@ -46,10 +46,10 @@
   </p>
 {{else}}
   <p>
-    <b>Sorry, but it doesn't look like you qualified for a free Vehicle Pass.</b>
+    <b>Sorry, but it doesn't look like you qualified for a Vehicle Pass.</b>
   </p>
   <p>
-    Free Vehicle Passes are provided to Rangers who qualified for a Staff Credential or
+    Vehicle Passes are provided to Rangers who qualified for a Staff Credential or
     Special Price Ticket.
   </p>
 {{/if}}

--- a/app/components/ticketing-announce.hbs
+++ b/app/components/ticketing-announce.hbs
@@ -59,7 +59,7 @@
       </p>
       <p>
         {{#if @ticketPackage.tickets}}
-          A free Vehicle Pass will be made available if you claim a ticket through the Ranger department and intend
+          A Vehicle Pass will be made available if you claim a ticket through the Ranger department and intend
           to work the upcoming event.
         {{else}}
           Sorry, you do not qualify for a Vehicle Pass through the Ranger department because no ticket was qualified for


### PR DESCRIPTION
Removes two references in templates to free VPs where the VP might be free or Special-Price based on the ticket type earned.