### PR TITLE
Fix qualified S.O. Setup Access Pass shown as "claimed"

### DIFF
--- a/app/components/ticket-overview.js
+++ b/app/components/ticket-overview.js
@@ -53,7 +53,10 @@ export default class TicketOverviewComponent extends Component {
       this.deliveryMethod = DELIVERY_NONE;
     }
 
-    this.wapSOList = ticketPackage.wapso;
+    // Only SO SAPs that have actually been claimed/submitted should be shown as
+    // "claimed" — mirror the regular SAP gate (usingWAP) below. A merely
+    // qualified WAPSO must not render the "SAPs For Significant Other Claimed" card.
+    this.wapSOList = ticketPackage.wapso.filter((so) => so.isUsing);
 
     // Find the effective WAP - either claimed SC or actual WAP.
     if (this.usingStaffCredential) {

--- a/app/components/ticket-summary.js
+++ b/app/components/ticket-summary.js
@@ -112,8 +112,8 @@ export default class TicketSummaryComponent extends Component {
       claimed.push(htmlSafe(`A Setup Access Pass for yourself<br>${text}`));
     }
 
-    const {wapso} = pkg;
-    if (wapso && wapso.find((w) => w.isClaimed)) {
+    const wapso = pkg.wapso.filter((w) => w.isUsing);
+    if (wapso.length) {
       let text = `${wapso.length} Setup Access Pass${wapso.length > 1 ? 'es' : ''} for Significant Others`;
       claimed.push(htmlSafe(text));
     }
@@ -158,8 +158,8 @@ export default class TicketSummaryComponent extends Component {
       unclaimed.push(`No Setup Access Pass for yourself`);
     }
 
-    const wapso = pkg.wapso;
-    if (!wapso || !wapso.length) {
+    const wapso = pkg.wapso.filter((w) => w.isUsing);
+    if (!wapso.length) {
       unclaimed.push('No Setup Access Passes for Significant Others');
     }
 

--- a/tests/integration/components/ticket-overview-test.js
+++ b/tests/integration/components/ticket-overview-test.js
@@ -1,0 +1,59 @@
+import {module, test} from 'qunit';
+import {setupRenderingTest} from 'ember-qunit';
+import {render} from '@ember/test-helpers';
+import {hbs} from 'ember-cli-htmlbars';
+import TicketPackage from 'clubhouse/utils/ticket-package';
+import {WAPSO, QUALIFIED, CLAIMED} from 'clubhouse/models/access-document';
+
+function buildPackage(owner, accessDocuments) {
+  const storePayload = owner.lookup('service:store-payload');
+  const pkg = {
+    access_documents: accessDocuments,
+    gift_items: [],
+    lsd_items: [],
+    provision_records: [],
+    provisions: null,
+    provisions_bankable: false,
+    provisions_banked: false,
+  };
+  return new TicketPackage(pkg, 1, storePayload);
+}
+
+module('Integration | Component | ticket-overview', function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    this.person = {email: 'ranger@example.com', first_name: 'Test', last_name: 'Ranger'};
+  });
+
+  test('a qualified-only SO SAP is NOT shown as claimed', async function (assert) {
+    this.ticketPackage = buildPackage(this.owner, [
+      {
+        id: '211829', person_id: 1, type: WAPSO, status: QUALIFIED,
+        name: 'Pat Partner', access_date: '2026-08-26 00:01:00', access_any_time: false,
+      },
+    ]);
+
+    await render(hbs`<TicketOverview @ticketPackage={{this.ticketPackage}} @person={{this.person}} />`);
+
+    assert.dom(this.element).includesText('No SAPs For Significant Others');
+    assert.dom(this.element).doesNotIncludeText('SAPs For Significant Other Claimed');
+    // The claimed card lists the SO name; make sure it is not rendered.
+    assert.dom(this.element).doesNotIncludeText('Pat Partner');
+  });
+
+  test('a claimed SO SAP IS shown as claimed', async function (assert) {
+    this.ticketPackage = buildPackage(this.owner, [
+      {
+        id: '211829', person_id: 1, type: WAPSO, status: CLAIMED,
+        name: 'Pat Partner', access_date: '2026-08-26 00:01:00', access_any_time: false,
+      },
+    ]);
+
+    await render(hbs`<TicketOverview @ticketPackage={{this.ticketPackage}} @person={{this.person}} />`);
+
+    assert.dom(this.element).includesText('SAPs For Significant Other Claimed');
+    assert.dom(this.element).includesText('Pat Partner');
+    assert.dom(this.element).doesNotIncludeText('No SAPs For Significant Others');
+  });
+});

