### PR TITLE
Use '-' instead of a blank for Imported column

### DIFF
--- a/app/templates/vc/spigot.hbs
+++ b/app/templates/vc/spigot.hbs
@@ -80,7 +80,11 @@
           {{/if}}
         </td>
         <td class="text-end">
-          {{day.imported.length}}
+          {{#if day.imported.length}}
+            {{day.imported.length}}
+          {{else}}
+            -
+          {{/if}}
         </td>
         <td class="text-end">
           <SpigotCallsigns @callsigns={{day.created}} @title="Created" @day={{day.day}} />


### PR DESCRIPTION
Use '-' instead of a blank for Imported column to make it look like the rest of the table