### PR TITLE
On the BMID management interfaces for non-rangers, only show the no-print BMID warning if they have no signups.

### DIFF
--- a/app/components/bmid-edit.hbs
+++ b/app/components/bmid-edit.hbs
@@ -1,13 +1,17 @@
 <ChForm @formId="bmid" @formFor={{@entry}} @onSubmit={{@onSave}} as |f|>
-  {{#if this.notQualified}}
+  {{#if @entry.notQualifiedToPrint}}
     <p>
       <UiNotice @type={{if @entry.isNew "danger" "secondary"}}
-                @title="No Claimed Ticket nor In-Person Training Sign-Up Found"
+                @title={{if this.isNonRanger "No Sign Ups Found" "No Claimed Ticket nor In-Person Training Sign-Up Found"}}
                 @icon="hand"
       >
         <p>
-          Because the person has not signed up for In-Person Training nor claimed a ticket, the recommendation is to not
-          print their BMID.
+          {{#if this.isNonRanger}}
+            Because the Non-Ranger has not signed up for any shifts, the recommendation is to not print their BMID.
+          {{else}}
+            Because the person has not signed up for an In-Person Training nor claimed a ticket, the recommendation is to not
+            print their BMID.
+          {{/if}}
         </p>
         {{#if @entry.isNew}}
           To ensure the BMID is printed, set the status to "Prep" or "Ready To Print" (don't forget to fill out the

--- a/app/components/bmid-edit.js
+++ b/app/components/bmid-edit.js
@@ -4,14 +4,14 @@ import {
   BmidStatusOptions,
   ShowerOptions
 } from 'clubhouse/models/bmid';
+import {NON_RANGER} from "clubhouse/constants/person_status";
 
 export default class BmidEditComponent extends Component {
   bmidStatusOptions = BmidStatusOptions;
   mealOptions = MealOptions;
   showerOptions = ShowerOptions;
 
-  get notQualified() {
-    const {entry} = this.args;
-    return !entry.has_ticket && !entry.training_signed_up;
+  get isNonRanger() {
+    return this.args.entry.person.status === NON_RANGER;
   }
 }

--- a/app/components/intake-notes.hbs
+++ b/app/components/intake-notes.hbs
@@ -7,19 +7,21 @@
       </div>
     </div>
     {{#if intake.have_notes}}
-      {{#each intake.notes as |note|}}
-        {{#unless note.is_log}}
-          <div class="mb-1">
-            &mdash; {{note.note}}
-            {{#if this.canAddNote}}
-              <div class="mt-2 mb-3">
-                <a href {{on-click this.updateNoteAction note}} class="me-4">Update</a>
-                <a href {{on-click this.deleteNoteAction note}}>Delete</a>
-              </div>
-            {{/if}}
-          </div>
-        {{/unless}}
-      {{/each}}
+      <ul class="no-indent">
+        {{#each intake.notes as |note|}}
+          {{#unless note.is_log}}
+            <li>
+              {{note.note}}
+              {{#if this.canAddNote}}
+                <div class="mt-2 mb-3">
+                  <a href {{on-click this.updateNoteAction note}} class="me-4">Update</a>
+                  <a href {{on-click this.deleteNoteAction note}}>Delete</a>
+                </div>
+              {{/if}}
+            </li>
+          {{/unless}}
+        {{/each}}
+      </ul>
     {{else}}
       <i>no notes</i>
     {{/if}}

--- a/app/components/intake-ranking.hbs
+++ b/app/components/intake-ranking.hbs
@@ -1,15 +1,25 @@
 {{#if this.rank~}}
   {{#if (eq this.rank 1)}}
-    <span class="rank-1">{{fa-icon "award" right=1}} Rank 1/Green</span>
+    <UiBadge @type="success">
+      {{fa-icon "award" right=1}} Rank 1/Green
+    </UiBadge>
   {{else if (eq this.rank 2)}}
-    <span class="rank-2">Rank 2/Normal</span>
+    <UiBadge @type="secondary">
+      Rank 2/Normal
+    </UiBadge>
   {{else if (eq this.rank 3)}}
-    <span class="rank-3">{{fa-icon "bell" type="r" right=1}} Rank 3/Yellow</span>
+    <UiBadge @type="warning">
+      {{fa-icon "bell" type="r" right=1}} Rank 3/Yellow
+    </UiBadge>
   {{else if (eq this.rank 4)}}
-    <span class="rank-4">{{fa-icon "flag" right=1}} Rank 4/FLAG</span>
+    <UiBadge @type="dark">
+      {{fa-icon "flag" right=1}} Rank 4/FLAG
+    </UiBadge>
   {{else}}
     {{this.rank}}/Unknown
   {{/if}}
-{{~else~}}
-  <span class="rank-none">No Rank</span>
+  {{~else~}}
+  <UiBadge @type="light">
+    No Rank
+  </UiBadge>
 {{~/if~}}

--- a/app/components/intake-training.hbs
+++ b/app/components/intake-training.hbs
@@ -19,18 +19,22 @@
           </div>
         {{else}}
           <div>
-            <UiBadge @text="Training Pending" @type="secondary" />
+            <UiBadge @text="training pending" @type="warning"/>
           </div>
         {{/if}}
       </div>
       {{#if training.slot_has_ended}}
-        {{#each training.training_notes as |note|}}
-          {{#unless note.is_log}}
-            &mdash; {{note.note}}<br>
-          {{/unless}}
+        {{#if training.training_notes}}
+          <ul class="no-indent">
+            {{#each training.training_notes as |note|}}
+              {{#unless note.is_log}}
+                <li>{{note.note}}</li>
+              {{/unless}}
+            {{/each}}
+          </ul>
         {{else}}
           <i>No training notes</i>
-        {{/each}}
+        {{/if}}
       {{/if}}
     </div>
   {{/each}}

--- a/app/components/ui-badge.hbs
+++ b/app/components/ui-badge.hbs
@@ -1,1 +1,7 @@
-<span class="badge text-bg-{{@type}}" ...attributes>{{@text}}</span>
+<span class="badge text-bg-{{@type}}" ...attributes>
+  {{#if (has-block)}}
+    {{yield}}
+  {{else}}
+    {{@text}}
+  {{/if}}
+</span>

--- a/app/models/bmid.js
+++ b/app/models/bmid.js
@@ -2,6 +2,7 @@ import Model, {attr} from '@ember-data/model';
 import {isEmpty} from '@ember/utils';
 import {ticketTypeLabel} from 'clubhouse/constants/ticket-types';
 import dayjs from 'dayjs';
+import {NON_RANGER} from "clubhouse/constants/person_status";
 
 export const MEALS_ALL = 'all';
 export const MEALS_EVENT = 'event';
@@ -261,6 +262,10 @@ export default class BmidModel extends Model {
   }
 
   get notQualifiedToPrint() {
-    return !this.has_ticket && !this.training_signed_up;
+    if (this.person?.status === NON_RANGER) {
+      return !this.has_signups;
+    } else {
+      return !this.has_ticket && !this.training_signed_up;
+    }
   }
 }

--- a/app/templates/person/bmid.hbs
+++ b/app/templates/person/bmid.hbs
@@ -8,4 +8,5 @@
 <BmidEdit @entry={{this.bmid}}
           @year={{this.year}}
           @admissionDateOptions={{this.admissionDateOptions}}
-          @onSave={{this.save}} />
+          @onSave={{this.save}}
+/>

--- a/app/templates/vc/bmid.hbs
+++ b/app/templates/vc/bmid.hbs
@@ -86,10 +86,10 @@
     <div class="col-auto">
       <UiButtonRow>
         <UiButton @type="secondary" @size="sm" @onClick={{this.toggleEditMode}}>
-          {{#if this.editMode}}{{fa-icon "table"}} Table View{{else}}{{fa-icon "edit"}} Edit Mode{{/if}}
+          {{#if this.editMode}}{{fa-icon "table" right=1}} Table View{{else}}{{fa-icon "edit" right=1}} Edit Mode{{/if}}
         </UiButton>
         <UiButton @type="secondary" @size="sm" @onClick={{this.exportCSV}}>
-          {{fa-icon "file-export"}} Export CSV
+          {{fa-icon "file-export" right=1}} Export CSV
         </UiButton>
       </UiButtonRow>
     </div>
@@ -104,9 +104,9 @@
   </p>
 
   <p>
-    <span class="d-inline-block">{{fa-icon "exclamation-circle" color="danger"}} = indicates person has not a claimed
+    <span class="d-inline-block">{{fa-icon "exclamation-circle" color="danger" right=1}} = indicates person has not a claimed
       a ticket or SAP, nor signed up for an In-Person Training.</span>
-    <span class="d-inline-block">{{fa-icon "eye" color="danger"}} = person does not have an approved photo</span>
+    <span class="d-inline-block">{{fa-icon "eye" color="danger" right=1}} = person does not have an approved photo</span>
     <span class="d-inline-block"><EarnedProvisionIcon/> = is earned provision which will be used.</span>
     <span class="d-inline-block"><AllocatedProvisionIcon/> = is allocated provision which will be used.</span>
     <span class="d-inline-block"><SetProvisionIcon/>= explicitly set provision</span>


### PR DESCRIPTION


Non-Rangers may acquire a ticket thru other means, and do not have to take the In-Person training.