### PR TITLE
ops/slot UI work.

### DIFF
--- a/app/components/admin/slots-table.hbs
+++ b/app/components/admin/slots-table.hbs
@@ -2,17 +2,16 @@
   <thead>
   <tr>
     <th class="text-end">ID</th>
-    <th>Active</th>
+    <th class="text-center">Active</th>
     <th>Time</th>
-    <th class="text-end">Max</th>
-    <th class="text-end">Count</th>
+    <th class="text-end">Signups</th>
     <th class="text-end">Credits</th>
     <th>Description</th>
     <th>Actions</th>
   </tr>
   </thead>
   <tbody>
-  {{#each @group.slots key="id" as |slot|}}
+  {{#each @slots key="id" as |slot|}}
     <tr id="slot-{{slot.id}}">
       <td class="text-end">{{slot.id}}</td>
       <td class="text-center">
@@ -28,20 +27,30 @@
         {{#if slot.trainer_slot}}
           <div class="mt-1">
             Multiplier
-            #{{slot.trainer_slot.id}} {{slot.trainer_slot.position.title}} {{slot.trainer_slot.description}}
-            {{shift-format slot.trainer_slot.begins}}
+            #{{slot.trainer_slot.id}} {{slot.trainer_slot.position.title}} - {{slot.trainer_slot.description}}
+            -  {{shift-format slot.trainer_slot.begins}}
           </div>
         {{/if}}
-        {{#if slot.parent_signup_slot}}
-          <div class="mt-1">
-            Parent
-            #{{slot.parent_signup_slot.id}} {{slot.parent_signup_slot.position.title}} {{slot.parent_signup_slot.description}}
-            {{shift-format slot.parent_signup_slot.begins}}
-          </div>
-        {{/if}}
+        {{#let (this.parentSlot slot) as |parent|}}
+          {{#if parent}}
+            <div class="mt-1">
+              Parent
+              #{{parent.id}} {{parent.position.title}}-  {{parent.description}} - {{shift-format parent.begins}}
+            </div>
+          {{/if}}
+        {{/let}}
+        {{#let (this.childSlot slot) as |child|}}
+          {{#if child}}
+            <div class="mt-1">
+              Child
+              #{{child.id}} {{child.position.title}} - {{child.description}} -
+              {{shift-format child.begins}}
+            </div>
+
+          {{/if}}
+        {{/let}}
       </td>
-      <td class="text-end">{{slot.max}}</td>
-      <td class="text-end">{{slot.signed_up}}</td>
+      <td class="text-end">{{slot.signed_up}} of {{slot.max}}</td>
       <td class="text-end">{{credits-format slot.credits}}</td>
       <td>
         <SlotInfoLink @description={{slot.description}} @info={{slot.url}} />

--- a/app/components/admin/slots-table.js
+++ b/app/components/admin/slots-table.js
@@ -1,0 +1,14 @@
+import Component from '@glimmer/component';
+import {action} from '@ember/object';
+
+export default class AdminSlotsTable extends Component {
+  @action
+  parentSlot(slot) {
+    return this.args.slotsById[slot.parent_signup_slot_id];
+  }
+
+  @action
+  childSlot(slot) {
+    return this.args.childrenByParentId[slot.id];
+  }
+}

--- a/app/controllers/ops/slots.js
+++ b/app/controllers/ops/slots.js
@@ -75,6 +75,16 @@ export default class OpsSlotsController extends ClubhouseController {
   }
 
   @cached
+  get slotsById() {
+    return _.keyBy(this.slots, 'id');
+  }
+
+  @cached
+  get childrenByParentId() {
+    return _.keyBy(this.slots.filter((s) => s.parent_signup_slot_id), 'parent_signup_slot_id');
+  }
+
+  @cached
   get viewSlots() {
     let slots = this.slots;
     const dayFilter = this.dayFilter;

--- a/app/routes/ops/slots.js
+++ b/app/routes/ops/slots.js
@@ -16,7 +16,6 @@ export default class OpsSlotsRoute extends ClubhouseRoute {
       slots: await this.store.query('slot', {year}),
       positions: await this.store.query('position', {}),
       year,
-      yearList: await this.ajax.request('slot/years').then((result) => result.years),
       eventDate: await this.ajax.request('event-dates/year', {data: {year}}).then((result) => result.event_date)
     }
   }

--- a/app/templates/ops/slots.hbs
+++ b/app/templates/ops/slots.hbs
@@ -2,7 +2,8 @@
   <div class={{if (or this.showSlotCopyDialog this.slot this.showBulkEditDialog this.linkGroup) "d-none"}}>
     <YearSelect @title="Clubhouse Slots"
                 @year={{this.year}}
-                @years={{this.yearList}}
+                @minYear={{2008}}
+                @skipPandemic={{true}}
                 @onChange={{set-value this 'year'}} />
 
     {{#if (and this.eventDate.pre_event_slot_start this.eventDate.pre_event_slot_end)}}
@@ -32,23 +33,33 @@
                         @onChange={{this.changeActiveFilter}} />
       </div>
       <FormLabel @auto={{true}}>Actions</FormLabel>
-      <div class="col-auto hstack gap-3">
-        <UiButton @onClick={{this.newSlot}} @size="sm">New Slot</UiButton>
-        {{#if this.slots.length}}
-          <UiButton @onClick={{fn this.openSlotCopy null}} @type="secondary" @size="sm">Copy Slots</UiButton>
-        {{/if}}
+      <div class="col-auto">
+        <UiButtonRow>
+          <UiButton @onClick={{this.newSlot}} @size="sm">New Slot</UiButton>
+          {{#if this.slots.length}}
+            <UiButton @onClick={{fn this.openSlotCopy null}} @type="secondary" @size="sm">Copy Slots</UiButton>
+          {{/if}}
+        </UiButtonRow>
       </div>
     </FormRow>
-    <FormRow>
+    <FormRow class="g-2">
       <FormLabel @auto={{true}}>
         Filter by description:
       </FormLabel>
       <div class="col-auto">
-        <Input @type="text" @value={{this.filterByDescription}} {{on "input" this.changeFilterByDescription}} size="20"
-               class="form-control"/>
+        <Input @type="text"
+               @value={{this.filterByDescription}}
+               size="20"
+               class="form-control"
+          {{on "input" this.changeFilterByDescription}}
+        />
       </div>
       <div class="col-auto">
-        <UiButton @type="secondary" @size="sm" @onClick={{this.clearFilterByDescription}}>Clear</UiButton>
+        <UiButton @type="secondary" class="btn-link" @size="md" @onClick={{this.clearFilterByDescription}}>
+          Clear
+        </UiButton>
+      </div>
+      <div class="col-auto">
       </div>
     </FormRow>
 
@@ -70,7 +81,9 @@
                 Results
               </UiButton>
             </div>
-            <Admin::SlotsTable @group={{this.filteredDescriptionGroup}}
+            <Admin::SlotsTable @slots={{this.filteredDescriptionGroup.slots}}
+                               @slotsById={{this.slotsById}}
+                               @childrenByParentId={{this.childrenByParentId}}
                                @repeatSlot={{this.repeatSlot}}
                                @repeatSlotAdd24Hours={{this.repeatSlotAdd24Hours}}
                                @deleteSlot={{this.deleteSlot}}
@@ -131,7 +144,9 @@
                   </UiButton>
                 {{/if}}
               </UiButtonRow>
-              <Admin::SlotsTable @group={{group}}
+              <Admin::SlotsTable @slots={{group.slots}}
+                                 @slotsById={{this.slotsById}}
+                                 @childrenByParentId={{this.childrenByParentId}}
                                  @repeatSlot={{this.repeatSlot}}
                                  @repeatSlotAdd24Hours={{this.repeatSlotAdd24Hours}}
                                  @deleteSlot={{this.deleteSlot}}


### PR DESCRIPTION
- Bring the listing to parity with the other slot reporting pages.
- {parent,child}_signup_slot is no longer returned for performance reasons. The table now uses hashes built from the retrieve slots to figure out the parent and child.