### PR TITLE
Disable air-datepicker keyboard nav in date/time picker

### DIFF
--- a/app/components/datetime-picker.js
+++ b/app/components/datetime-picker.js
@@ -19,6 +19,9 @@ export default class DatetimePickerComponent extends Component {
       today: 'Today',
       clear: 'Clear',
       locale: localeEn,
+      // Let arrow keys / Shift+arrows move and highlight text in the input
+      // instead of navigating the calendar grid, which steals keyboard focus.
+      keyboardNav: false,
       onSelect:  ({formattedDate})  => this.args.onChange(formattedDate),
     }
 


### PR DESCRIPTION
## Problem

On the Edit Slots screen (Ops → Schedule Slots → Edit) — and every other date/time field — the calendar popup grabbed the keyboard. While the calendar was open, the arrow keys and Shift+arrows navigated the **calendar grid** instead of moving/highlighting text in the input, making the fields hard to edit by keyboard.

## Cause

`air-datepicker` enables `keyboardNav` by default, which routes keyboard events to calendar navigation.

## Fix

Set `keyboardNav: false` in the shared `datetime-picker` component so the input behaves like a normal text field. This applies to all `f.datetime` fields across the Clubhouse.

Mouse selection, the Today/Clear buttons, and click-to-pick are unaffected.

## Testing

Verified locally against a full-stack dev environment (Dockerized API + Ember): with the calendar open, arrow keys now move the cursor and Shift+arrows highlight text in the Start/Ending Time inputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)