### PR TITLE
Add time of day to PNV Alpha message on the dashboard

### DIFF
--- a/app/components/dashboard-pnv.js
+++ b/app/components/dashboard-pnv.js
@@ -69,7 +69,7 @@ const ALPHA_STEPS = [
 
       return {
         result: WAITING,
-        message: `Not Available Yet. Alpha shifts will be available on ${dayjs(milestones.alpha_shift_publish_date).format('MMMM Do')} OR the Wednesday AFTER you complete training, which ever is later. ${ALPHA_SHIFT_DISCLAIMER}`,
+        message: `Not Available Yet. Alpha shifts will be available after noon Pacific on ${dayjs(milestones.alpha_shift_publish_date).format('MMMM Do')} OR the Wednesday AFTER you complete training, which ever is later. ${ALPHA_SHIFT_DISCLAIMER}`,
       };
     }
   },


### PR DESCRIPTION
Noon Pacific is the standard timing for release of Alpha shifts and we seem to get a message from at least one Alpha a week asking why they didn't open at midnight, despite the time being specified in other places. This attempts to stop those by including a time in the PNV message. I'm open to the feedback that this is not the way to do that.