### PR TITLE
Relocate the year selector in a page title to just below it.

### DIFF
--- a/app/components/person/years-breakdown.hbs
+++ b/app/components/person/years-breakdown.hbs
@@ -13,8 +13,8 @@ Rangered events:
   {{#if @person.years_as_contributor}}
     {{pluralize @person.years_as_contributor.length "event"}}
     [{{year-range @person.years_as_contributor}}]
-  {{/if}}
-{{/if}}<br>
+  {{/if}}<br>
+{{/if}}
 Service years:
 {{#if @person.years_of_service}}
   {{pluralize @person.years_of_service.length "year"}}

--- a/app/components/year-select.hbs
+++ b/app/components/year-select.hbs
@@ -1,20 +1,12 @@
-{{#if @subheader}}
-  <div class="h2 mb-4">
-    <ChForm::Select @name="year"
-                    @value={{@year}}
-                    @options={{this.yearOptions}}
-                    @onChange={{@onChange}}
-                    @controlClass=""/>
-    {{@title}}
-  </div>
-{{else}}
-  <h1 class="mb-4">
-    <ChForm::Select @name="year"
-                    @value={{@year}}
-                    @options={{this.yearOptions}}
-                    @onChange={{@onChange}}
-                    @controlClass=""/>
-    {{@title}}
-  </h1>
-{{/if}}
+<div class="mb-2 {{if @subheader "h2" "h1"}}">
+  {{@year}} {{@title}}
+</div>
 
+<div class="mb-4">
+  <span class="me-2">Select year to view:</span>
+  <ChForm::Select @name="year"
+                  @value={{@year}}
+                  @options={{this.yearOptions}}
+                  @onChange={{@onChange}}
+                  @controlClass=""/>
+</div>


### PR DESCRIPTION
The year selector in a title is a very poor UX design choice.