--- a/tests/integration/components/ticket-summary-test.js
+++ b/tests/integration/components/ticket-summary-test.js
@@ -1,0 +1,47 @@
+import {module, test} from 'qunit';
+import {setupRenderingTest} from 'ember-qunit';
+import {render} from '@ember/test-helpers';
+import {hbs} from 'ember-cli-htmlbars';
+import TicketPackage from 'clubhouse/utils/ticket-package';
+import {WAPSO, QUALIFIED, CLAIMED} from 'clubhouse/models/access-document';
+
+function buildPackage(owner, accessDocuments) {
+  const storePayload = owner.lookup('service:store-payload');
+  const pkg = {
+    access_documents: accessDocuments,
+    gift_items: [],
+    lsd_items: [],
+    provision_records: [],
+    provisions: null,
+    provisions_bankable: false,
+    provisions_banked: false,
+  };
+  return new TicketPackage(pkg, 1, storePayload);
+}
+
+module('Integration | Component | ticket-summary', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('SO SAP claimed count excludes qualified documents', async function (assert) {
+    // One claimed + one qualified SO SAP -> should count as 1, not 2.
+    this.ticketPackage = buildPackage(this.owner, [
+      {id: '1', person_id: 1, type: WAPSO, status: CLAIMED, name: 'Pat Partner', access_any_time: true},
+      {id: '2', person_id: 1, type: WAPSO, status: QUALIFIED, name: 'Sam Spouse', access_any_time: true},
+    ]);
+
+    await render(hbs`<TicketSummary @ticketPackage={{this.ticketPackage}} />`);
+
+    assert.dom(this.element).includesText('1 Setup Access Pass for Significant Others');
+    assert.dom(this.element).doesNotIncludeText('2 Setup Access Pass');
+  });
+
+  test('a qualified-only SO SAP is reported as unclaimed', async function (assert) {
+    this.ticketPackage = buildPackage(this.owner, [
+      {id: '1', person_id: 1, type: WAPSO, status: QUALIFIED, name: 'Pat Partner', access_any_time: true},
+    ]);
+
+    await render(hbs`<TicketSummary @ticketPackage={{this.ticketPackage}} />`);
+
+    assert.dom(this.element).includesText('No Setup Access Passes for Significant Others');
+  });
+});


### PR DESCRIPTION
The member "Tickets & Stuff" dashboard rendered the "SAPs For Significant Other Claimed" card whenever the person had *any* WAPSO (S.O. Setup Access Pass) access document, regardless of its status. A merely `qualified` WAPSO therefore appeared as claimed / "will be emailed to you", while the regular SAP correctly showed as not claimed.

The regular SAP card is gated on status via `usingWAP` (isClaimed || isSubmitted); the SO branch was gated only on list non-emptiness. Filter the SO list by `isUsing` to match, in TicketOverview.

The same root cause affected TicketSummary: `claimedItems` counted `wapso.length` (all statuses, over-counting a claimed+qualified mix) and `unclaimedItems` only reported "none" when zero WAPSOs of any status existed, so a qualified-only WAPSO showed in neither list. Both now filter by `isUsing`.

Adds integration tests for both components covering the qualified vs. claimed cases and the count.