### PR TITLE
Name the at-capacity shift in the force-signup modal

### DIFF
--- a/app/services/shift-manage.js
+++ b/app/services/shift-manage.js
@@ -204,13 +204,15 @@ export default class ShiftManageService extends Service {
     const signupCallback = () => this.slotSignup(slot, person, callback, true);
 
     switch (result.status) {
-      case 'full':
+      case 'full': {
+        const fullShift = result.full_position_title ? `The ${result.full_position_title} shift` : 'The shift';
         this.modal.confirm(
           'Shift is at capacity',
-          `The shift is full, however you have the privileges to add this shift to the schedule. ${CONFIRM_FORCE_MESSAGE}`,
+          `${fullShift} is full, however you have the privileges to add this shift to the schedule. ${CONFIRM_FORCE_MESSAGE}`,
           signupCallback
         );
         return;
+      }
 
       case 'has-started':
       case 'has-ended': {


### PR DESCRIPTION
The "Shift is at capacity" force-confirm modal now names the shift that is actually full, using the API's `full_position_title`. For linked parent/child shifts this clarifies when an add is blocked by a *linked* shift (e.g. adding to a Mentee shift whose Ridealong parent pool is full) even though the clicked shift still shows open seats. Falls back to the generic wording when the field is absent.

Companion [API PR](https://github.com/burningmantech/ranger-clubhouse-api/pull/2198) (adds `full_position_title`). Backward-compatible — safe to merge independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3WHpzguKQrphQmFbYwqjA