### PR TITLE
New permission - Edit Emergency Contact Year Round

### DIFF
--- a/app/constants/roles.js
+++ b/app/constants/roles.js
@@ -38,6 +38,7 @@ export const POD_MANAGEMENT = 126;
 export const AWARD_MANAGEMENT = 127; // Allows a person to grant or revoke service awards.
 export const FULL_REPORT_ACCESS = 128; // Allows a person to see an unrestrict report view for reports like Timesheets By Callsign
 export const EDIT_HANDLE_RESERVATIONS = 129; // Can manage the handle reservations list.
+export const EDIT_EMERGENCY_CONTACT = 130; // Can edit / view Emergency Contact Info even if EMOP is disabled.
 
 export const ROLE_BASE_MASK = 0x7f000000;
 export const POSITION_MASK = 0x0fff;

--- a/app/routes/hq/site-checkin.js
+++ b/app/routes/hq/site-checkin.js
@@ -1,4 +1,5 @@
 import ClubhouseRoute from 'clubhouse/routes/clubhouse-route';
+import {EDIT_EMERGENCY_CONTACT} from "clubhouse/constants/roles";
 
 export default class HqSiteCheckinRoute extends ClubhouseRoute {
   setupController(controller, model) {
@@ -9,5 +10,9 @@ export default class HqSiteCheckinRoute extends ClubhouseRoute {
     controller.showSiteCheckInWizard = false;
     controller.siteCheckInStarted = false;
     controller.siteCheckInFinished = false;
-   }
+    controller.canEditEmergencyContact =
+      this.session.isAdmin
+      || this.session.isEMOPEnabled
+      || this.session.hasRole(EDIT_EMERGENCY_CONTACT);
+  }
 }

--- a/app/routes/person/emergency-contact.js
+++ b/app/routes/person/emergency-contact.js
@@ -1,19 +1,22 @@
 import ClubhouseRoute from 'clubhouse/routes/clubhouse-route';
-import {ADMIN, MANAGE} from 'clubhouse/constants/roles';
+import {ADMIN, EDIT_EMERGENCY_CONTACT, MANAGE} from 'clubhouse/constants/roles';
 
 export default class PersonEmergencyContactRoute extends ClubhouseRoute {
   roleRequired = [ADMIN, MANAGE];
 
   setupController(controller) {
     const person = this.modelFor('person');
-    controller.set('person', person);
+    controller.person = person;
     /*
      Person allowed to view EC info if
      - the user is the person OR
      - the person is an Admin
      - the person has LM and EventManagementOnPlayaEnabled is on.
      */
-    controller.set('canAccessEmergencyContact',
-      (+person.id === this.session.userId) || this.session.isAdmin || this.session.isEMOPEnabled);
+    controller.canAccessEmergencyContact =
+      (person.idNumber === this.session.userId)
+      || this.session.isAdmin
+      || this.session.isEMOPEnabled
+      || this.session.hasRole(EDIT_EMERGENCY_CONTACT);
   }
 }

--- a/app/templates/hq/site-checkin.hbs
+++ b/app/templates/hq/site-checkin.hbs
@@ -99,7 +99,7 @@
       <w.step @title="Verify Emergency Contact Information"
               @nextLabel="Save & Next"
               @nextAction={{fn this.saveContactForm f.model}}>
-        {{#if this.session.isEMOPEnabled}}
+        {{#if this.canEditEmergencyContact}}
           <p class="ms-2">
             <b>Off-Playa:</b>
             Real world name, relationship (partner, friend, sibling, parent), phone number, &amp; email.<br>


### PR DESCRIPTION
This is intended to handle the Pre-Event week before EMOP is activated yet On Site Registration is happening.