### PR TITLE
Dashboard tweaks.

### DIFF
--- a/app/components/dashboard-ranger.js
+++ b/app/components/dashboard-ranger.js
@@ -272,7 +272,7 @@ const STEPS = [
   DashboardStep.TICKETING_CLOSED,
   {
     name: 'Sign the Sandman Affidavit',
-    skipPeriod: [ POST_EVENT, AFTER_EVENT],
+    skipPeriod: [POST_EVENT, AFTER_EVENT],
     check({milestones}) {
       if (milestones.sandman_affidavit_signed) {
         return {result: COMPLETED};
@@ -385,13 +385,23 @@ export default class DashboardRangerComponent extends Component {
     const {
       immediateSteps,
       steps,
-      completed
+      completed,
+      note
     } = this._processStepGroup(this.args.person.isNonRanger ? NON_RANGER_STEPS : STEPS);
 
+    const pushNote = () => {
+        if (note.length) {
+          groups.push(new StepGroup('Important Note', note, true, true));
+        }
+      };
     if (immediateSteps.length) {
       groups.push(new StepGroup('IMMEDIATE ACTION REQUIRED', immediateSteps, true, true));
-    } else if (!steps.length) {
+      pushNote();
+     } else if (!steps.length) {
+      pushNote();
       steps.push((isPostEvent || isAfterEvent) ? AFTER_EVENT_NO_MORE_THINGS_STEP : BEFORE_EVENT_NO_MORE_THINGS_STEP);
+    } else {
+      pushNote();
     }
 
     if (!isAfterEvent || !isPostEvent || steps.length) {
@@ -433,7 +443,7 @@ export default class DashboardRangerComponent extends Component {
     const period = milestones.period;
     let haveAction = false;
 
-    const steps = [], immediateSteps = [], completed = [];
+    const steps = [], immediateSteps = [], completed = [], note = [];
 
     checks.forEach((step) => {
       if (matchPeriod(step.period, period, true)
@@ -463,6 +473,8 @@ export default class DashboardRangerComponent extends Component {
 
       if (check.immediate || step.immediate) {
         immediateSteps.push(check);
+      } else if (check.result === NOTE) {
+        note.push(check);
       } else if (check.result === COMPLETED) {
         completed.push(check);
       } else {
@@ -474,7 +486,7 @@ export default class DashboardRangerComponent extends Component {
     this._sortSteps(immediateSteps);
     this._sortSteps(completed);
 
-    return {steps, immediateSteps, completed};
+    return {steps, immediateSteps, completed, note};
   }
 
   _sortSteps(steps) {

--- a/app/constants/dashboard-steps.js
+++ b/app/constants/dashboard-steps.js
@@ -21,7 +21,7 @@ import {
   AFTER_EVENT,
   BEFORE_EVENT,
   COMPLETED, DURING_EVENT,
-  NOT_AVAILABLE,
+  NOT_AVAILABLE, NOTE,
   OPTIONAL, POST_EVENT,
   SKIP,
   URGENT,
@@ -920,7 +920,6 @@ export const SIGN_NDA = {
 };
 
 export const AFTER_EVENT_STATUS_ADVISORY = {
-  immediate: true,
   check({person}) {
     const {status} = person;
 
@@ -932,8 +931,8 @@ export const AFTER_EVENT_STATUS_ADVISORY = {
       return {
         name: 'Retired Status',
         email: 'VCEmail',
-        result: ACTION_NEEDED,
-        message: htmlSafe("<p>Your status has been changed to <i>retired</i> because you have not rangered in 5 or more consecutive events.</p>" +
+        result: NOTE,
+        message: htmlSafe("<p>Your status has been changed to <i>retired</i> because you have not rangered on playa in 5 or more consecutive events.</p>" +
           "<p>If you wish to volunteer with the Rangers next event, you will need to attend a full day's " +
           "In-Person Training, and walk a Cheetah Cub shift with a Mentor.</p><p>The Mentor Cadre will restore your active status at the end of the Cheetah Cub shift if they determine you are fit to resume rangering.</p>Contact the Volunteer Coordinators for more information.")
       };
@@ -941,11 +940,11 @@ export const AFTER_EVENT_STATUS_ADVISORY = {
       return {
         name: `Inactive ${person.status === INACTIVE_EXTENSION ? 'Extension ' : ''}Status`,
         email: 'VCEmail',
-        result: ACTION_NEEDED,
+        result: NOTE,
         message: htmlSafe(
-          `<p>Your status has been changed to <i>${person.status}</i> because you have not rangered in 3 or more consecutive events.<p>` +
-          "<p>If you wish to volunteer with the Rangers next event, you will need to attend a full day's " +
-          "In-Person Training, and work a non-training, non-mentee shift.</p><p>Your active status will be automatically restored upon completing a shift that is neither a training nor a mentee shift.</p> Contact the Volunteer Coordinators for more information.")
+          `<p>Your status has been changed to <i>${person.status}</i> because you have not rangered on playa in 3 or more consecutive events.<p>` +
+          "<p>If you wish to volunteer with the Rangers next event, you will need to:<ul><li>Attend a full day's " +
+          "In-Person Training</li><li>And work a shift that is neither a training nor a mentee shift. Any Dirt shift or similar will qualify towards restoring your active status.</li></ul>Training and mentee shifts, such as a Sandman Training and Green Dot Mentee shifts, do not count toward qualifying for restoring your active status.</p><p>Your active status will be automatically restored upon completing a shift that is neither a training nor a mentee shift.</p> Contact the Volunteer Coordinators for more information.")
       };
     }
   }


### PR DESCRIPTION
- Have the inactive / retired notification be a note, not an "Immediate Action Item".
- Clarified the language about working a non-training, non-mentee shift to restore active status.