### PR TITLE
Fix stale HQ site-checkin state when switching person

### DIFF
--- a/app/controllers/hq/shift.js
+++ b/app/controllers/hq/shift.js
@@ -44,6 +44,21 @@ export function isUnreviewedTimesheet(t) {
 }
 
 export default class HqShiftController extends ClubhouseController {
+  /*
+   * Supplied by the route's setupController via setProperties. These MUST be @tracked
+   * for the same reason as in hq/site-checkin.js: getters such as isShinyPenny and
+   * pendingItems read them from native getter bodies, which consume no tag unless the
+   * field is tracked. Switching person via the search bar re-runs setupController but
+   * reuses this controller instance, so only tracked invalidation updates the DOM.
+   */
+  @tracked person;
+  @tracked personEvent;
+  @tracked positions;
+  @tracked attachments;
+  @tracked eventPeriods;
+  @tracked upcomingSlots;
+  @tracked scheduleRecommendations;
+
   @tracked isMarkingOffSite = false;
 
   @tracked timesheets;

--- a/app/controllers/hq/site-checkin.js
+++ b/app/controllers/hq/site-checkin.js
@@ -18,6 +18,20 @@ const NO_RADIO_CHECKED_OUT_BODY = (callsign) =>
 export default class HqSiteCheckinController extends ClubhouseController {
   @service saveModel;
 
+  /*
+   * Supplied by the route's setupController via setProperties. These MUST be @tracked:
+   * the getters below read them from native getter bodies, which consume no tag unless
+   * the field is tracked. Without this, switching person via the search bar re-runs
+   * setupController but never invalidates the getters, because the hq route is not
+   * exited and this controller instance is reused.
+   */
+  @tracked person;
+  @tracked personEvent;
+  @tracked eventInfo;
+  @tracked assets;
+  @tracked attachments;
+  @tracked eventPeriods;
+
   @tracked isSubmitting = false;
   @tracked showSiteCheckInWizard = false;
   @tracked siteCheckInStarted = false;

--- a/tests/acceptance/hq-site-checkin-test.js
+++ b/tests/acceptance/hq-site-checkin-test.js
@@ -97,6 +97,54 @@ module('Acceptance | hq site-checkin', function (hooks) {
       .exists('the Start Shift Check-In action is a button-styled link');
   });
 
+  // Regression guard. The notice and the Begin button's disabled state are both
+  // driven by the controller's `isOnSite` getter. Switching person via the search
+  // bar re-runs setupController but never exits the hq route, so the controller
+  // instance and the rendered template are reused -- only tracked invalidation can
+  // update the DOM. While `person` was not declared @tracked, the native getter
+  // body consumed no tag, so the notice survived the switch and the button stayed
+  // disabled. Every other test here uses a fresh visit(), which rebuilds the
+  // controller and hides the bug entirely.
+  test('clears the completion notice when switching to a person who is not on site', async function (assert) {
+    await authenticateUser(this.user.id);
+
+    const onSitePerson = this.server.create('person', {
+      callsign: 'Softwarez',
+      status: 'active',
+      on_site: true,
+    });
+
+    await visit(`/hq/${onSitePerson.id}/site-checkin`);
+    assert
+      .dom(this.element)
+      .includesText('Softwarez Marked On Site', 'notice renders for the on-site person');
+
+    // Switch person the way the search bar does: transitionTo hq.index, which
+    // routes a not-on-site person onward to hq.site-checkin. Deliberately NOT a
+    // second visit(). The onward redirect aborts this transition, so the
+    // rejection is swallowed; settled() waits for the router to come to rest.
+    this.owner
+      .lookup('service:router')
+      .transitionTo('hq.index', this.subject.id)
+      .catch(() => {});
+    await settled();
+
+    assert.strictEqual(
+      currentURL(),
+      `/hq/${this.subject.id}/site-checkin`,
+      'lands on site-checkin for the not-on-site person'
+    );
+    assert
+      .dom(this.element)
+      .doesNotIncludeText('Marked On Site', 'stale completion notice is gone after the switch');
+
+    const beginButton = [...document.querySelectorAll('button')].find((el) =>
+      el.textContent.includes('Begin On-Site Registration')
+    );
+    assert.ok(beginButton, 'begin button renders for the new person');
+    assert.false(beginButton.disabled, 'begin button is re-enabled for the new person');
+  });
+
   test('walking the wizard to the end marks the person on site', async function (assert) {
     await authenticateUser(this.user.id);
 


### PR DESCRIPTION
The isOnSite getter reads this.person, which the route assigns via setProperties but the controller never declared. A native getter body consumes no tracking tag, so {{#if this.isOnSite}} never re-evaluated when the person was swapped via the search bar: the hq route is not exited, so the controller instance and rendered template are reused, and only tracked invalidation can update the DOM. The "Marked On Site" notice survived the switch and the Begin On-Site Registration button stayed disabled.

Declare the route-supplied properties as @tracked on both HQ controllers, matching the convention already used in app/controllers/hq.js. This also fixes the sibling getters activeAssets, allowedEventRadio, and isAlphaOrProspective, and closes the same hole in hq/shift.js, where isShinyPenny and pendingItems go stale the same way.

Add an acceptance test that switches person via a router transition rather than a fresh visit(). Every existing test in the file rebuilds the controller, which is why this regression shipped unnoticed.

Regressed in 77b405f8.

Refs #2508


Claude-Session: https://claude.ai/code/session_012MtJNBvby71qg6RwJ8Db2g