### PR TITLE
Added null coalesce when handling the copy-to-clipboard button.

### DIFF
--- a/app/components/email-list.js
+++ b/app/components/email-list.js
@@ -27,7 +27,7 @@ export default class EmailListComponent extends Component {
 
   @action
   copyToClipboardAction(event) {
-    event.preventDefault();
+    event?.preventDefault();
 
     // Find out the element to copy to the clipboard
     const element = document.querySelector('#'+this.listId);


### PR DESCRIPTION
(Not sure why this is breaking now when it was working perfectly for a couple of years)