### PR TITLE
Various shift related fixes.

### DIFF
--- a/app/components/admin/slot-form.hbs
+++ b/app/components/admin/slot-form.hbs
@@ -53,9 +53,9 @@
     </FormRow>
   </fieldset>
   <fieldset class="mt-2">
-    <legend>Additional Shift Information</legend>
+    <legend>Shift Information</legend>
     <div class="my-2">
-      Remember to provide additional information about the shift in the area below. Any url and emails will be
+      Remember to provide information about the shift in the area below. Any url and emails will be
       hyperlinked automatically. When the user signs up for this shift, the following information will be displayed
       automatically.
     </div>

--- a/app/components/shift-check-in-out.hbs
+++ b/app/components/shift-check-in-out.hbs
@@ -57,57 +57,55 @@
   {{/unless}}
 {{else}}
   {{#unless @hasUnreviewedTimesheet}}
-    {{#unless this.inPersonTrainingPassed}}
-      {{#if @upcomingSlots.imminent}}
-        <div class="mb-2 fw-semibold">
-          {{@person.callsign}} can be signed in to a scheduled shift OR an unscheduled shift (aka position).
-        </div>
-        <UiTable @normalSize={{true}} @noStriped={{true}}>
-          <thead>
-          <tr>
-            <th>Shift</th>
-            <th>Time</th>
-            <th>Action</th>
+    {{#if @upcomingSlots.imminent}}
+      <div class="mb-2 fw-semibold">
+        {{@person.callsign}} can be signed in to a scheduled shift OR an unscheduled shift (aka position).
+      </div>
+      <UiTable @normalSize={{true}} @noStriped={{true}}>
+        <thead>
+        <tr>
+          <th>Shift</th>
+          <th>Time</th>
+          <th>Action</th>
+        </tr>
+        </thead>
+        <tbody>
+        {{#each @upcomingSlots.imminent as |slot|}}
+          <tr class="{{if slot.slot_description "tr-no-border"}}">
+            <td class="align-middle">
+              {{slot.position_title}}
+            </td>
+            <td class="align-middle">{{shift-format slot.slot_begins slot.slot_ends}}</td>
+            <td class="align-middle">
+              <UiButton @type="primary"
+                        @onClick={{fn this.signInShiftAction slot}}
+                        @disabled={{this.isSubmitting}}
+                        @size="md">
+                {{fa-icon "person-walking" right=2}} Start Shift
+              </UiButton>
+              {{#if this.isSubmitting}}
+                <LoadingIndicator/>
+              {{/if}}
+            </td>
           </tr>
-          </thead>
-          <tbody>
-          {{#each @upcomingSlots.imminent as |slot|}}
-            <tr class="{{if slot.slot_description "tr-no-border"}}">
-              <td class="align-middle">
-                {{slot.position_title}}
-              </td>
-              <td class="align-middle">{{shift-format slot.slot_begins slot.slot_ends}}</td>
-              <td class="align-middle">
-                <UiButton @type="primary"
-                          @onClick={{fn this.signInShiftAction slot}}
-                          @disabled={{this.isSubmitting}}
-                          @size="md">
-                  {{fa-icon "person-walking" right=2}} Start Shift
-                </UiButton>
-                {{#if this.isSubmitting}}
-                  <LoadingIndicator/>
-                {{/if}}
+          {{#if slot.slot_description}}
+            <tr class="tr-no-top-padding">
+              <td colspan="3">
+                <SlotInfoLink @description={{slot.slot_description}} @info={{slot.slot_url}} />
               </td>
             </tr>
-            {{#if slot.slot_description}}
-              <tr class="tr-no-top-padding">
-                <td colspan="3">
-                  <SlotInfoLink @description={{slot.slot_description}} @info={{slot.slot_url}} />
-                </td>
-              </tr>
-            {{/if}}
+          {{/if}}
 
-          {{/each}}
-          </tbody>
-        </UiTable>
-        <p>
-          <b>
-            To sign in to a different shift / position, select the position below, and use the
-            <i>Start Shift</i> button.
-          </b>
-        </p>
-      {{/if}}
-    {{/unless}}
+        {{/each}}
+        </tbody>
+      </UiTable>
+      <p>
+        <b>
+          To sign in to a different shift / position, select the position below, and use the
+          <i>Start Shift</i> button.
+        </b>
+      </p>
+    {{/if}}
 
     <FormRow>
       <label class="col-auto col-form-label">

--- a/app/components/shift-check-in-out.js
+++ b/app/components/shift-check-in-out.js
@@ -7,7 +7,7 @@ import {
   DIRT_SHINY_PENNY,
   BURN_PERIMETER,
   NVO_RANGER,
-  DPW_RANGER,
+  DPW_RANGER, TOW_TRUCK_TRAINING, TROUBLESHOOTER_TRAINING, SANDMAN_TRAINING,
 } from 'clubhouse/constants/positions';
 import {cached, tracked} from '@glimmer/tracking';
 import {ECHELON} from 'clubhouse/constants/person_status';
@@ -61,7 +61,17 @@ export default class ShiftCheckInOutComponent extends Component {
 
     let {positions} = this.args;
 
-    positions = positions.filter((p) => (p.type !== TYPE_TRAINING || p.title.match(/trainer/i)));
+    positions = positions.filter((p) => {
+      if (p.type !== TYPE_TRAINING) {
+        return true;
+      }
+
+      if (p.title.match(/trainer/i)) {
+        return true;
+      }
+
+      return  (p.id === TOW_TRUCK_TRAINING || p.id === TROUBLESHOOTER_TRAINING || p.id === SANDMAN_TRAINING);
+    });
     this.noTrainingRequiredPositions = positions.filter((p) => isEmpty(p.blockers));
     if (this.noTrainingRequiredPositions.length && this.args.isSelfServe) {
       this.activePositions = this.noTrainingRequiredPositions;

--- a/app/components/slot-info-link.js
+++ b/app/components/slot-info-link.js
@@ -16,6 +16,6 @@ export default class SlotInfoLink extends Component {
       return;
     }
 
-    this.modal.info('Additional Shift Information', hyperlinkText(text));
+    this.modal.info('Shift Information', hyperlinkText(text));
   }
 }


### PR DESCRIPTION
- Recommended shift sign-ins were being blocked by untrained individuals.
- Removed "Additional" word from shift info dialog. (some people were being confused thinking a second information text was being delivered.)
- Allow Troubleshooter Training, Sandman Training to be checked in as well.