### PR TITLE
New sign in permission feature.

### DIFF
--- a/app/components/position-edit.hbs
+++ b/app/components/position-edit.hbs
@@ -179,7 +179,11 @@
       <FormRow>
         <div class="col-12">
           <f.checkbox @name="require_training_for_roles"
-                      @label="ART training must be passed each year before roles are granted"/>
+                      @label="ART training must be passed each year before permissions are granted"/>
+        </div>
+        <div class="col-12">
+          <f.checkbox @name="require_signin_for_roles"
+                      @label="Permissions are only granted while signed into this position"/>
         </div>
       </FormRow>
       <FormRow>

--- a/app/models/position.js
+++ b/app/models/position.js
@@ -24,6 +24,10 @@ export const ATTR_LABELS = [
     label: 'Requires ART to be passed before roles are granted.'
   },
   {
+    id: 'require_signin_for_roles',
+    label: 'Permissions are only granted while signed into this position'
+  },
+  {
     id: 'new_user_eligible',
     label: 'Grant to New Accounts',
   },
@@ -118,6 +122,7 @@ export default class PositionModel extends Model {
   @attr('string', {defaultValue: TEAM_CATEGORY_OPTIONAL}) team_category;
 
   @attr('boolean', {defaultValue: false}) require_training_for_roles;
+  @attr('boolean', {defaultValue: false}) require_signin_for_roles;
 
   @attr('boolean', {defaultValue: false}) no_training_required;
 

--- a/app/routes/me/homepage.js
+++ b/app/routes/me/homepage.js
@@ -1,4 +1,5 @@
 import ClubhouseRoute from 'clubhouse/routes/clubhouse-route';
+import {setting} from "clubhouse/utils/setting";
 
 export default class MeHomepageRoute extends ClubhouseRoute {
   async model() {
@@ -12,10 +13,18 @@ export default class MeHomepageRoute extends ClubhouseRoute {
       data.agreements = await this.ajax.request(`agreements/${user.id}`).then(({agreements}) => agreements);
     }
     return data;
+
   }
 
   setupController(controller, model) {
     const bullentins = model.bullentins;
+    const {user} = this.session;
+
+    if ((user.isRanger || user.isEchelon) && !!setting('EventManagementOnPlayaEnabled')) {
+      controller.set('signinPositions', user.role_signin_positions);
+    } else {
+      controller.set('signinPositions', null);
+    }
 
     controller.set('person', this.modelFor('me'));
     controller.set('photo', model.milestones.photo);

--- a/app/templates/me/homepage.hbs
+++ b/app/templates/me/homepage.hbs
@@ -19,6 +19,20 @@
                     @agreements={{this.agreements}}
                     @debugUpdateAction={{this.debugUpdateAction}} />
 {{else}}
+  {{#if this.signinPositions}}
+    <UiNotice @type="secondary" @title="Sign in before you volunteer for certain positions" @icon="person-walking">
+      <div class="lh-2">
+        To volunteer any of the following positions, you need to be signed in to it.<br>
+        Signing in gives you the Clubhouse permissions that position requires.<br>
+        <b>No one around to sign you in?</b> Call Khaki.
+      </div>
+      <ul class="mt-2 mb-0">
+        {{#each this.signinPositions as |pos|}}
+          <li>{{pos.title}}</li>
+        {{/each}}
+      </ul>
+    </UiNotice>
+  {{/if}}
   <DashboardRanger @milestones={{this.milestones}}
                    @person={{this.person}}
                    @motds={{this.motds}}


### PR DESCRIPTION
Positions have a new flag to indicate the associated permissions will only be granted when they are signed into the position.

The use case is HQ Window where people may be trained yet may not work a HQ position.