### PR TITLE
Fixed signup caching issue.

### DIFF
--- a/app/components/schedule-manage.js
+++ b/app/components/schedule-manage.js
@@ -236,6 +236,8 @@ export default class ScheduleManageComponent extends Component {
     slot.isRetrievingSignUps = true;
     try {
       slot.signUpInfo = await this.ajax.request(`slot/${slot.id}/people`);
+      slot.slot_signed_up = slot.signUpInfo.signed_up;
+      slot.slot_max = slot.signUpInfo.max;
      } catch (response) {
       this.house.handleErrorResponse(response);
     } finally {

--- a/app/records/schedule-slot.js
+++ b/app/records/schedule-slot.js
@@ -13,6 +13,7 @@ export default class ScheduleSlotModel {
   @tracked signUpInfo = null;
 
   @tracked slot_signed_up = 0;
+  @tracked slot_max = 0;
 
   constructor(data) {
     Object.assign(this, data);


### PR DESCRIPTION
When showing the people signed up for a shift, also update the signup count in case the value changed between when the listing was shown, and when the show signups button was pushed.