### PR TITLE
Timesheet management enhancements

### DIFF
--- a/app/components/person/timesheet-edit-modal.hbs
+++ b/app/components/person/timesheet-edit-modal.hbs
@@ -5,249 +5,298 @@
           @onSubmit={{@saveEntryAction}}
           as |f|>
     <Modal.body>
-      {{#if @entry.stillOnDuty}}
-        <UiNotice @type="danger" @icon="hand" @title="Still On Duty">
-          {{@person.callsign}} is still on duty. Please do not touch the entry until the shift has ended.
-        </UiNotice>
-      {{else if @entry.isPending}}
-        <UiNotice @type="danger" @icon="arrow-right" @title="Correction Request Review Required">
-          Entry has a correction request and needs to be reviewed.
-        </UiNotice>
-      {{else if @entry.isUnverified}}
-        <UiNotice @type="danger" @title="Unverified - No Review Required" @icon="hourglass">
-          No review action required at this time. {{@person.callsign}} needs to verify this entry.
-        </UiNotice>
-      {{else if @entry.isVerified}}
-        <UiNotice @type="success" @icon="check" @title="Entry Verified - No Review Required">
-          Review is not needed at this time.
-          Verified on {{shift-format @entry.verified_at}} by {{@entry.verified_person.callsign}}.
-        </UiNotice>
-      {{else if @entry.isApproved}}
-        <UiNotice @type="danger" @title="Verification Needed - No Review Required" @icon="hourglass">
-          Review is not needed at this time. The correction request was approved.
-          However, the correction still needs to be reviewed by {{@person.callsign}}.
-        </UiNotice>
-      {{/if}}
-
-      <fieldset>
-        <legend>User &amp; Timesheet Wrangler Notes</legend>
-        <TimesheetNotes @notes={{@entry.notes}} @showNoNotesMessage={{true}} />
-        {{#if @canManageTimesheets}}
-          <FormRow>
-            <f.textarea @name="additional_wrangler_notes"
-                        @label="New note to {{@person.callsign}}  (your callsign & the time will automatically be added):"
-                        @cols={{80}}
-                        @rows={{2}}/>
-          </FormRow>
+      {{#unless @entry.stillOnDuty}}
+        {{#if @entry.isPending}}
+          <UiNotice @type="danger" @icon="arrow-right" @title="Correction Request Review Required">
+            Entry has a correction request and needs to be reviewed.
+          </UiNotice>
+        {{else if @entry.isUnverified}}
+          <UiNotice @type="danger" @title="Unverified - No Review Required" @icon="hourglass">
+            No review action required at this time. {{@person.callsign}} needs to verify this entry.
+          </UiNotice>
+        {{else if @entry.isVerified}}
+          <UiNotice @type="success" @icon="check" @title="Entry Verified - No Review Required">
+            Review is not needed at this time.
+            Verified on {{shift-format @entry.verified_at}} by {{@entry.verified_person.callsign}}.
+          </UiNotice>
+        {{else if @entry.isApproved}}
+          <UiNotice @type="danger" @title="Verification Needed - No Review Required" @icon="hourglass">
+            Review is not needed at this time. The correction request was approved.
+            However, the correction still needs to be reviewed by {{@person.callsign}}.
+          </UiNotice>
         {{/if}}
-      </fieldset>
-      {{#if @canManageTimesheets}}
-        <fieldset>
-          <legend>Administration Notes (not shown to user)</legend>
-          <TimesheetNotes @notes={{@entry.admin_notes}} @showNoNotesMessage={{true}} />
-          <FormRow>
-            <f.textarea @name="additional_admin_notes"
-                        @label="New admin. note (your callsign & the time will automatically be added):"
-                        @cols={{80}}
-                        @rows={{2}}/>
-          </FormRow>
-        </fieldset>
-      {{/if}}
-      <fieldset>
-        <legend>Time &amp; Position</legend>
-        <div class="my-1">
-          {{#if @entry.slot}}
-            For reference, the scheduled sign-up is:
-            <UiTable class="my-1">
-              <thead>
-              <tr>
-                <th>Scheduled Time</th>
-                <th>Duration</th>
-                <th>Slot ID</th>
-              </tr>
-              </thead>
-              <tbody>
-              <tr>
-                <td>{{shift-format @entry.slot.begins @entry.slot.ends}}</td>
-                <td>{{hour-minute-words @entry.slot.duration}}</td>
-                <td class="text-end">{{@entry.slot.id}}</td>
-              </tr>
-              </tbody>
-            </UiTable>
-            The actual time worked might be longer or shorter than the scheduled sign-up.
-          {{else}}
-            Entry does not appear to be associated with a scheduled signed-up.
+      {{/unless}}
+
+      <UiSection>
+        <:title>User &amp; Timesheet Wrangler Notes</:title>
+        <:body>
+          <TimesheetNotes @notes={{@entry.notes}} @showNoNotesMessage={{true}} />
+          {{#if @canManageTimesheets}}
+            <FormRow>
+              <f.textarea @name="additional_wrangler_notes"
+                          @label="New note to {{@person.callsign}}  (your callsign & the time will automatically be added):"
+                          @cols={{80}}
+                          @rows={{2}}/>
+            </FormRow>
           {{/if}}
-        </div>
-        {{#if @entry.isTooShort}}
-          <div class="text-danger mb-1">
-            Entry might be too short. Duration is less than 15 minutes.
+        </:body>
+      </UiSection>
+      {{#if @canManageTimesheets}}
+        <UiSection>
+          <:title>Administration Notes (not shown to user)</:title>
+          <:body>
+            <TimesheetNotes @notes={{@entry.admin_notes}} @showNoNotesMessage={{true}} />
+            <FormRow>
+              <f.textarea @name="additional_admin_notes"
+                          @label="New admin. note (your callsign & the time will automatically be added):"
+                          @cols={{80}}
+                          @rows={{2}}/>
+            </FormRow>
+          </:body>
+        </UiSection>
+      {{/if}}
+      <UiSection>
+        <:title>Time &amp; Position</:title>
+        <:body>
+          {{#unless @entry.stillOnDuty}}
+            {{#if @entry.isTooShort}}
+              <UiAlert @type="warning">
+                Entry might be too short. Duration is less than 15 minutes.
+              </UiAlert>
+            {{else if @entry.isTooLong}}
+              <UiAlert @type="warning">
+                Entry might be too long. Duration is over 1.5x the scheduled shift of
+                {{hour-minute-words @entry.slot.duration}}.
+              </UiAlert>
+            {{/if}}
+            {{#if @entry.timesOutsideRange}}
+              <UiAlert @type="warning" @icon="hand">
+                The entry’s times fall outside the scheduled sign-up times for the entire event. This could be due to an
+                incorrect previous correction, an accidental shift start, or selecting the wrong position during shift
+                check-in. It’s also possible that this was an authorized check-in and the times are correct.
+                <ul>
+                  {{this.timeWarningsMessage}}
+                </ul>
+              </UiAlert>
+            {{/if}}
+          {{/unless}}
+          <div class="my-1">
+            {{#if @entry.slot}}
+              For reference, the scheduled sign-up is:
+              <UiTable class="my-1">
+                <thead>
+                <tr>
+                  <th>Scheduled Time</th>
+                  <th>Duration</th>
+                  <th>Slot ID</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                  <td>{{shift-format @entry.slot.begins @entry.slot.ends}}</td>
+                  <td>{{hour-minute-words @entry.slot.duration}}</td>
+                  <td class="text-end">{{@entry.slot.id}}</td>
+                </tr>
+                </tbody>
+              </UiTable>
+              The actual time worked might be longer or shorter than the scheduled sign-up.
+            {{else}}
+              Entry does not appear to be associated with a scheduled signed-up.
+            {{/if}}
           </div>
-        {{else if @entry.isTooLong}}
-          <div class="text-danger mb-1">
-            Entry might be too long. Duration is over 1.5x the scheduled shift of
-            {{hour-minute-words @entry.slot.duration}}.
-          </div>
-        {{/if}}
-        {{#if @entry.timesOutsideRange}}
-          <div class="mb-1">
-            <span
-              class="text-danger fw-semibold">The entry's date/times are outside the scheduled sign-up date ranges.</span>
-            A previous correction may have been done incorrectly, an accidental shift
-            start occurred, or the wrong position selected at shift check-in.
-            <ul>
-              {{this.timeWarningsMessage}}
-            </ul>
-          </div>
-        {{/if}}
-
-        {{#if @canManageTimesheets}}
-          {{#if (or @entry.desired_position @entry.desired_on_duty @entry.desired_off_duty)}}
+          {{#if @canManageTimesheets}}
+            {{#unless @entry.stillOnDuty}}
+              {{#if (or @entry.desired_position @entry.desired_on_duty @entry.desired_off_duty)}}
+                <UiTable>
+                  <thead>
+                  <tr>
+                    <th>Field</th>
+                    <th colspan="3">Desired Change</th>
+                    <th>Applied?</th>
+                  </tr>
+                  </thead>
+                  <tbody>
+                  {{#if @entry.desired_position}}
+                    <tr>
+                      <th>Position</th>
+                      <td>
+                        {{@entry.position.title}}
+                      </td>
+                      <td>
+                        {{fa-icon "arrow-right"}}
+                      </td>
+                      <td>
+                        {{@entry.desired_position.title}}
+                      </td>
+                      <td>
+                        {{#if (not-eq @entry.desired_position.id @entry.position_id)}}
+                          <UiBadge @type="secondary">
+                            not applied yet
+                          </UiBadge>
+                        {{else}}
+                          <UiBadge @type="success">
+                            applied
+                          </UiBadge>
+                        {{/if}}
+                      </td>
+                    </tr>
+                  {{/if}}
+                  {{#if @entry.desired_on_duty}}
+                    <tr>
+                      <th>On Duty</th>
+                      <td>
+                        {{shift-format @entry.on_duty}}
+                      </td>
+                      <td>
+                        {{fa-icon "arrow-right"}}
+                      </td>
+                      <td>
+                        {{shift-format @entry.desired_on_duty}}
+                      </td>
+                      <td>
+                        {{#if (not-eq @entry.on_duty @entry.desired_on_duty)}}
+                          <UiBadge @type="secondary">
+                            not applied yet
+                          </UiBadge>
+                        {{else}}
+                          <UiBadge @type="success">
+                            applied
+                          </UiBadge>
+                        {{/if}}
+                      </td>
+                    </tr>
+                  {{/if}}
+                  {{#if @entry.desired_off_duty}}
+                    <tr>
+                      <th>Off Duty</th>
+                      <td>
+                        {{shift-format @entry.off_duty}}
+                      </td>
+                      <td>
+                        {{fa-icon "arrow-right"}}
+                      </td>
+                      <td>
+                        {{shift-format @entry.desired_off_duty}}
+                      </td>
+                      <td>
+                        {{#if (not-eq @entry.off_duty @entry.desired_off_duty)}}
+                          <UiBadge @type="secondary">
+                            not applied yet
+                          </UiBadge>
+                        {{else}}
+                          <UiBadge @type="success">
+                            applied
+                          </UiBadge>
+                        {{/if}}
+                      </td>
+                    </tr>
+                  {{/if}}
+                  </tbody>
+                </UiTable>
+                {{#if @entry.desiredOutsideRange}}
+                  <UiAlert @type="warning" @icon="hand">
+                    The DESIRED times are outside the scheduled sign-up date ranges for the entire event.
+                    This might indicate the times were entered incorrectly by the person:
+                    <ul>
+                      {{this.desiredWarningsMessage}}
+                    </ul>
+                  </UiAlert>
+                {{/if}}
+                <UiButton @onClick={{fn this.populatedDesiredChanges f.model}} @size="sm" @type="secondary">
+                  Use the desired change(s)
+                </UiButton>
+              {{else}}
+                <div class="text-danger fw-semi-bold">The person has not entered any desired changes.</div>
+              {{/if}}
+            {{/unless}}
+            <FormRow class="mt-2">
+              <f.datetime @name="on_duty"
+                          @label="On Duty"
+                          @size={{20}}
+              />
+              {{#unless @entry.stillOnDuty}}
+                <f.datetime @name="off_duty"
+                            @label="Off Duty"
+                            @size={{20}}
+                />
+              {{/unless}}
+              <f.select @name="position_id"
+                        @label="Position"
+                        @options={{@positionOptions}}
+              />
+            </FormRow>
+            {{#unless @entry.stillOnDuty}}
+              <div class="fw-medium mb-2">Timesheet Duration {{this.entryDuration f.model}}</div>
+            {{/unless}}
+          {{else}}
             <UiTable>
               <thead>
               <tr>
-                <th colspan="4">Desired Changes</th>
+                <th>Position</th>
+                <th>Time</th>
+                <th>Duration</th>
+                <th>Credits</th>
               </tr>
               </thead>
               <tbody>
-              {{#if @entry.desired_position}}
-                <tr>
-                  <th>Position</th>
-                  <td>
-                    {{@entry.position.title}}
-                  </td>
-                  <td>
-                    {{fa-icon "arrow-right"}}
-                  </td>
-                  <td>
-                    {{@entry.desired_position.title}}
-                  </td>
-                </tr>
-              {{/if}}
-              {{#if @entry.desired_on_duty}}
-                <tr>
-                  <th>On Duty</th>
-                  <td>
-                    {{shift-format @entry.on_duty}}
-                  </td>
-                  <td>
-                    {{fa-icon "arrow-right"}}
-                  </td>
-                  <td>
-                    {{shift-format @entry.desired_on_duty}}
-                  </td>
-                </tr>
-              {{/if}}
-              {{#if @entry.desired_off_duty}}
-                <tr>
-                  <th>Off Duty</th>
-                  <td>
-                    {{shift-format @entry.off_duty}}
-                  </td>
-                  <td>
-                    {{fa-icon "arrow-right"}}
-                  </td>
-                  <td>
-                    {{shift-format @entry.desired_off_duty}}
-                  </td>
-                </tr>
-              {{/if}}
+              <tr>
+                <td>
+                  {{@entry.position.title}}
+                  {{#if @entry.is_non_ranger}}
+                    (as non ranger volunteer)
+                  {{/if}}
+                </td>
+                <td>
+                  {{shift-format @entry.on_duty @entry.off_duty}}
+                </td>
+                <td>
+                  {{hour-minute-words @entry.duration}}
+                </td>
+                <td>
+                  {{credits-format @entry.credits}}
+                </td>
+              </tr>
               </tbody>
             </UiTable>
-            {{#if @entry.desiredOutsideRange}}
-              <div>
-                <span class="text-danger fw-semibold">
-                  The DESIRED date/times are outside the scheduled sign-up date ranges.
-                </span>
-                This might indicate the date/times were entered incorrectly by the person:
-                <ul>
-                  {{this.desiredWarningsMessage}}
-                </ul>
-              </div>
-            {{/if}}
-            <UiButton @onClick={{fn this.populatedDesiredChanges f.model}} @size="sm" @type="secondary">
-              Use the desired change(s)
-            </UiButton>
-          {{else}}
-            <div class="text-danger fw-semi-bold">The person has not entered any desired changes.</div>
           {{/if}}
-          <FormRow class="mt-2">
-            <f.datetime @name="on_duty"
-                        @label="On Duty"
-                        @size={{20}}
-            />
-            <f.datetime @name="off_duty"
-                        @label="Off Duty"
-                        @size={{20}}
-            />
-            <f.select @name="position_id"
-                      @label="Position"
-                      @options={{@positionOptions}}
-            />
-          </FormRow>
-          <div class="fw-medium mb-2">Timesheet Duration {{this.entryDuration f.model}}</div>
+        </:body>
+      </UiSection>
+      {{#unless @entry.stillOnDuty}}
+        {{#if @canManageTimesheets}}
+          <UiSection>
+            <:title>Attributes</:title>
+            <:body>
+              <FormRow class="mt-3">
+                <div class="col-auto">
+                  <f.checkbox @name="is_non_ranger"
+                              @label="Entry is for a dept volunteer (non-ranger status) - time will not count towards service years"/>
+                </div>
+              </FormRow>
+              <FormRow>
+                <div class="col-auto">
+                  <f.checkbox @name="suppress_duration_warning"
+                              @label="Supress duration warnings (too short / too long), and date/times warnings."/>
+                </div>
+              </FormRow>
+            </:body>
+          </UiSection>
+          <UiSection>
+            <:title>Entry Status</:title>
+            <:body>
+              <FormRow>
+                <div class="col-auto">
+                  <f.radioGroup @name="review_status"
+                                @options={{this.reviewOptions}}
+                                @inline={{true}}
+                  />
+                </div>
+              </FormRow>
+            </:body>
+          </UiSection>
         {{else}}
-          <UiTable>
-            <thead>
-            <tr>
-              <th>Position</th>
-              <th>Time</th>
-              <th>Duration</th>
-              <th>Credits</th>
-            </tr>
-            </thead>
-            <tbody>
-            <tr>
-              <td>
-                {{@entry.position.title}}
-                {{#if @entry.is_non_ranger}}
-                  (as non ranger volunteer)
-                {{/if}}
-              </td>
-              <td>
-                {{shift-format @entry.on_duty @entry.off_duty}}
-              </td>
-              <td>
-                {{hour-minute-words @entry.duration}}
-              </td>
-              <td>
-                {{credits-format @entry.credits}}
-              </td>
-            </tr>
-            </tbody>
-          </UiTable>
+          <b>Review Status:</b> {{@entry.review_status}}
         {{/if}}
-      </fieldset>
-      {{#if @canManageTimesheets}}
-        <fieldset>
-          <legend>Attributes</legend>
-          <FormRow class="mt-3">
-            <div class="col-auto">
-              <f.checkbox @name="is_non_ranger"
-                          @label="Entry is for a dept volunteer (non-ranger status) - time will not count towards service years"/>
-            </div>
-          </FormRow>
-          <FormRow>
-            <div class="col-auto">
-              <f.checkbox @name="suppress_duration_warning"
-                          @label="Supress duration warnings (too short / too long), and date/times warnings."/>
-            </div>
-          </FormRow>
-        </fieldset>
-        <fieldset>
-          <legend>Entry Status</legend>
-          <FormRow>
-            <div class="col-auto">
-              <f.radioGroup @name="review_status"
-                            @options={{this.reviewOptions}}
-                            @inline={{true}}
-              />
-            </div>
-          </FormRow>
-        </fieldset>
-      {{else}}
-        <b>Review Status:</b> {{@entry.review_status}}
-      {{/if}}
+      {{/unless}}
     </Modal.body>
     <Modal.footer @align="start">
       {{#if @canManageTimesheets}}
@@ -256,13 +305,15 @@
         {{#if @entry.isSaving}}
           <LoadingIndicator/>
         {{/if}}
-        <div class="ms-auto">
-          <UiButton @type="danger"
-                    @onClick={{fn @showDeleteDialogAction f.model}}
-                    @disabled={{@entry.isSaving}}>
-            {{fa-icon "trash"}} Delete
-          </UiButton>
-        </div>
+        {{#unless @entry.stillOnDuty}}
+          <div class="ms-auto">
+            <UiButton @type="danger"
+                      @onClick={{fn @showDeleteDialogAction f.model}}
+                      @disabled={{@entry.isSaving}}>
+              {{fa-icon "trash"}} Delete
+            </UiButton>
+          </div>
+        {{/unless}}
       {{else}}
         <UiCancelButton @disabled={{@entry.isSaving}} @onClick={{@cancelEntryAction}} />
       {{/if}}

--- a/app/components/person/timesheet-manage.hbs
+++ b/app/components/person/timesheet-manage.hbs
@@ -114,7 +114,10 @@
             {{/if}}
           </td>
           <td>
-            {{#if (is-empty ts.off_duty)}}
+            {{#if ts.stillOnDuty}}
+              <UiButton @type="secondary" @size="sm" @onClick={{fn this.editEntryAction ts}}>
+                Correct Position / On Duty
+              </UiButton>
               <UiButton @type="danger" @size="sm" @onClick={{fn this.signoffAction ts}}>
                 End Shift
               </UiButton>

--- a/app/components/person/timesheet-manage.js
+++ b/app/components/person/timesheet-manage.js
@@ -19,6 +19,8 @@ export default class PersonTimesheetManageComponent extends Component {
   @tracked editVerification = false;
   @tracked deleteEntry = null;
 
+  @tracked correctingInProgress = false;
+
   @tracked positionOptions = [];
 
 
@@ -85,7 +87,6 @@ export default class PersonTimesheetManageComponent extends Component {
       this.editVerification = false;
       this.editEntry = timesheet;
       this._markOverlapping();
-
     } catch (response) {
       this.house.handleErrorResponse(response);
     } finally {
@@ -142,6 +143,8 @@ export default class PersonTimesheetManageComponent extends Component {
         model.rollbackProperty('off_duty');
         this.modal.info('Correction Rejected - Position and times not changed',
           `You changed position and/or times while corrections were rejected. The new positions and/or times have NOT be saved.`, this._saveCheckTimesCommon(model));
+      } else if (model.stillOnDuty) {
+        this._saveCommon(model);
       } else {
         this._saveCheckTimesCommon(model);
       }

--- a/app/services/shift-manage.js
+++ b/app/services/shift-manage.js
@@ -269,9 +269,9 @@ export default class ShiftManageService extends Service {
     }
 
     if (status === 'before-begins') {
-      return `<li >The ${label} time ${shiftFormat([date], {})} <b class="text-danger">is BEFORE the first shift</b> starting on ${shiftFormat([begins], {})}.</li>`;
+      return `<li >The ${label} time ${shiftFormat([date], {})} <b class="text-danger">is BEFORE the very first shift of the event</b> starting on ${shiftFormat([begins], {})}.</li>`;
     } else {
-      return `<li>The ${label} time ${shiftFormat([date], {})} <b class="text-danger">is AFTER the last shift</b> ending on ${shiftFormat([ends], {})}.</li>`;
+      return `<li>The ${label} time ${shiftFormat([date], {})} <b class="text-danger">is AFTER the very last shift of the event</b> ending on ${shiftFormat([ends], {})}.</li>`;
     }
   }
 


### PR DESCRIPTION
- Allow a still-on-duty entry to be edited.
- Use UiSection to improve readability on timesheet edit modal
- Clarify language on what it means to have a time fall outside of the schedule signups.
- Indicate if the desired changes have been previously applied.