### PR TITLE
Asset enhancement work.

### DIFF
--- a/app/components/asset-checkout-form.hbs
+++ b/app/components/asset-checkout-form.hbs
@@ -36,11 +36,18 @@
     <ModalDialog @onEscape={{this.closeExpiredDialog}} as |Modal|>
       <Modal.title>Asset Has Expired</Modal.title>
       <Modal.body>
-        Asset {{this.assetExpired.barcode}} has expired and should not be handed out. Please place it
-        in the designated pile for return to the vendor.
+        <p>
+          Asset #{{this.assetExpired.barcode}} is no longer eligible for checkout and should not be handed out.
+          Place it in the designated pile for return to the vendor.
+        </p>
+        The checkout can be forced if you have authorization from the HQ Lead due to unforeseen circumstances. The
+        action will be logged and subject to review.
       </Modal.body>
       <Modal.footer>
         <UiCloseButton @onClick={{this.closeExpiredDialog}} />
+        <UiButton @onClick={{this.forceCheckout}} @type="warning">
+          Force Checkout
+        </UiButton>
       </Modal.footer>
     </ModalDialog>
   {{else}}

--- a/app/components/asset-duration-label.hbs
+++ b/app/components/asset-duration-label.hbs
@@ -1,0 +1,13 @@
+{{#if (eq @asset.type "radio")}}
+  {{#if @asset.perm_assign}}
+    <UiBadge @text="event" @type="gray"/>
+  {{else}}
+    <UiBadge @text="shift" @type="warning"/>
+  {{/if}}
+{{else}}
+  {{#if @asset.perm_assign}}
+    <UiBadge @text="permanent" @type="gray"/>
+  {{else}}
+    <UiBadge @text="temporary" @type="warning"/>
+  {{/if}}
+{{/if}}

--- a/app/components/asset-table.hbs
+++ b/app/components/asset-table.hbs
@@ -5,10 +5,11 @@
     <th>Type</th>
     <th>Barcode</th>
     <th>Attachment</th>
-    <th>Assigned</th>
+    <th>Duration</th>
     <th>Description</th>
     <th>Checked Out Time /<br>By Person</th>
     <th>Checked In Time /<br>By Person</th>
+    <th>Time (HH:SS)</th>
     <th>Action</th>
   </tr>
   </thead>
@@ -20,7 +21,9 @@
       <td>
         <PresentOrNot @value={{ap.attachment.description}} @empty="-"/>
       </td>
-      <td>{{if ap.asset.perm_assign "Perm" "Temp"}}</td>
+      <td class="text-center">
+        <AssetDurationLabel @asset={{ap.asset}}/>
+      </td>
       <td>
         <PresentOrNot @value={{ap.asset.description}} @empty="-"/>
       </td>
@@ -48,6 +51,9 @@
             <SpinIcon/>
           {{/if}}
         {{/if}}
+      </td>
+      <td class="text-end">
+        {{hour-minute-format ap.duration}}
       </td>
       <td>
         <UiButton @type="secondary" @size="sm" @onClick={{fn this.showHistoryAction ap.asset}}>

--- a/app/components/hq-asset-table.hbs
+++ b/app/components/hq-asset-table.hbs
@@ -4,7 +4,7 @@
     <th>Type</th>
     <th>Barcode</th>
     <th>Attachment</th>
-    <th>Description</th>
+    <th>Description / Group</th>
     <th>Checked Out</th>
     <th>Actions</th>
     <th class="w-5">&nbsp;</th>
@@ -13,7 +13,10 @@
   <tbody>
   {{#each @assetsCheckedOut as |ap|}}
     <tr>
-      <td>{{this.typeLabel ap.asset.type}}</td>
+      <td>
+        {{this.typeLabel ap.asset.type}}
+        <AssetDurationLabel @asset={{ap.asset}} />
+      </td>
       <td>{{ap.asset.barcode}}</td>
       <td>
         <PresentOrNot @value={{ap.attachment.description}} @empty="none"/>
@@ -26,19 +29,8 @@
       <td>
         <PresentOrNot @value={{ap.asset.description}} @empty="-"/>
         <br>
-        {{#if (eq ap.asset.type "radio")}}
-          {{#if ap.asset.perm_assign}}
-            <UiBadge @text="Event Radio" @type="gray" />
-          {{else}}
-            <UiBadge @text="Shift Radio" @type="warning" />
-          {{/if}}
-        {{else}}
-          {{#if ap.asset.perm_assign}}
-            <UiBadge @text="Permanent" @type="gray" />
-          {{else}}
-            <UiBadge @text="Temporary" @type="warning" />
-          {{/if}}
-        {{/if}}
+        <PresentOrNot @value={{ap.asset.group_name}} @empty="-"/>
+        <br>
       </td>
       <td>{{shift-format ap.checked_out}}</td>
       <td>

--- a/app/components/ui-table.hbs
+++ b/app/components/ui-table.hbs
@@ -1,3 +1,3 @@
-<table class="table {{unless @noWidthAuto "table-width-auto"}} {{unless @normalSize "table-sm"}} table-hover {{unless @noStriped "table-striped"}}" ...attributes>
+<table class="table {{unless @noWidthAuto "table-width-auto"}} {{unless @normalSize "table-sm"}} table-hover {{unless @noStriped "table-striped"}} {{if @stickyHeader "table-sticky"}}" ...attributes>
   {{yield}}
 </table>

--- a/app/models/asset-person.js
+++ b/app/models/asset-person.js
@@ -9,6 +9,8 @@ export default class AssetPersonModel extends Model {
   @attr('number') check_out_person_id;
   @attr('number') check_in_person_id;
 
+  @attr('number', { readOnly: true }) duration;
+
   @attr('', { readOnly: true }) asset;
   @attr('', { readOnly: true }) attachment;
   @attr('', { readOnly: true }) person;

--- a/app/models/asset.js
+++ b/app/models/asset.js
@@ -9,14 +9,33 @@ export const TYPE_VEHICLE = 'vehicle';
 export const TYPE_KEY = 'key';
 export const TYPE_AMBER = 'amber';
 
+export const TYPE_DESKTOP_RADIO = 'desktop-radio';
+export const TYPE_MOBILE_RADIO = 'mobile-radio';
+export const TYPE_RADIO_CHARGER = 'radio-charger';
+
 export const TypeLabels = {
   [TYPE_AMBER]: 'Amber',
+  [TYPE_DESKTOP_RADIO]: 'Desktop Radio',
   [TYPE_GEAR]: 'Gear',
   [TYPE_KEY]: 'Key',
+  [TYPE_MOBILE_RADIO]: 'Mobile Radio',
   [TYPE_RADIO]: 'Radio',
+  [TYPE_RADIO_CHARGER]: 'Radio Charger',
   [TYPE_TEMP_ID]: 'Temporary BMID',
   [TYPE_VEHICLE]: 'Vehicle',
 };
+
+export const TypeSort = {
+  [TYPE_RADIO]: 1,
+  [TYPE_DESKTOP_RADIO]: 2,
+  [TYPE_MOBILE_RADIO]: 3,
+  [TYPE_RADIO_CHARGER]: 4,
+  [TYPE_TEMP_ID]: 5,
+  [TYPE_GEAR]: 6,
+  [TYPE_VEHICLE]:  7,
+  [TYPE_AMBER]: 8,
+  [TYPE_KEY]: 9,
+}
 
 export default class AssetModel extends Model {
   @attr('string') type;
@@ -24,14 +43,17 @@ export default class AssetModel extends Model {
   @attr('string') description;
   @attr('boolean') perm_assign;
 
-  @attr('string') category;
   @attr('string') notes;
+
+  @attr('string') entity_assignment;
+  @attr('string') group_name;
+  @attr('string') order_number;
 
   @attr('number') year;
   @attr('string', {readOnly: true}) created_at;
 
   @attr('string') expires_on;
-  @attr('boolean', { readOnly: true}) has_expired;
+  @attr('boolean', {readOnly: true}) has_expired;
 
   get isRadio() {
     return this.type === TYPE_RADIO;

--- a/app/routes/ops/assets.js
+++ b/app/routes/ops/assets.js
@@ -3,7 +3,7 @@ import requestYear from 'clubhouse/utils/request-year';
 import {ADMIN, EDIT_ASSETS} from 'clubhouse/constants/roles';
 
 export default class OpsAssetsRoute extends ClubhouseRoute {
-  roleRequired = [ ADMIN, EDIT_ASSETS];
+  roleRequired = [ADMIN, EDIT_ASSETS];
 
   queryParams = {
     year: {refreshModel: true}
@@ -17,11 +17,16 @@ export default class OpsAssetsRoute extends ClubhouseRoute {
   }
 
   setupController(controller, model) {
-    controller.set('assetForHistory', null);
-    controller.set('entry', null);
-    controller.set('tempIdFilter', 'All');
-    controller.set('descriptionFilter', 'All');
-    controller.set('year', this.year);
-    controller.set('assets', model);
+    controller.assetForHistory = null;
+    controller.assets = model;
+    controller.descriptionFilter = 'all';
+    controller.entityAssignmentFilter = 'all';
+    controller.entry = null;
+    controller.expireFilter = 'all';
+    controller.groupFilter = 'all';
+    controller.tempIdFilter = 'all';
+    controller.typeFilter = 'all';
+    controller.orderNumberFilter = 'all';
+    controller.year = this.year;
   }
 }

--- a/app/routes/reports/radio-assets.js
+++ b/app/routes/reports/radio-assets.js
@@ -120,6 +120,7 @@ export default class ReportsRadioAssetsRoute extends ClubhouseRoute {
       barcode,
       count,
       description,
+      type: 'radio',
       perm_assign
     });
   }

--- a/app/templates/hq/site-checkin.hbs
+++ b/app/templates/hq/site-checkin.hbs
@@ -122,7 +122,7 @@
         {{/if}}
       </w.step>
     </ChForm>
-    <w.step @title="Radios"  @nextAction={{this.checkForRadio}}>
+    <w.step @title="Radios" @nextAction={{this.checkForRadio}}>
       {{#unless this.eventInfo.radio_info_available}}
         <UiNotice @type="danger">
           Warning: Event radio information has not been posted yet. Radio eligibility cannot be determined.
@@ -143,30 +143,9 @@
           />
           {{#if this.activeAssets}}
             {{pluralize this.activeAssets.length "asset"}} checked out.
-            <UiTable>
-              <thead>
-              <tr>
-                <th>Barcode</th>
-                <th>Type</th>
-                <th>Assigned</th>
-                <th>Attachment</th>
-                <th>Out</th>
-              </tr>
-              </thead>
-              <tbody>
-              {{#each this.activeAssets as |ap|}}
-                <tr>
-                  <td>{{ap.asset.barcode}}</td>
-                  <td>{{ap.asset.description}}</td>
-                  <td>{{if ap.asset.perm_assign "Permanent" "Temporary"}}</td>
-                  <td>
-                    <PresentOrNot @value={{ap.attachment.description}} @empty="-"/>
-                  </td>
-                  <td>{{shift-format ap.checked_out}}</td>
-                </tr>
-              {{/each}}
-              </tbody>
-            </UiTable>
+            <HqAssetTable @assetsCheckedOut={{this.activeAssets}}
+                          @attachments={{this.attachments}}
+            />
           {{/if}}
           {{#if this.assets.isUpdating}}
             <LoadingIndicator @text="Refreshing assets"/>

--- a/app/templates/ops/assets.hbs
+++ b/app/templates/ops/assets.hbs
@@ -4,28 +4,54 @@
               @minYear={{2009}}
               @skipPandemic={{true}}
               @onChange={{set-value this 'year'}} />
-  <FormRow>
-    <FormLabel @auto={{true}}>Type</FormLabel>
-    <div class="col-auto">
-      <ChForm::Select @name="typeFilter"
-                      @value={{this.typeFilter}}
-                      @options={{this.typeOptions}}
-                      @onChange={{set-value this 'typeFilter'}}
-      />
-    </div>
+  <p>
+
+  </p>
+  <FormRow class="small">
     <FormLabel @auto={{true}}>Description</FormLabel>
     <div class="col-auto">
       <ChForm::Select @name="descriptionFilter"
                       @value={{this.descriptionFilter}}
                       @options={{this.descriptionOptions}}
-                      @onChange={{set-value this 'descriptionFilter'}} />
+                      @onChange={{set-value this 'descriptionFilter'}}
+                      @fieldSize="sm"
+      />
+    </div>
+    <FormLabel @auto={{true}}>Asset Group</FormLabel>
+    <div class="col-auto">
+      <ChForm::Select @name="groupFilter"
+                      @value={{this.groupFilter}}
+                      @options={{this.groupOptions}}
+                      @onChange={{set-value this 'groupFilter'}}
+                      @fieldSize="sm"
+      />
+    </div>
+    <FormLabel @auto={{true}}>Assignment</FormLabel>
+    <div class="col-auto">
+      <ChForm::Select @name="entityAssignmentFilter"
+                      @value={{this.entityAssignmentFilter}}
+                      @options={{this.entityAssignmentOptions}}
+                      @onChange={{set-value this 'entityAssignmentFilter'}}
+                      @fieldSize="sm"
+      />
+    </div>
+    <FormLabel @auto={{true}}>Order #</FormLabel>
+    <div class="col-auto">
+      <ChForm::Select @name="orderNumberFilter"
+                      @value={{this.orderNumberFilter}}
+                      @options={{this.orderNumberOptions}}
+                      @onChange={{set-value this 'orderNumberFilter'}}
+                      @fieldSize="sm"
+      />
     </div>
     <FormLabel @auto={{true}}>Expired?</FormLabel>
     <div class="col-auto">
       <ChForm::Select @name="expireFilter"
                       @value={{this.expireFilter}}
                       @options={{this.expireFilterOptions}}
-                      @onChange={{set-value this 'expireFilter'}} />
+                      @onChange={{set-value this 'expireFilter'}}
+                      @fieldSize="sm"
+      />
     </div>
     <FormLabel @auto={{true}}>Action</FormLabel>
     <div class="col-auto">
@@ -33,63 +59,77 @@
     </div>
   </FormRow>
 
-  <UiSection>
-    <:title> Showing {{this.viewAssets.length}} of {{pluralize this.assets.length "asset"}}</:title>
-    <:actions>
-      <UiExportToCSVButton @onClick={{this.exportToCSV}} @size="sm"/>
-    </:actions>
-    <:body>
-      <UiTable>
-        <thead>
-        <tr>
-          <th>Barcode</th>
-          <th>Type</th>
-          <th>Description</th>
-          <th>Assigned</th>
-          <th>Expires On</th>
-          <th>Actions</th>
-        </tr>
-        </thead>
+  {{#each this.viewAssetsByType as |group|}}
+    <UiAccordion as |accordian|>
+      <accordian.title>{{group.label}} [{{pluralize group.assets.length 'record'}}]</accordian.title>
+      <accordian.body>
+        <p>
+          <UiExportToCSVButton @onClick={{fn this.exportToCSV group}} @size="sm"/>
+        </p>
+        <UiTable @stickyHeader={{true}}>
+          <thead>
+          <tr>
+            <th>Barcode</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Duration</th>
+            <th>Entity Assignment</th>
+            <th>Asset Group</th>
+            <th>Order #</th>
+            <th>Expires On</th>
+            <th>Actions</th>
+          </tr>
+          </thead>
 
-        <tbody>
-        {{#each this.viewAssets key="id" as |asset|}}
-          <tr>
-            <td>{{asset.barcode}}</td>
-            <td>{{asset.typeLabel}}</td>
-            <td>
-              <PresentOrNot @value={{asset.description}} @empty="-"/>
-            </td>
-            <td class="text-center">{{asset.assignmentLabel}}</td>
-            <td>
-              {{#if asset.expires_on}}
-                {{ymd-format asset.expires_on}}
-                {{#if asset.has_expired}}
-                  <UiBadge @type="warning" class="ms-1">expired</UiBadge>
+          <tbody>
+          {{#each group.assets key="id" as |asset|}}
+            <tr>
+              <td class="text-end">{{asset.barcode}}</td>
+              <td>{{asset.typeLabel}}</td>
+              <td>
+                <PresentOrNot @value={{asset.description}} @empty="-"/>
+              </td>
+              <td class="text-center">{{asset.assignmentLabel}}</td>
+              <td>
+                <PresentOrNot @value={{asset.entity_assignment}} @empty="-"/>
+              </td>
+              <td>
+                <PresentOrNot @value={{asset.group_name}} @empty="-"/>
+              </td>
+              <td>
+                <PresentOrNot @value={{asset.order_number}} @empty="-"/>
+              </td>
+              <td>
+                {{#if asset.expires_on}}
+                  {{ymd-format asset.expires_on}}
+                  {{#if asset.has_expired}}
+                    <UiBadge @type="warning" class="ms-1">expired</UiBadge>
+                  {{/if}}
+                {{else}}
+                  -
                 {{/if}}
-              {{else}}
-                -
-              {{/if}}
-            </td>
-            <td>
-              <UiButton @type="secondary" @size="sm" @onClick={{fn this.assetHistoryAction asset}}>
-                {{fa-icon "rectangle-list" right=1}} History
-              </UiButton>
-              <UiButton @size="sm" @onClick={{fn this.editAsset asset}}>
-                {{fa-icon "edit" right=1}} Edit
-              </UiButton>
-            </td>
-          </tr>
-        {{else if this.assets}}
-          <tr>
-            <td colspan="5" class="text-danger">No assets matched.</td>
-          </tr>
-        {{else}}
-          <td colspan="5" class="text-danger">No assets were found for {{this.year}}?!?</td>
-        {{/each}}
-        </tbody>
-      </UiTable>
-    </:body>
-  </UiSection>
+              </td>
+              <td>
+                <UiButton @type="secondary" @size="sm" @onClick={{fn this.assetHistoryAction asset}}>
+                  {{fa-icon "rectangle-list" right=1}} History
+                </UiButton>
+                <UiButton @size="sm" @onClick={{fn this.editAsset asset}}>
+                  {{fa-icon "edit" right=1}} Edit
+                </UiButton>
+              </td>
+            </tr>
+          {{else if this.assets}}
+            <tr>
+              <td colspan="8" class="text-danger">No assets matched.</td>
+            </tr>
+          {{else}}
+            <td colspan="8" class="text-danger">No assets were found for {{this.year}}?!?</td>
+          {{/each}}
+          </tbody>
+        </UiTable>
+      </accordian.body>
+    </UiAccordion>
+  {{/each}}
   {{#if this.entry}}
     <ModalDialog @title={{if this.entry.isNew "New Asset" "Edit Asset"}} @onEscape={{this.cancelAsset}} as |Modal|>
       <ChForm @formId="asset"
@@ -115,25 +155,59 @@
                     @showCharCount={{true}}
             />
           </FormRow>
+          <p>
+            If the Entity Assignment field is filled in, the asset cannot be checked out. The field will be
+            used by the Last Caller App to show who's talking. This is intended to handle radios where the
+            person does not have a Clubhouse account, or where the asset is being used by a team, not an individual.
+          </p>
+          <FormRow>
+            <f.text @name="entity_assignment"
+                    @label="Entity Assignment"
+                    @size={{40}}
+                    @showCharCount={{true}}
+                    @maxlength={{40}}
+            />
+          </FormRow>
           <FormRow>
             <div class="col-auto">
               <f.radioGroup @name="perm_assign"
-                            @label="Assignment"
+                            @label="Usage Duration"
                             @options={{this.permanentOptions}}
               />
             </div>
-            <f.select @name="category"
-                      @label="Category"
-                      @options={{this.categoryOptions}}
+          </FormRow>
+          <FormRow>
+            <p class="col-12">
+              The Group Name is used to represent which group / team / collection the radio is a part of or has been
+              given to.
+              E.g., SITE, Shift, Event, NVO/DPW, HRS, BPS, etc.
+            </p>
+            <f.text @name="group_name"
+                    @label="Group Name"
+                    @size={{40}}
+                    @maxlength={{40}}
+                    @showCharCount={{true}}
             />
-            <f.text @name="year"
-                    @label="Event Year"
-                    @size={{4}}
-                    @maxlength={{4}}
-            />
+          </FormRow>
+          <p>
+            The expires on field is used to prevent radios from being checked out after a given date at 23:59.
+            (e.g., 2024-09-01 will prevent radios from being checked out after 2024-09-01 @ 23:59.)
+          </p>
+          <FormRow>
             <f.datetime @name="expires_on"
                         @dateOnly={{true}}
                         @label="Expires On (optional)"/>
+          </FormRow>
+          <p>
+            The Order Number field is used to identity which vendor order number the radio belongs to.
+          </p>
+          <FormRow>
+            <f.text @name="order_number"
+                    @label="Order Number"
+                    @size={{40}}
+                    @maxlength={{40}}
+                    @showCharCount={{true}}
+            />
           </FormRow>
           <FormRow>
             <f.textarea @name="notes"

--- a/app/templates/reports/asset-history.hbs
+++ b/app/templates/reports/asset-history.hbs
@@ -15,7 +15,7 @@ Showing {{pluralize this.assets.length "non-radio asset entry"}}
     <th>Barcode</th>
     <th>Type</th>
     <th>Description</th>
-    <th>Assigned</th>
+    <th>Duration</th>
     <th>Cbecked Out Time /<br>By Person</th>
     <th>Checked In Time /<br>By Person</th>
     <th>Callsign</th>
@@ -27,8 +27,12 @@ Showing {{pluralize this.assets.length "non-radio asset entry"}}
       <tr>
         <td>{{asset.barcode}}</td>
         <td>{{this.typeLabel asset.type}}</td>
-        <td><PresentOrNot @value={{asset.description}} @empty="-" /></td>
-        <td>{{if asset.perm_assign "Permanent" "Temporary"}}</td>
+        <td>
+          <PresentOrNot @value={{asset.description}} @empty="-"/>
+        </td>
+        <td class="text-center">
+          <AssetDurationLabel @asset={{asset}} />
+        </td>
         <td>
           {{shift-format history.checked_out}}<br>
           {{#if history.check_out_person}}

--- a/app/templates/reports/assets-outstanding.hbs
+++ b/app/templates/reports/assets-outstanding.hbs
@@ -16,7 +16,7 @@ Showing {{pluralize this.assets.length "asset"}} outstanding.
     <th>Type</th>
     <th>Description</th>
     <th>Attachment</th>
-    <th>Assigned</th>
+    <th>Duration</th>
     <th>Checked Out /<br>By Person</th>
   </tr>
   </thead>
@@ -42,8 +42,8 @@ Showing {{pluralize this.assets.length "asset"}} outstanding.
           -
         {{/if}}
       </td>
-      <td>
-        {{if asset.perm_assign "Permanent" "Temporary"}}
+      <td class="text-center">
+        <AssetDurationLabel @asset={{asset}} />
       </td>
        <td>
         {{shift-format asset.checked_out.checked_out}}<br>

--- a/app/templates/reports/radio-assets.hbs
+++ b/app/templates/reports/radio-assets.hbs
@@ -15,7 +15,7 @@
       <th>Count</th>
     {{/if}}
     <th>Description</th>
-    <th>Assigned</th>
+    <th>Duration</th>
   </tr>
   </thead>
   <tbody>
@@ -26,7 +26,9 @@
         <td class="text-end">{{asset.count}}</td>
       {{/if}}
       <td>{{asset.description}}</td>
-      <td>{{if asset.perm_assign "Permanent" "Temporary"}}</td>
+      <td class="text-center">
+        <AssetDurationLabel @asset={{asset}} />
+      </td>
     </tr>
   {{else}}
     <tr>

--- a/app/templates/reports/radio-checkout.hbs
+++ b/app/templates/reports/radio-checkout.hbs
@@ -57,6 +57,10 @@ Showing {{pluralize this.radios.length "entry"}}
         {{else}}
           -
         {{/if}}
+        {{#if radio.check_out_forced}}
+          <br>
+          <UiBadge @type="warning">check out forced</UiBadge>
+        {{/if}}
       </td>
       {{#if (or this.event_summary this.include_eligible)}}
         <td>

--- a/app/templates/reports/vehicle-paperwork.hbs
+++ b/app/templates/reports/vehicle-paperwork.hbs
@@ -15,7 +15,7 @@ This report will show anyone who meets one of the following conditions:
   <UiButton @onClick={{this.exportToCsv}}>Export to CSV</UiButton>
 </p>
 Showing {{pluralize this.people.length "person"}}
-<UiTable @noWidthAuto={{true}} class="table-sticky">
+<UiTable @noWidthAuto={{true}} @stickyHeader={{true}}>
   <thead>
   <tr>
     <th>Callsign</th>

--- a/app/templates/search/assets.hbs
+++ b/app/templates/search/assets.hbs
@@ -31,7 +31,7 @@
   {{/if}}
   <h3 class="mt-3">
     Asset {{this.asset.barcode}}
-    ({{if this.asset.perm_assign "permanent" "temporary"}})
+    <AssetDurationLabel @asset={{this.asset}} />
     {{this.asset.type}} {{this.asset.description}}
   </h3>
   <UiSection>
@@ -61,6 +61,12 @@
                 <PersonLink @person={{row.check_out_person}} />
               {{else}}
                 -
+              {{/if}}
+              {{#if row.check_out_forced}}
+                <br>
+                <UiBadge @type="warning">
+                  check out forced
+                </UiBadge>
               {{/if}}
             </td>
             <td>


### PR DESCRIPTION
- Added an order number column to track the vendor's order number a radio belongs to.
- Allow expired assets to be forced checked out because the playa always throws a curveball every event.
- Indicate if an asset was forced checked out on some reports and table listings.
- Added mobile/vehicle radios, desktop radios, and radio charge asset types.
- Let the user know assets with entity assignments cannot be checked out.
- Renamed asset assignment (event vs shift) columns to duration.