### PR TITLE
Ensure a browser window showing bookmarks is not affected by login/logout

### DIFF
--- a/app/routes/bookmark.js
+++ b/app/routes/bookmark.js
@@ -1,4 +1,5 @@
 import ClubhouseRoute from "clubhouse/routes/clubhouse-route";
+import {getOwner} from '@ember/application';
 
 export default class BookmarkRoute extends ClubhouseRoute {
   authRequired = false;
@@ -7,15 +8,28 @@ export default class BookmarkRoute extends ClubhouseRoute {
     return bookmark_id;
   }
 
-  setupController(controller, bookmarkId) {
+  async setupController(controller, bookmarkId) {
     controller.content = null;
     controller.bookmarkId = bookmarkId;
     controller.refreshTime = 0;
     controller.countdown = 0;
     controller.notFound = false;
     controller.setupTick();
-    controller.loadDocument();
+    await controller.loadDocument();
     this.session.showingBookmark = true;
+
+    this.session.user = null;
+    // Some hackery to get ember-simple-auth to not respond to login / logout events in other windows.
+    // Kill the authentication, and remove the local storage listener.
+    const applicationInstance = getOwner(this);
+    const session = applicationInstance.lookup('session:main');
+    session.setProperties({
+      isAuthenticated: false,
+      authenticator: null,
+      'content.authenticated': {}
+    });
+    const store = applicationInstance.lookup('session-store:local-storage');
+    window.removeEventListener('storage', store._handleStorageEvent);
   }
 
   resetController(controller, isExiting) {


### PR DESCRIPTION
ember-simple-auth uses events to watch for updated to the local storage. This enables the addon to login and logout other browser windows if need be.

Since we're showing a bookmark, we want to kill the login just for the current browser window, and not login or logout if another window does so.